### PR TITLE
Require OwnerAccess to modify project member

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/RemoveProjectOwnerException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/RemoveProjectOwnerException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class RemoveProjectOwnerException : Exception
+    {
+        public int CurrentUserId { get; set; }
+
+        public RemoveProjectOwnerException(int currentUserId)
+            : base($"User {currentUserId} cannot remove the project owner.")
+        {
+            CurrentUserId = currentUserId;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IProjectMemberService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IProjectMemberService.cs
@@ -55,9 +55,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// </summary>
         /// <param name="projectId">Id of the project</param>
         /// <param name="userId">Id of the user</param>
+        /// <param name="currentUserId">Id of the current user</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns></returns>
-        Task RemoveProjectMember(int projectId, int userId, CancellationToken cancellationToken = default(CancellationToken));
+        Task RemoveProjectMember(int projectId, int userId, int currentUserId = 0, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get project member by id

--- a/src/API/Polyrific.Catapult.Api/Controllers/AccountController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Web;
 using AutoMapper;
@@ -117,7 +118,7 @@ namespace Polyrific.Catapult.Api.Controllers
         [Authorize]
         public async Task<IActionResult> GetUser(int userId)
         {
-            var currentUserId = await _userService.GetUserId(User);
+            var currentUserId = User.GetUserId();
             if (currentUserId != userId && !User.IsInRole(UserRole.Administrator))
             {
                 return Unauthorized();
@@ -134,7 +135,7 @@ namespace Polyrific.Catapult.Api.Controllers
         [Authorize]
         public async Task<IActionResult> GetCurrentUser()
         {
-            var currentUserId = await _userService.GetUserId(User);
+            var currentUserId = User.GetUserId();
 
             var user = await _userService.GetUserById(currentUserId);
 
@@ -196,7 +197,7 @@ namespace Polyrific.Catapult.Api.Controllers
         [Authorize]
         public async Task<IActionResult> UpdateUser(int userId, UpdateUserDto updatedUser)
         {
-            var currentUserId = await _userService.GetUserId(User);
+            var currentUserId = User.GetUserId();
             if (currentUserId != userId && !User.IsInRole(UserRole.Administrator))
             {
                 return Unauthorized();
@@ -252,7 +253,7 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             try
             {
-                var currentUserId = await _userService.GetUserId(User);
+                var currentUserId = User.GetUserId();
                 if (currentUserId != userId && !User.IsInRole(UserRole.Administrator))
                 {
                     return Unauthorized();

--- a/src/API/Polyrific.Catapult.Api/Controllers/ExternalServiceController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ExternalServiceController.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Api.Core.Exceptions;
 using Polyrific.Catapult.Api.Core.Services;
+using Polyrific.Catapult.Api.Identity;
 using Polyrific.Catapult.Shared.Dto.ExternalService;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -36,7 +37,7 @@ namespace Polyrific.Catapult.Api.Controllers
         [Authorize]
         public async Task<IActionResult> GetExternalServices()
         {
-            var currentUserId = await _userService.GetUserId(User);
+            var currentUserId = User.GetUserId();
             var externalServices = await _externalServiceService.GetExternalServices(currentUserId);
             var results = _mapper.Map<List<ExternalServiceDto>>(externalServices);
 
@@ -83,7 +84,7 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             try
             {
-                var currentUserId = await _userService.GetUserId(User);
+                var currentUserId = User.GetUserId();
                 var newExternalService = _mapper.Map<ExternalServiceDto>(dto);
 
                 newExternalService.Id = await _externalServiceService.AddExternalService(dto.Name,

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
@@ -40,7 +40,7 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             try
             {
-                var currentUserId = await _userService.GetUserId(User);
+                var currentUserId = User.GetUserId();
                 var projects = await _projectService.GetProjectsByUser(currentUserId, status);
                 var results = _mapper.Map<List<ProjectDto>>(projects.Select(p => p.Item1));
 
@@ -88,7 +88,7 @@ namespace Polyrific.Catapult.Api.Controllers
             try
             {
                 var projectMembers = newProject.Members.Select(m => (m.UserId, m.ProjectMemberRoleId)).ToList();
-                var currentUserId = await _userService.GetUserId(User);
+                var currentUserId = User.GetUserId();
 
                 List<ProjectDataModel> models = null;
                 List<JobDefinition> jobs = null;

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <returns></returns>
         [HttpPost("Project/{projectId}/member", Name = "CreateProjectMember")]
         [ProducesResponseType(201)]
-        [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
+        [Authorize(Policy = AuthorizePolicy.ProjectOwnerAccess)]
         public async Task<IActionResult> CreateProjectMember(int projectId, NewProjectMemberDto newProjectMember)
         {
             try
@@ -132,7 +132,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="projectMember">Update project member request body</param>
         /// <returns></returns>
         [HttpPut("Project/{projectId}/member/{memberId}")]
-        [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
+        [Authorize(Policy = AuthorizePolicy.ProjectOwnerAccess)]
         public async Task<IActionResult> UpdateProjectMember(int projectId, int memberId, UpdateProjectMemberDto projectMember)
         {
             if (memberId != projectMember.Id)
@@ -150,7 +150,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="memberId">Id of the project member</param>
         /// <returns></returns>
         [HttpDelete("Project/{projectId}/member/{memberId}")]
-        [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
+        [Authorize(Policy = AuthorizePolicy.ProjectOwnerAccess)]
         public async Task<IActionResult> RemoveProjectMember(int projectId, int memberId)
         {
             var member = await _projectMemberService.GetProjectMemberById(memberId);

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Polyrific.Catapult.Api.Core.Exceptions;
 using Polyrific.Catapult.Api.Core.Services;
 using Polyrific.Catapult.Api.Identity;
+using Polyrific.Catapult.Shared.Dto.Constants;
 using Polyrific.Catapult.Shared.Dto.ProjectMember;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -16,11 +17,13 @@ namespace Polyrific.Catapult.Api.Controllers
     public class ProjectMemberController : ControllerBase
     {
         private readonly IProjectMemberService _projectMemberService;
+        private readonly IUserService _userService;
         private readonly IMapper _mapper;
 
-        public ProjectMemberController(IProjectMemberService projectMemberService, IMapper mapper)
+        public ProjectMemberController(IProjectMemberService projectMemberService, IUserService userService, IMapper mapper)
         {
             _projectMemberService = projectMemberService;
+            _userService = userService;
             _mapper = mapper;
         }
 
@@ -153,14 +156,26 @@ namespace Polyrific.Catapult.Api.Controllers
         [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
         public async Task<IActionResult> RemoveProjectMember(int projectId, int memberId)
         {
-            var member = await _projectMemberService.GetProjectMemberById(memberId);
-
-            if (member != null)
+            try
             {
-                await _projectMemberService.RemoveProjectMember(projectId, member.UserId);
-            }            
+                var member = await _projectMemberService.GetProjectMemberById(memberId);
 
-            return NoContent();
+                if (member != null)
+                {
+                    int currentUserId = 0;
+
+                    if (!User.IsInRole(UserRole.Administrator))
+                        currentUserId = await _userService.GetUserId(User);
+
+                    await _projectMemberService.RemoveProjectMember(projectId, member.UserId, currentUserId);
+                }
+
+                return NoContent();
+            }
+            catch (RemoveProjectOwnerException ex)
+            {
+                return BadRequest(ex.Message);
+            }
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <returns></returns>
         [HttpPost("Project/{projectId}/member", Name = "CreateProjectMember")]
         [ProducesResponseType(201)]
-        [Authorize(Policy = AuthorizePolicy.ProjectOwnerAccess)]
+        [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
         public async Task<IActionResult> CreateProjectMember(int projectId, NewProjectMemberDto newProjectMember)
         {
             try
@@ -132,7 +132,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="projectMember">Update project member request body</param>
         /// <returns></returns>
         [HttpPut("Project/{projectId}/member/{memberId}")]
-        [Authorize(Policy = AuthorizePolicy.ProjectOwnerAccess)]
+        [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
         public async Task<IActionResult> UpdateProjectMember(int projectId, int memberId, UpdateProjectMemberDto projectMember)
         {
             if (memberId != projectMember.Id)
@@ -150,7 +150,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="memberId">Id of the project member</param>
         /// <returns></returns>
         [HttpDelete("Project/{projectId}/member/{memberId}")]
-        [Authorize(Policy = AuthorizePolicy.ProjectOwnerAccess)]
+        [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
         public async Task<IActionResult> RemoveProjectMember(int projectId, int memberId)
         {
             var member = await _projectMemberService.GetProjectMemberById(memberId);

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectMemberController.cs
@@ -165,7 +165,7 @@ namespace Polyrific.Catapult.Api.Controllers
                     int currentUserId = 0;
 
                     if (!User.IsInRole(UserRole.Administrator))
-                        currentUserId = await _userService.GetUserId(User);
+                        currentUserId = User.GetUserId();
 
                     await _projectMemberService.RemoveProjectMember(projectId, member.UserId, currentUserId);
                 }

--- a/src/API/Polyrific.Catapult.Api/Controllers/TokenController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/TokenController.cs
@@ -51,7 +51,7 @@ namespace Polyrific.Catapult.Api.Controllers
             var tokenIssuer = _configuration["Security:Tokens:Issuer"];
             var tokenAudience = _configuration["Security:Tokens:Audience"];
 
-            var token = AuthorizationToken.GenerateToken(dto.Email, userRole, userProjects, tokenKey, tokenIssuer,
+            var token = AuthorizationToken.GenerateToken(user.Id, dto.Email, userRole, userProjects, tokenKey, tokenIssuer,
                 tokenAudience);
 
             return Ok(token);

--- a/src/API/Polyrific.Catapult.Api/Identity/AuthorizationToken.cs
+++ b/src/API/Polyrific.Catapult.Api/Identity/AuthorizationToken.cs
@@ -13,7 +13,7 @@ namespace Polyrific.Catapult.Api.Identity
 {
     public class AuthorizationToken
     {
-        public static string GenerateToken(string userName, string userRole, List<(int, string, string)> userProjects, string tokenKey, string tokenIssuer, string tokenAudience)
+        public static string GenerateToken(int userId, string userName, string userRole, List<(int, string, string)> userProjects, string tokenKey, string tokenIssuer, string tokenAudience)
         {
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(tokenKey));
                 
@@ -23,6 +23,7 @@ namespace Polyrific.Catapult.Api.Identity
                 claims: new []
                 {
                     new Claim(ClaimTypes.Name, userName),
+                    new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
                     new Claim(CustomClaimTypes.Projects, JsonConvert.SerializeObject(userProjects.Select(up => new ProjectClaim
                     {
                         ProjectId = up.Item1,

--- a/src/API/Polyrific.Catapult.Api/Identity/ClaimPrincipalExtensions.cs
+++ b/src/API/Polyrific.Catapult.Api/Identity/ClaimPrincipalExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+using System.Security.Claims;
+
+namespace Polyrific.Catapult.Api.Identity
+{
+    public static class ClaimPrincipalExtensions
+    {
+        public static int GetUserId(this ClaimsPrincipal principal)
+        {
+            if (principal == null)
+                throw new ArgumentNullException(nameof(principal));
+
+            var userIdClaim = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (int.TryParse(userIdClaim, out var userId))
+                return userId;
+
+            return 0;
+        }
+    }
+}

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectMemberServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectMemberServiceTests.cs
@@ -51,6 +51,10 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                     r.GetSingleBySpec(It.IsAny<ProjectMemberFilterSpecification>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((ProjectMemberFilterSpecification spec, CancellationToken cancellationToken) =>
                     _data.FirstOrDefault(d => d.ProjectId == spec.ProjectId && d.UserId == spec.UserId));
+            _projectMemberRepository.Setup(r =>
+                    r.CountBySpec(It.IsAny<ProjectMemberFilterSpecification>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProjectMemberFilterSpecification spec, CancellationToken cancellationToken) =>
+                    _data.Count(d => d.ProjectId == spec.ProjectId && d.UserId == spec.UserId));
             _projectMemberRepository.Setup(s =>
                     s.GetBySpec(It.IsAny<ProjectMemberFilterSpecification>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((ProjectMemberFilterSpecification spec, CancellationToken cancellationToken) =>
@@ -188,9 +192,18 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void RemoveProjectMember_ValidItem()
         {
             var projectMemberService = new ProjectMemberService(_projectMemberRepository.Object, _projectRepository.Object, _userRepository.Object);
-            await projectMemberService.RemoveProjectMember(1, 1);
+            await projectMemberService.RemoveProjectMember(1, 1, 1);
 
             Assert.Empty(_data);
+        }
+
+        [Fact]
+        public void RemoveProjectMember_RemoveProjectOwnerException()
+        {
+            var projectMemberService = new ProjectMemberService(_projectMemberRepository.Object, _projectRepository.Object, _userRepository.Object);
+            var exception = Record.ExceptionAsync(() => projectMemberService.RemoveProjectMember(1, 1, 2));
+
+            Assert.IsType<RemoveProjectOwnerException>(exception?.Result);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
After giving it a thought, I think we should require the user to have Owner Access instead of just Maintainer Access, for modifying the project member. 

Because it'd make less sense if a maintainer can add a member that have the Owner role. Or remove an Owner of a project.