### PR TITLE
use environment variable for connection string

### DIFF
--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseCommand.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseCommand.cs
@@ -9,10 +9,12 @@ namespace EntityFrameworkCore
     public class DatabaseCommand : IDatabaseCommand
     {
         private readonly ILogger _logger;
+        private readonly string _connectionString;
 
-        public DatabaseCommand(ILogger logger)
+        public DatabaseCommand(ILogger logger, string connectionString)
         {
             _logger = logger;
+            _connectionString = connectionString;
         }
 
         public async Task<string> Update(string dataProject, string startupProject, string configuration = "Debug")
@@ -23,7 +25,10 @@ namespace EntityFrameworkCore
 
         private async Task<string> RunDotnet(string args)
         {
-            var result = await CommandHelper.Execute("dotnet", args, _logger);
+            var result = await CommandHelper.Execute("dotnet", args, new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "ConnectionStrings__DefaultConnection", _connectionString }
+            }, _logger);
 
             return result.error;
         }

--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseProvider.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseProvider.cs
@@ -56,8 +56,12 @@ namespace EntityFrameworkCore
             if (additionalConfigs != null && additionalConfigs.ContainsKey("Configuration"))
                 buildConfiguration = additionalConfigs["Configuration"];
 
+            string connectionString = "";
+            if (additionalConfigs != null && additionalConfigs.ContainsKey("ConnectionString"))
+                connectionString = additionalConfigs["ConnectionString"];
+
             if (_databaseCommand == null)
-                _databaseCommand = new DatabaseCommand(logger);
+                _databaseCommand = new DatabaseCommand(logger, connectionString);
 
             var error = await _databaseCommand.Update(dataProjectPath, startupProjectPath, buildConfiguration);
             if (!string.IsNullOrEmpty(error))

--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/Helpers/CommandHelper.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/Helpers/CommandHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace EntityFrameworkCore.Helpers
 {
     public class CommandHelper
     {
-        public static async Task<(string output, string error)> Execute(string fileName, string args, ILogger logger = null)
+        public static async Task<(string output, string error)> Execute(string fileName, string args, Dictionary<string, string> environmentVariables = null, ILogger logger = null)
         {
             var outputBuilder = new StringBuilder();
             var error = "";
@@ -23,6 +24,10 @@ namespace EntityFrameworkCore.Helpers
                 RedirectStandardError = true,
                 CreateNoWindow = true
             };
+
+            if (environmentVariables != null)
+                foreach (var envVariable in environmentVariables)
+                    info.EnvironmentVariables.Add(envVariable.Key, envVariable.Value);
 
             using (var process = Process.Start(info))
             {

--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/tests/DatabaseProviderTests.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/tests/DatabaseProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -33,8 +34,13 @@ namespace DotNetCore.Tests
                 MigrationLocation = "src",
                 WorkingLocation = workingLocation
             };
+            
+            var additionalConfig = new Dictionary<string, string>
+            {
+                { "ConnectionString", "Server=localhost;Database=generated.db;User ID=sa;Password=samprod;" }
+            };
 
-            var result = await provider.DeployDatabase("MyProject", taskConfig, null, _logger.Object);
+            var result = await provider.DeployDatabase("MyProject", taskConfig, additionalConfig, _logger.Object);
 
             Assert.Equal("", result.errorMessage);
             Assert.Equal("MyProject.Data", result.databaseLocation);

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGenerator.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using AspNetCoreMvc.Helpers;
 using AspNetCoreMvc.ProjectGenerators;
+using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Shared.Dto.ProjectDataModel;
 
 namespace AspNetCoreMvc
@@ -19,17 +20,19 @@ namespace AspNetCoreMvc
         private readonly DataProjectGenerator _dataProjectGenerator;
         private readonly InfrastructureProjectGenerator _infrastructureProjectGenerator;
         private readonly MainProjectGenerator _mainProjectGenerator;
+        private readonly ILogger _logger;
         
-        public CodeGenerator(string projectName, string outputLocation, List<ProjectDataModelDto> models, string connectionString)
+        public CodeGenerator(string projectName, string outputLocation, List<ProjectDataModelDto> models, string connectionString, ILogger logger = null)
         {
             _projectName = projectName;
             _outputLocation = outputLocation;
             _models = models;
-            _projectHelper = new ProjectHelper(projectName, outputLocation);
-            _coreProjectGenerator = new CoreProjectGenerator(projectName, _projectHelper, models);
-            _dataProjectGenerator = new DataProjectGenerator(projectName, _projectHelper, models);
-            _infrastructureProjectGenerator = new InfrastructureProjectGenerator(projectName, _projectHelper, models);
-            _mainProjectGenerator = new MainProjectGenerator(projectName, _projectHelper, models, connectionString);
+            _projectHelper = new ProjectHelper(projectName, outputLocation, logger);
+            _coreProjectGenerator = new CoreProjectGenerator(projectName, _projectHelper, models, logger);
+            _dataProjectGenerator = new DataProjectGenerator(projectName, _projectHelper, models, logger);
+            _infrastructureProjectGenerator = new InfrastructureProjectGenerator(projectName, _projectHelper, models, logger);
+            _mainProjectGenerator = new MainProjectGenerator(projectName, _projectHelper, models, connectionString, logger);
+            _logger = logger;
         }
 
         public async Task<string> InitSolution()

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/CommandHelper.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/CommandHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace AspNetCoreMvc.Helpers
 {
     public class CommandHelper
     {
-        public static Task<string> Execute(string fileName, string args, ILogger logger = null)
+        public static Task<string> Execute(string fileName, string args, Dictionary<string, string> environmentVariables = null, ILogger logger = null)
         {
             var returnValue = new StringBuilder();
 
@@ -21,6 +22,10 @@ namespace AspNetCoreMvc.Helpers
                 RedirectStandardOutput = true,
                 CreateNoWindow = true
             };
+
+            if (environmentVariables != null)
+                foreach (var envVariable in environmentVariables)
+                    info.EnvironmentVariables.Add(envVariable.Key, envVariable.Value);
 
             using (var process = Process.Start(info))
             {
@@ -41,9 +46,9 @@ namespace AspNetCoreMvc.Helpers
             return Task.FromResult(returnValue.ToString());
         }
         
-        public static Task<string> RunDotnet(string args, ILogger logger = null)
+        public static Task<string> RunDotnet(string args, Dictionary<string, string> environmentVariables = null, ILogger logger = null)
         {
-            return Execute("dotnet", args, logger);
+            return Execute("dotnet", args, environmentVariables, logger);
         }
     }
 }

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/ProjectHelper.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/ProjectHelper.cs
@@ -2,6 +2,7 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace AspNetCoreMvc.Helpers
 {
@@ -9,11 +10,13 @@ namespace AspNetCoreMvc.Helpers
     {
         private readonly string _projectName;
         private readonly string _outputLocation;
+        private readonly ILogger _logger;
 
-        public ProjectHelper(string projectName, string outputLocation)
+        public ProjectHelper(string projectName, string outputLocation, ILogger logger)
         {
             _projectName = projectName;
             _outputLocation = outputLocation;
+            _logger = logger;
         }
 
         public async Task<string> CreateProject(string projectName, string template, string[] projectReferences = null, (string name, string version)[] packages = null)
@@ -24,22 +27,22 @@ namespace AspNetCoreMvc.Helpers
 
             var args = $"new {template} -n {projectName} -o {projectFolder}";
 
-            var message = await CommandHelper.RunDotnet(args);
+            var message = await CommandHelper.RunDotnet(args, null, _logger);
             DeleteFileToProject(projectName, "Class1.cs");
 
             var projectFile = GetProjectFullPath(projectName);
 
             if (projectReferences != null)
                 foreach (var projectReference in projectReferences)
-                    await CommandHelper.RunDotnet($"add {projectFile} reference {projectReference}");
+                    await CommandHelper.RunDotnet($"add {projectFile} reference {projectReference}", null, _logger);
 
             if (packages != null)
                 foreach (var package in packages)
-                    await CommandHelper.RunDotnet($"add {projectFile} package {package.name} -v {package.version}");
+                    await CommandHelper.RunDotnet($"add {projectFile} package {package.name} -v {package.version}", null, _logger);
 
             // add project to solution
             var solutionFile = Path.Combine(_outputLocation, $"{_projectName}.sln");
-            await CommandHelper.RunDotnet($"sln {solutionFile} add {projectFile}");
+            await CommandHelper.RunDotnet($"sln {solutionFile} add {projectFile}", null, _logger);
 
             return message;
         }

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/CoreProjectGenerator.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/CoreProjectGenerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using AspNetCoreMvc.Helpers;
+using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Shared.Dto.Constants;
 using Polyrific.Catapult.Shared.Dto.ProjectDataModel;
 
@@ -14,16 +15,18 @@ namespace AspNetCoreMvc.ProjectGenerators
         private string _projectName;
         private readonly ProjectHelper _projectHelper;
         private readonly List<ProjectDataModelDto> _models;
+        private readonly ILogger _logger;
 
         public const string CoreProject = "Core";
 
         private string Name => $"{_projectName}.{CoreProject}";
 
-        public CoreProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models)
+        public CoreProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models, ILogger logger)
         {
             _projectName = projectName;
             _projectHelper = projectHelper;
             _models = models;
+            _logger = logger;
         }
 
         public async Task<string> Initialize()

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/DataProjectGenerator.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/DataProjectGenerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using AspNetCoreMvc.Helpers;
+using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Shared.Dto.ProjectDataModel;
 
 namespace AspNetCoreMvc.ProjectGenerators
@@ -13,16 +14,18 @@ namespace AspNetCoreMvc.ProjectGenerators
         private string _projectName;
         private readonly ProjectHelper _projectHelper;
         private readonly List<ProjectDataModelDto> _models;
+        private readonly ILogger _logger;
 
         public const string DataProject = "Data";
 
         private string Name => $"{_projectName}.{DataProject}";
 
-        public DataProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models)
+        public DataProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models, ILogger logger)
         {
             _projectName = projectName;
             _projectHelper = projectHelper;
             _models = models;
+            _logger = logger;
         }
 
         public async Task<string> Initialize()

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/InfrastructureProjectGenerator.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/InfrastructureProjectGenerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using AspNetCoreMvc.Helpers;
+using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Shared.Dto.ProjectDataModel;
 
 namespace AspNetCoreMvc.ProjectGenerators
@@ -13,16 +14,18 @@ namespace AspNetCoreMvc.ProjectGenerators
         private string _projectName;
         private readonly ProjectHelper _projectHelper;
         private readonly List<ProjectDataModelDto> _models;
+        private readonly ILogger _logger;
 
         public const string InfrastructureProject = "Infrastructure";
 
         private string Name => $"{_projectName}.{InfrastructureProject}";
 
-        public InfrastructureProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models)
+        public InfrastructureProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models, ILogger logger)
         {
             _projectName = projectName;
             _projectHelper = projectHelper;
             _models = models;
+            _logger = logger;
         }
 
         public async Task<string> Initialize()


### PR DESCRIPTION
## Summary
Use environment variable instead of appsettings.json to get the connection string when running update migration script or db deploy. This way, the generated code that are pushed to the repo will be clean from db credentials.