### PR TITLE
Show service types in service add help

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/ExternalServiceTypeService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ExternalServiceTypeService.cs
@@ -33,9 +33,13 @@ namespace Polyrific.Catapult.Api.Core.Services
             return await _externalServiceTypeRepository.GetSingleBySpec(spec, cancellationToken);
         }
 
-        public async Task<List<ExternalServiceType>> GetExternalServiceTypes(CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<List<ExternalServiceType>> GetExternalServiceTypes(bool includeProperties = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return (await _externalServiceTypeRepository.GetBySpec(new ExternalServiceTypeFilterSpecification(), cancellationToken)).ToList();
+            var getAllSpec = new ExternalServiceTypeFilterSpecification();
+            if (includeProperties)
+                getAllSpec.Includes.Add(s => s.ExternalServiceProperties);
+
+            return (await _externalServiceTypeRepository.GetBySpec(getAllSpec, cancellationToken)).ToList();
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IExternalServiceTypeService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IExternalServiceTypeService.cs
@@ -14,9 +14,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <summary>
         /// Get the list of external service types related to current user
         /// </summary>
+        /// <param name="includeProperties">Indicate whether the properties will be included in the result</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>List of the external service type entity</returns>
-        Task<List<ExternalServiceType>> GetExternalServiceTypes(CancellationToken cancellationToken = default(CancellationToken));
+        Task<List<ExternalServiceType>> GetExternalServiceTypes(bool includeProperties = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get a single external service type

--- a/src/API/Polyrific.Catapult.Api/Controllers/ExternalServiceTypeController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ExternalServiceTypeController.cs
@@ -29,9 +29,9 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <returns>The list of external service type</returns>
         [HttpGet]
         [Authorize]
-        public async Task<IActionResult> GetExternalServiceTypes()
+        public async Task<IActionResult> GetExternalServiceTypes(bool includeProperties = false)
         {
-            var externalServiceTypes = await _externalServiceTypeService.GetExternalServiceTypes();
+            var externalServiceTypes = await _externalServiceTypeService.GetExternalServiceTypes(includeProperties);
             var results = _mapper.Map<List<ExternalServiceTypeDto>>(externalServiceTypes);
 
             return Ok(results);

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
@@ -33,7 +33,7 @@ namespace Polyrific.Catapult.Cli.Commands
         /// <returns>Execution result message</returns>
         public abstract string Execute();
 
-        protected virtual string GetHelpFooter()
+        public virtual string GetHelpFooter()
         {
             return "";
         }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
@@ -33,6 +33,11 @@ namespace Polyrific.Catapult.Cli.Commands
         /// <returns>Execution result message</returns>
         public abstract string Execute();
 
+        protected virtual string GetHelpFooter()
+        {
+            return "";
+        }
+
         protected virtual int OnExecute(CommandLineApplication app)
         {
             Console.WriteLine("-----------------------------");

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
@@ -104,5 +104,32 @@ namespace Polyrific.Catapult.Cli.Commands.Service
 
             return message;
         }
+
+        protected override string GetHelpFooter()
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("Types of the external service:");
+
+            try
+            {
+                var serviceTypes = _externalServiceTypeService.GetExternalServiceTypes(true).Result;
+                foreach (var serviceType in serviceTypes)
+                {
+                    sb.AppendLine($"  - {serviceType.Name}");
+                    if (serviceType.ExternalServiceProperties != null && serviceType.ExternalServiceProperties.Count > 0)
+                    {
+                        sb.AppendLine("    Properties:");
+                        foreach (var property in serviceType.ExternalServiceProperties)
+                            sb.AppendLine($"      - {property.Name} {(property.IsRequired ? "(required)" : "")}");
+                    }
+                }
+            }
+            catch
+            {
+                sb.AppendLine("Failed retrieving external service types. Please try to login into application");
+            }
+
+            return sb.ToString();
+        }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
@@ -105,7 +105,7 @@ namespace Polyrific.Catapult.Cli.Commands.Service
             return message;
         }
 
-        protected override string GetHelpFooter()
+        public override string GetHelpFooter()
         {
             var sb = new System.Text.StringBuilder();
             sb.AppendLine("Types of the external service:");

--- a/src/CLI/Polyrific.Catapult.Cli/Program.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Program.cs
@@ -63,7 +63,6 @@ namespace Polyrific.Catapult.Cli
             services.AddTransient<ITemplateWriter, TemplateWriter>();
             services.AddTransient<ICliConfig, CliConfig>();
             services.AddTransient<IConsoleReader, ConsoleReader>();
-            services.AddTransient<CatapultHelpTextGenerator, CatapultHelpTextGenerator>();
 
             services.AddCatapultApi(configuration);
         }
@@ -74,7 +73,7 @@ namespace Polyrific.Catapult.Cli
                 .UseDefaultConventions()
                 .UseConstructorInjection(serviceProvider);
 
-            app.HelpTextGenerator = serviceProvider.GetService<CatapultHelpTextGenerator>();
+            app.HelpTextGenerator = new CatapultHelpTextGenerator();
 
             app.ValueParsers.Add(new CatapultOptionParser());
 

--- a/src/CLI/Polyrific.Catapult.Cli/Program.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Program.cs
@@ -63,6 +63,7 @@ namespace Polyrific.Catapult.Cli
             services.AddTransient<ITemplateWriter, TemplateWriter>();
             services.AddTransient<ICliConfig, CliConfig>();
             services.AddTransient<IConsoleReader, ConsoleReader>();
+            services.AddTransient<CatapultHelpTextGenerator, CatapultHelpTextGenerator>();
 
             services.AddCatapultApi(configuration);
         }
@@ -72,6 +73,8 @@ namespace Polyrific.Catapult.Cli
             app.Conventions
                 .UseDefaultConventions()
                 .UseConstructorInjection(serviceProvider);
+
+            app.HelpTextGenerator = serviceProvider.GetService<CatapultHelpTextGenerator>();
 
             app.ValueParsers.Add(new CatapultOptionParser());
 

--- a/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using McMaster.Extensions.CommandLineUtils;
 using McMaster.Extensions.CommandLineUtils.HelpText;
+using Polyrific.Catapult.Cli.Commands;
 
 namespace Polyrific.Catapult.Cli
 {
@@ -20,12 +21,12 @@ namespace Polyrific.Catapult.Cli
 
         private string InvokeGetHelpFooter(CommandLineApplication application)
         {
-            const BindingFlags binding = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
             var commandInstance = application.GetType().GetProperty("Model").GetValue(application, null);
-            var commandType = commandInstance.GetType();
-            var method = commandType.GetMethod("GetHelpFooter", binding);
 
-            return method?.Invoke(commandInstance, null) as string;
+            if (commandInstance is BaseCommand command)
+                return command.GetHelpFooter();
+
+            return null;
         }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
@@ -1,47 +1,31 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System.IO;
+using System.Reflection;
 using McMaster.Extensions.CommandLineUtils;
 using McMaster.Extensions.CommandLineUtils.HelpText;
-using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli
 {
     public class CatapultHelpTextGenerator : DefaultHelpTextGenerator
     {
-        private readonly IExternalServiceTypeService _externalServiceTypeService;
-
-        public CatapultHelpTextGenerator(IExternalServiceTypeService externalServiceTypeService)
-        {
-            _externalServiceTypeService = externalServiceTypeService;
-        }
-
         protected override void GenerateFooter(CommandLineApplication application, TextWriter output)
         {
             base.GenerateFooter(application, output);
+            
+            var customFooter = InvokeGetHelpFooter(application);
+            if (!string.IsNullOrEmpty(customFooter))
+                output.WriteLine(customFooter);
+        }
 
-            if (application.Name == "add" && application.Parent.Name == "service")
-            {
-                output.WriteLine("Types of the external service:");
-                try
-                {
-                    var serviceTypes = _externalServiceTypeService.GetExternalServiceTypes(true).Result;
-                    foreach (var serviceType in serviceTypes)
-                    {
-                        output.WriteLine($"  - {serviceType.Name}");
-                        if (serviceType.ExternalServiceProperties != null && serviceType.ExternalServiceProperties.Count > 0)
-                        {
-                            output.WriteLine("    Properties:");
-                            foreach (var property in serviceType.ExternalServiceProperties)
-                                output.WriteLine($"      - {property.Name} {(property.IsRequired ? "(required)" : "")}");
-                        }
-                    }
-                }
-                catch
-                {
-                    output.WriteLine("Failed retrieving external service types. Please try to login into application");
-                }
-            }
+        private string InvokeGetHelpFooter(CommandLineApplication application)
+        {
+            const BindingFlags binding = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+            var commandInstance = application.GetType().GetProperty("Model").GetValue(application, null);
+            var commandType = commandInstance.GetType();
+            var method = commandType.GetMethod("GetHelpFooter", binding);
+
+            return method?.Invoke(commandInstance, null) as string;
         }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System.IO;
-using System.Reflection;
 using McMaster.Extensions.CommandLineUtils;
 using McMaster.Extensions.CommandLineUtils.HelpText;
 using Polyrific.Catapult.Cli.Commands;

--- a/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Utility/CatapultHelpTextGenerator.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.IO;
+using McMaster.Extensions.CommandLineUtils;
+using McMaster.Extensions.CommandLineUtils.HelpText;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Cli
+{
+    public class CatapultHelpTextGenerator : DefaultHelpTextGenerator
+    {
+        private readonly IExternalServiceTypeService _externalServiceTypeService;
+
+        public CatapultHelpTextGenerator(IExternalServiceTypeService externalServiceTypeService)
+        {
+            _externalServiceTypeService = externalServiceTypeService;
+        }
+
+        protected override void GenerateFooter(CommandLineApplication application, TextWriter output)
+        {
+            base.GenerateFooter(application, output);
+
+            if (application.Name == "add" && application.Parent.Name == "service")
+            {
+                output.WriteLine("Types of the external service:");
+                try
+                {
+                    var serviceTypes = _externalServiceTypeService.GetExternalServiceTypes(true).Result;
+                    foreach (var serviceType in serviceTypes)
+                    {
+                        output.WriteLine($"  - {serviceType.Name}");
+                        if (serviceType.ExternalServiceProperties != null && serviceType.ExternalServiceProperties.Count > 0)
+                        {
+                            output.WriteLine("    Properties:");
+                            foreach (var property in serviceType.ExternalServiceProperties)
+                                output.WriteLine($"      - {property.Name} {(property.IsRequired ? "(required)" : "")}");
+                        }
+                    }
+                }
+                catch
+                {
+                    output.WriteLine("Failed retrieving external service types. Please try to login into application");
+                }
+            }
+        }
+    }
+}

--- a/src/Shared/Polyrific.Catapult.Shared.ApiClient/ExternalServiceTypeService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.ApiClient/ExternalServiceTypeService.cs
@@ -27,9 +27,12 @@ namespace Polyrific.Catapult.Shared.ApiClient
             return await Api.Get<ExternalServiceTypeDto>(path);
         }
 
-        public async Task<List<ExternalServiceTypeDto>> GetExternalServiceTypes()
+        public async Task<List<ExternalServiceTypeDto>> GetExternalServiceTypes(bool includeProperties = false)
         {
             var path = "serviceType";
+
+            if (includeProperties)
+                path += "?includeProperties=true";
 
             return await Api.Get<List<ExternalServiceTypeDto>>(path);
         }

--- a/src/Shared/Polyrific.Catapult.Shared.Service/IExternalServiceTypeService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Service/IExternalServiceTypeService.cs
@@ -11,8 +11,9 @@ namespace Polyrific.Catapult.Shared.Service
         /// <summary>
         /// Get the list of external service types related to current user
         /// </summary>
+        /// <param name="includeProperties">Indicate whether the properties will be included in the result</param>
         /// <returns>List of the external service type entity</returns>
-        Task<List<ExternalServiceTypeDto>> GetExternalServiceTypes();
+        Task<List<ExternalServiceTypeDto>> GetExternalServiceTypes(bool includeProperties = false);
 
         /// <summary>
         /// Get a single external service type


### PR DESCRIPTION
## Summary
Show available external service types in its properties when user run `service add --help`

Issue: #59 