### PR TITLE
Fix get projects return error when user is not admin

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessHandler.cs
+++ b/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessHandler.cs
@@ -46,6 +46,10 @@ namespace Polyrific.Catapult.Api.Identity
             {
                 projectClaim = userProjects.FirstOrDefault(up => up.ProjectName?.ToLower() == expectedProjectName.ToLower());
             }
+            else
+            {
+                projectClaim = userProjects.FirstOrDefault(up => string.IsNullOrEmpty(expectedMemberRole) || IsAllowedByMemberRole(up.MemberRole, expectedMemberRole));
+            }
 
             if (projectClaim != null)
             {


### PR DESCRIPTION
## Summary
Fix error in endpoint `/project` that use authorization policy `ProjectMemberAccess`. The error occured because the `ProjectAccessHandler` require `projectId` or `projectName` in the route, when the user is not admin