### PR TITLE
Avoid error due to null in WebRootPath

### DIFF
--- a/src/Shared/Polyrific.Catapult.Shared.Common/LocalTextWriter.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/LocalTextWriter.cs
@@ -77,7 +77,7 @@ namespace Polyrific.Catapult.Shared.Common
 
         private string GetFolderPath(string folderName)
         {
-            return Path.Combine(_basePath, $"{folderName}");
+            return Path.Combine(_basePath ?? string.Empty, $"{folderName}");
         }
     }
 }


### PR DESCRIPTION
## Summary
There's error occured in external service POST endpoint when running in production. This is due to WebRootPath returns null. To avoid the error, I add the null checking and provide default value to get the base path