### PR TITLE
Integration additional config into task

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/JobTaskDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/JobTaskDefinition.cs
@@ -35,6 +35,11 @@ namespace Polyrific.Catapult.Api.Core.Entities
         public string ConfigString { get; set; }
 
         /// <summary>
+        /// Additional configurations which are required by specific providers in json string format
+        /// </summary>
+        public string AdditionalConfigString { get; set; }
+
+        /// <summary>
         /// Sequence of the job task definition
         /// </summary>
         public int? Sequence { get; set; }

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/PluginAdditionalConfigRequiredException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/PluginAdditionalConfigRequiredException.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class PluginAdditionalConfigRequiredException : Exception
+    {
+        public string AdditionalConfigName { get; set; }
+        public string ProviderName { get; set; }
+
+        public PluginAdditionalConfigRequiredException(string additionalConfigName, string providerName)
+            : base($"Provider {providerName} require additional config \"{additionalConfigName}\"")
+        {
+            AdditionalConfigName = additionalConfigName;
+            ProviderName = providerName;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IPluginAdditionalConfigService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IPluginAdditionalConfigService.cs
@@ -18,6 +18,14 @@ namespace Polyrific.Catapult.Api.Core.Services
         Task<List<PluginAdditionalConfig>> GetByPlugin(int pluginId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Get additional configs by plugin name
+        /// </summary>
+        /// <param name="pluginName">Name of the plugin</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
+        /// <returns>Collection of the Plugin additional configs</returns>
+        Task<List<PluginAdditionalConfig>> GetByPluginName(string pluginName, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Add range of additional configs to plugin
         /// </summary>
         /// <param name="pluginId">Id of the plugin</param>

--- a/src/API/Polyrific.Catapult.Api.Core/Services/PluginAdditionalConfigService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/PluginAdditionalConfigService.cs
@@ -44,5 +44,13 @@ namespace Polyrific.Catapult.Api.Core.Services
 
             return result.ToList();
         }
+
+        public async Task<List<PluginAdditionalConfig>> GetByPluginName(string pluginName, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var spec = new PluginAdditionalConfigFilterSpecification(pluginName);
+            var result = await _pluginAdditionalConfigRepository.GetBySpec(spec, cancellationToken);
+
+            return result.ToList();
+        }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/PluginAdditionalConfigFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/PluginAdditionalConfigFilterSpecification.cs
@@ -14,5 +14,14 @@ namespace Polyrific.Catapult.Api.Core.Specifications
             : base(m => m.PluginId == pluginId)
         {
         }
+
+        /// <summary>
+        /// Filter Plugin additional configs by plugin name
+        /// </summary>
+        /// <param name="pluginId"></param>
+        public PluginAdditionalConfigFilterSpecification(string pluginName)
+            : base(m => m.Plugin.Name == pluginName)
+        {
+        }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20180924123227_TaskAdditionalConfig.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20180924123227_TaskAdditionalConfig.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180924123227_TaskAdditionalConfig")]
+    partial class TaskAdditionalConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20180924123227_TaskAdditionalConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20180924123227_TaskAdditionalConfig.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class TaskAdditionalConfig : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AdditionalConfigString",
+                table: "JobTaskDefinitions",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdditionalConfigString",
+                table: "JobTaskDefinitions");
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobTaskDefinitionAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobTaskDefinitionAutoMapperProfile.cs
@@ -16,11 +16,17 @@ namespace Polyrific.Catapult.Api.AutoMapperProfiles
                 .ForMember(
                     dest => dest.Configs, 
                     opt => opt.MapFrom(src => JsonConvert.DeserializeObject<Dictionary<string, string>>(src.ConfigString))
+                )
+                .ForMember(
+                    dest => dest.AdditionalConfigs,
+                    opt => opt.MapFrom(src => JsonConvert.DeserializeObject<Dictionary<string, string>>(src.AdditionalConfigString))
                 );
             CreateMap<CreateJobTaskDefinitionDto, JobTaskDefinition>()
-                .ForMember(dest => dest.ConfigString, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.Configs)));
+                .ForMember(dest => dest.ConfigString, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.Configs)))
+                .ForMember(dest => dest.AdditionalConfigString, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.AdditionalConfigs)));
             CreateMap<UpdateJobTaskDefinitionDto, JobTaskDefinition>()
-                .ForMember(dest => dest.ConfigString, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.Configs)));;
+                .ForMember(dest => dest.ConfigString, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.Configs)))
+                .ForMember(dest => dest.AdditionalConfigString, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.AdditionalConfigs)));
         }
         
     }

--- a/src/API/Polyrific.Catapult.Api/Controllers/PluginController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/PluginController.cs
@@ -16,7 +16,6 @@ namespace Polyrific.Catapult.Api.Controllers
 {
     [Route("plugin")]
     [ApiController]
-    [Authorize(Policy = AuthorizePolicy.UserRoleAdminAccess)]
     public class PluginController : ControllerBase
     {
         private readonly IPluginService _pluginService;
@@ -35,6 +34,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpGet]
+        [Authorize(Policy = AuthorizePolicy.UserRoleAdminAccess)]
         public async Task<IActionResult> GetPlugins()
         {
             var plugins = await _pluginService.GetPlugins();
@@ -50,6 +50,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="pluginType">Type of the plugin</param>
         /// <returns></returns>
         [HttpGet("type/{pluginType}")]
+        [Authorize(Policy = AuthorizePolicy.UserRoleAdminAccess)]
         public async Task<IActionResult> GetPluginsByType(string pluginType)
         {
             var plugins = await _pluginService.GetPlugins(pluginType);
@@ -65,6 +66,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="pluginId">Id of the plugin</param>
         /// <returns></returns>
         [HttpGet("{pluginId}", Name = "GetPluginById")]
+        [Authorize(Policy = AuthorizePolicy.UserRoleBasicAccess)]
         public async Task<IActionResult> GetPluginById(int pluginId)
         {
             var plugin = await _pluginService.GetPluginById(pluginId);
@@ -86,6 +88,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="pluginName">Name of the plugin</param>
         /// <returns></returns>
         [HttpGet("name/{pluginName}", Name = "GetPluginByName")]
+        [Authorize(Policy = AuthorizePolicy.UserRoleBasicAccess)]
         public async Task<IActionResult> GetPluginByName(string pluginName)
         {
             var plugin = await _pluginService.GetPluginByName(pluginName);
@@ -107,6 +110,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="dto"><see cref="NewPluginDto"/> object</param>
         /// <returns></returns>
         [HttpPost]
+        [Authorize(Policy = AuthorizePolicy.UserRoleAdminAccess)]
         public async Task<IActionResult> RegisterPlugin(NewPluginDto dto)
         {
             try
@@ -134,11 +138,29 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="pluginId">Id of the plugin</param>
         /// <returns></returns>
         [HttpDelete("{pluginId}")]
+        [Authorize(Policy = AuthorizePolicy.UserRoleAdminAccess)]
         public async Task<IActionResult> DeletePluginById(int pluginId)
         {
             await _pluginService.DeletePlugin(pluginId);
 
             return NoContent();
         }
+
+        /// <summary>
+        /// Get list of additional configs of a plugin
+        /// </summary>
+        /// <param name="pluginName">Name of the plugin</param>
+        /// <returns></returns>
+        [HttpGet("name/{pluginName}/config")]
+        [Authorize(Policy = AuthorizePolicy.UserRoleBasicAccess)]
+        public async Task<IActionResult> GetPluginAdditionalConfigsByPluginName(string pluginName)
+        {
+            var additionalConfigs = await _pluginAdditionalConfigService.GetByPluginName(pluginName);
+
+            var result = _mapper.Map<List<PluginAdditionalConfigDto>>(additionalConfigs);
+
+            return Ok(result);
+        }
+
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/GetCommand.cs
@@ -15,12 +15,14 @@ namespace Polyrific.Catapult.Cli.Commands.Task
     {
         private readonly IProjectService _projectService;
         private readonly IJobDefinitionService _jobDefinitionService;
+        private readonly IPluginService _pluginService;
 
         public GetCommand(IConsole console, ILogger<GetCommand> logger,
-            IProjectService projectService, IJobDefinitionService jobDefinitionService) : base(console, logger)
+            IProjectService projectService, IJobDefinitionService jobDefinitionService, IPluginService pluginService) : base(console, logger)
         {
             _projectService = projectService;
             _jobDefinitionService = jobDefinitionService;
+            _pluginService = pluginService;
         }
 
         [Required]
@@ -56,7 +58,9 @@ namespace Polyrific.Catapult.Cli.Commands.Task
 
                     if (task != null)
                     {
-                        message = task.ToCliString($"Task {Name} in job {Job}:");
+                        var configs = _pluginService.GetPluginAdditionalConfigByPluginName(task.Provider).Result;
+                        var secretConfigs = configs.Where(c => c.IsSecret).Select(c => c.Name).ToArray();
+                        message = task.ToCliString($"Task {Name} in job {Job}:", secretConfigs);
                         return message;
                     }
                 }

--- a/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
@@ -51,7 +51,7 @@ namespace Polyrific.Catapult.Cli.Extensions
             return sb.ToString();
         }
 
-        public static string ToListCliString(this IEnumerable list, string openingLine = "")
+        public static string ToListCliString(this IEnumerable list, string openingLine = "", string[] obfuscatedFields = null)
         {
             var sb = new StringBuilder(openingLine);
             sb.AppendLine();
@@ -60,7 +60,7 @@ namespace Polyrific.Catapult.Cli.Extensions
             foreach (var listitem in list)
             {
                 empty = false;
-                sb.Append(listitem.ToCliString());
+                sb.Append(listitem.ToCliString("", obfuscatedFields));
             }
 
             if (empty)

--- a/src/Shared/Polyrific.Catapult.Shared.ApiClient/PluginService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.ApiClient/PluginService.cs
@@ -27,6 +27,13 @@ namespace Polyrific.Catapult.Shared.ApiClient
             await Api.Delete(path);
         }
 
+        public async Task<List<PluginAdditionalConfigDto>> GetPluginAdditionalConfigByPluginName(string pluginName)
+        {
+            var path = $"plugin/name/{pluginName}/config";
+
+            return await Api.Get<List<PluginAdditionalConfigDto>>(path);
+        }
+
         public async Task<PluginDto> GetPluginById(int id)
         {
             var path = $"plugin/{id}";

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobTaskDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobTaskDefinitionDto.cs
@@ -29,6 +29,11 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         public Dictionary<string, string> Configs { get; set; }
 
         /// <summary>
+        /// Additional configurations which are required by specific providers
+        /// </summary>
+        public Dictionary<string, string> AdditionalConfigs { get; set; }
+
+        /// <summary>
         /// Sequence of the job task definition
         /// </summary>
         public int? Sequence { get; set; }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/UpdateJobTaskDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/UpdateJobTaskDefinitionDto.cs
@@ -35,6 +35,11 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         public Dictionary<string, string> Configs { get; set; }
 
         /// <summary>
+        /// Additional configurations which are required by specific providers
+        /// </summary>
+        public Dictionary<string, string> AdditionalConfigs { get; set; }
+
+        /// <summary>
         /// Sequence of the job task definition
         /// </summary>
         public int? Sequence { get; set; }

--- a/src/Shared/Polyrific.Catapult.Shared.Service/IPluginService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Service/IPluginService.cs
@@ -42,5 +42,12 @@ namespace Polyrific.Catapult.Shared.Service
         /// <param name="name">Name of the plugin</param>
         /// <returns></returns>
         Task<PluginDto> GetPluginByName(string name);
+
+        /// <summary>
+        /// Get plugin additional configs by plugin name
+        /// </summary>
+        /// <param name="pluginName">Name of the plugin</param>
+        /// <returns></returns>
+        Task<List<PluginAdditionalConfigDto>> GetPluginAdditionalConfigByPluginName(string pluginName);
     }
 }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
@@ -25,6 +25,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         private readonly Mock<IProjectRepository> _projectRepository;
         private readonly Mock<IPluginRepository> _pluginRepository;
         private readonly Mock<IExternalServiceRepository> _externalServiceRepository;
+        private readonly Mock<IPluginAdditionalConfigRepository> _pluginAdditionalConfigRepository;
 
         public JobDefinitionServiceTests()
         {
@@ -145,12 +146,14 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             _pluginRepository = new Mock<IPluginRepository>();
 
             _externalServiceRepository = new Mock<IExternalServiceRepository>();
+
+            _pluginAdditionalConfigRepository = new Mock<IPluginAdditionalConfigRepository>();
         }
 
         [Fact]
         public async void AddJobDefinition_ValidItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             int newId = await projectJobDefinitionService.AddJobDefinition(1, "Complete CI/CD");
 
             Assert.True(newId > 1);
@@ -160,7 +163,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public void AddJobDefinition_DuplicateItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(1, "Default"));
 
             Assert.IsType<DuplicateJobDefinitionException>(exception?.Result);
@@ -169,7 +172,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public void AddJobDefinition_InvalidProject()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(2, "Category"));
 
             Assert.IsType<ProjectNotFoundException>(exception?.Result);
@@ -178,7 +181,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobDefinitions_ReturnItems()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var dataModels = await projectJobDefinitionService.GetJobDefinitions(1);
 
             Assert.NotEmpty(dataModels);
@@ -187,7 +190,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobDefinitions_ReturnEmpty()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var dataModels = await projectJobDefinitionService.GetJobDefinitions(2);
 
             Assert.Empty(dataModels);
@@ -196,7 +199,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobDefinitionById_ReturnItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var projectJobDefinition = await projectJobDefinitionService.GetJobDefinitionById(1);
 
             Assert.NotNull(projectJobDefinition);
@@ -206,7 +209,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobDefinitionById_ReturnNull()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobDefinition = await projectJobDefinitionService.GetJobDefinitionById(2);
 
             Assert.Null(jobDefinition);
@@ -215,7 +218,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobDefinitionByName_ReturnItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var projectJobDefinition = await projectJobDefinitionService.GetJobDefinitionByName(1, "Default");
 
             Assert.NotNull(projectJobDefinition);
@@ -225,7 +228,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobDefinitionByName_ReturnNull()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobDefinition = await projectJobDefinitionService.GetJobDefinitionByName(1, "Default2");
 
             Assert.Null(jobDefinition);
@@ -234,7 +237,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void DeleteJobDefinition_ValidItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             await projectJobDefinitionService.DeleteJobDefinition(1);
 
             Assert.Empty(_data);
@@ -244,7 +247,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void RenameJobDefinition_ValidItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             await projectJobDefinitionService.RenameJobDefinition(1, "newName");
 
             var dataModel = _data.First(d => d.Id == 1);
@@ -262,7 +265,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 Name = "newName"
             });
 
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.RenameJobDefinition(1, "newName"));
 
             Assert.IsType<DuplicateJobDefinitionException>(exception?.Result);
@@ -288,12 +291,24 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                     }
                 });
 
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            _pluginAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<PluginAdditionalConfig>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginAdditionalConfig>
+                {
+                    new PluginAdditionalConfig
+                    {
+                        Id = 1,
+                        Name = "testconfig",
+                        IsRequired = true
+                    }
+                });
+
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             int newId = await projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
             {
                 JobDefinitionId = 1,
                 Type = JobTaskDefinitionType.Push,
                 ConfigString = @"{""GitHubExternalService"":""github-default""}",
+                AdditionalConfigString = @"{""testconfig"":""testvalue""}",
                 Provider = "GitHubProvider"
             });
 
@@ -307,7 +322,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
 
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
             {
                 JobDefinitionId = 1,
@@ -325,7 +340,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
 
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
             {
                 JobDefinitionId = 1,
@@ -343,7 +358,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
 
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
             {
                 JobDefinitionId = 1,
@@ -371,7 +386,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                     }
                 });
 
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
             {
                 JobDefinitionId = 1,
@@ -386,7 +401,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public void AddJobTaskDefinition_InvalidJobDefinition()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
             {
                 JobDefinitionId = 2,
@@ -398,9 +413,67 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         }
 
         [Fact]
+        public void AddJobTaskDefinition_AdditionalConfigNull_AdditionalConfigRequiredException()
+        {
+            _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider });
+
+            _pluginAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<PluginAdditionalConfig>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginAdditionalConfig>
+                {
+                    new PluginAdditionalConfig
+                    {
+                        Id = 1,
+                        Name = "testconfig",
+                        IsRequired = true
+                    }
+                });
+
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
+            {
+                JobDefinitionId = 1,
+                Type = JobTaskDefinitionType.Push,
+                AdditionalConfigString = null,
+                Provider = "GitHubProvider"
+            }));
+
+            Assert.IsType<PluginAdditionalConfigRequiredException>(exception?.Result);
+        }
+
+        [Fact]
+        public void AddJobTaskDefinition_AdditionalConfigNotExist_AdditionalConfigRequiredException()
+        {
+            _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider });
+
+            _pluginAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<PluginAdditionalConfig>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginAdditionalConfig>
+                {
+                    new PluginAdditionalConfig
+                    {
+                        Id = 1,
+                        Name = "testconfig",
+                        IsRequired = true
+                    }
+                });
+
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
+            {
+                JobDefinitionId = 1,
+                Type = JobTaskDefinitionType.Push,
+                AdditionalConfigString = "{}",
+                Provider = "GitHubProvider"
+            }));
+
+            Assert.IsType<PluginAdditionalConfigRequiredException>(exception?.Result);
+        }
+
+        [Fact]
         public async void AddJobTaskDefinitions_ValidItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var newIds = await projectJobDefinitionService.AddJobTaskDefinitions(1, new List<JobTaskDefinition>
             {
                 new JobTaskDefinition
@@ -429,7 +502,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public void AddJobTaskDefinitions_JobDefinitionNotFound()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinitions(2, new List<JobTaskDefinition>
             {
                 new JobTaskDefinition
@@ -452,7 +525,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void DeleteJobTaskDefinition_ValidItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             await projectJobDefinitionService.DeleteJobTaskDefinition(1);
 
             Assert.Empty(_dataTask);
@@ -461,7 +534,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobTaskDefinitions_ReturnItems()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobTaskDefinitions = await projectJobDefinitionService.GetJobTaskDefinitions(1);
 
             Assert.NotEmpty(jobTaskDefinitions);
@@ -470,7 +543,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobTaskDefinitions_ReturnEmpty()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobTaskDefinitions = await projectJobDefinitionService.GetJobTaskDefinitions(2);
 
             Assert.Empty(jobTaskDefinitions);
@@ -479,7 +552,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobTaskDefinitioById_ReturnItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobTaskDefinition = await projectJobDefinitionService.GetJobTaskDefinitionById(1);
 
             Assert.NotNull(jobTaskDefinition);
@@ -488,7 +561,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobTaskDefinitionById_ReturnEmpty()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobTaskDefinition = await projectJobDefinitionService.GetJobTaskDefinitionById(2);
 
             Assert.Null(jobTaskDefinition);
@@ -497,7 +570,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobTaskDefinitioByName_ReturnItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobTaskDefinition = await projectJobDefinitionService.GetJobTaskDefinitionByName(1, "Generate");
 
             Assert.NotNull(jobTaskDefinition);
@@ -506,7 +579,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobTaskDefinitionByName_ReturnEmpty()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             var jobTaskDefinition = await projectJobDefinitionService.GetJobTaskDefinitionByName(1, "Push");
 
             Assert.Null(jobTaskDefinition);
@@ -515,7 +588,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void UpdateJobTaskDefinition_ValidItem()
         {
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             await projectJobDefinitionService.UpdateJobTaskDefinition(new JobTaskDefinition
             {
                 Id = 1,
@@ -539,7 +612,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
 
             var updatedConfigString = JsonConvert.SerializeObject(updatedConfig);
 
-            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object);
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object);
             await projectJobDefinitionService.UpdateJobTaskConfig(1, updatedConfig);
 
             var jobTaskDefinition = _dataTask.First(d => d.Id == 1);

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/PluginAdditionalConfigServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/PluginAdditionalConfigServiceTests.cs
@@ -57,6 +57,39 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         }
 
         [Fact]
+        public async void GetByPluginName_ReturnItems()
+        {
+            _pluginAdditionalConfigRepository
+                .Setup(r => r.GetBySpec(It.IsAny<PluginAdditionalConfigFilterSpecification>(),
+                    It.IsAny<CancellationToken>())).ReturnsAsync(new List<PluginAdditionalConfig>
+                {
+                    new PluginAdditionalConfig {Id = 1, PluginId = 1, Plugin = new Plugin { Name = "Plugin1" }, Name = "Config1"}
+                });
+
+            var service =
+                new PluginAdditionalConfigService(_pluginRepository.Object, _pluginAdditionalConfigRepository.Object);
+
+            var configs = await service.GetByPluginName("Plugin1");
+
+            Assert.NotEmpty(configs);
+        }
+
+        [Fact]
+        public async void GetByPluginName_ReturnEmpty()
+        {
+            _pluginAdditionalConfigRepository
+                .Setup(r => r.GetBySpec(It.IsAny<PluginAdditionalConfigFilterSpecification>(),
+                    It.IsAny<CancellationToken>())).ReturnsAsync(new List<PluginAdditionalConfig>());
+
+            var service =
+                new PluginAdditionalConfigService(_pluginRepository.Object, _pluginAdditionalConfigRepository.Object);
+
+            var configs = await service.GetByPluginName("Plugin1");
+
+            Assert.Empty(configs);
+        }
+
+        [Fact]
         public async void AddAdditionalConfigs_Success()
         {
             _pluginRepository.Setup(r => r.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
## Summary
Integrate the plugin's additional config into task

## PR Coverage
- [x] Modify task API endpoints to include additional config
- [x] validate in create project
- [x] validate in create/update task
- [x] obfuscate the secret additional config when retrieving task(s)
- [x] server side validation