### PR TITLE
Handle CommandParsingException in Engine

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine/Program.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Program.cs
@@ -32,7 +32,16 @@ namespace Polyrific.Catapult.Engine
             var app = new CommandLineApplication<Program>();
             ConfigureApplication(app, serviceProvider);
 
-            return app.Execute(args);
+            try
+            {
+                return app.Execute(args);
+            }
+            catch (CommandParsingException ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+
+            return -1;
         }
 
         private static void ConfigureServices(IServiceCollection services, IConfiguration configuration)


### PR DESCRIPTION
## Summary
Handle CommandParsingException in engine so it does not throw unhandled exception when user input unknown command

Issue #64 