### PR TITLE
Fix typo in CLI welcome message

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
@@ -36,7 +36,7 @@ namespace Polyrific.Catapult.Cli.Commands
         protected virtual int OnExecute(CommandLineApplication app)
         {
             Console.WriteLine("-----------------------------");
-            Console.WriteLine("= Polyrific Catapult Engine =");
+            Console.WriteLine("= Polyrific Catapult CLI =");
             Console.WriteLine("-----------------------------");
             Console.WriteLine();
 


### PR DESCRIPTION
## Summary
Fix typo in CLI where it shows welcome message of Catapult engine