### PR TITLE
Fix several bugs in engine and generator

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/IProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IProjectDataModelService.cs
@@ -40,9 +40,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// Get list of project data models
         /// </summary>
         /// <param name="projectId">Id of the project</param>
+        /// <param name="includeProperties">Indicate whether the result should include model's properties</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>List of project data models</returns>
-        Task<List<ProjectDataModel>> GetProjectDataModels(int projectId, CancellationToken cancellationToken = default(CancellationToken));
+        Task<List<ProjectDataModel>> GetProjectDataModels(int projectId, bool includeProperties, CancellationToken cancellationToken = default(CancellationToken));
         
         /// <summary>
         /// Get a project data model by id

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
@@ -143,11 +143,15 @@ namespace Polyrific.Catapult.Api.Core.Services
             return await _dataModelPropertyRepository.GetSingleBySpec(new ProjectDataModelPropertyFilterSpecification(propertyName, dataModelId), cancellationToken);
         }
 
-        public async Task<List<ProjectDataModel>> GetProjectDataModels(int projectId, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<List<ProjectDataModel>> GetProjectDataModels(int projectId, bool includeProperties, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var projectMemberByProjectSpec = new ProjectDataModelFilterSpecification(projectId);
+
+            if (includeProperties)
+                projectMemberByProjectSpec.IncludeStrings.Add("Properties.RelatedProjectDataModel");
+
             var projectMembers = await _dataModelRepository.GetBySpec(projectMemberByProjectSpec, cancellationToken);
 
             return projectMembers.ToList();

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
@@ -147,14 +147,14 @@ namespace Polyrific.Catapult.Api.Core.Services
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var projectMemberByProjectSpec = new ProjectDataModelFilterSpecification(projectId);
+            var dataModelByProjectSpec = new ProjectDataModelFilterSpecification(projectId);
 
             if (includeProperties)
-                projectMemberByProjectSpec.IncludeStrings.Add("Properties.RelatedProjectDataModel");
+                dataModelByProjectSpec.IncludeStrings.Add("Properties.RelatedProjectDataModel");
 
-            var projectMembers = await _dataModelRepository.GetBySpec(projectMemberByProjectSpec, cancellationToken);
+            var dataModels = await _dataModelRepository.GetBySpec(dataModelByProjectSpec, cancellationToken);
 
-            return projectMembers.ToList();
+            return dataModels.ToList();
         }
 
         public async Task UpdateDataModel(ProjectDataModel updatedDataModel, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/ProjectDataModelPropertyAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/ProjectDataModelPropertyAutoMapperProfile.cs
@@ -10,7 +10,8 @@ namespace Polyrific.Catapult.Api.AutoMapperProfiles
     {
         public ProjectDataModelPropertyAutoMapperProfile()
         {
-            CreateMap<ProjectDataModelProperty, ProjectDataModelPropertyDto>();
+            CreateMap<ProjectDataModelProperty, ProjectDataModelPropertyDto>()
+                .ForMember(dest => dest.RelatedProjectDataModelName, opt => opt.MapFrom(src => src.RelatedProjectDataModel.Name));
             CreateMap<UpdateProjectDataModelPropertyDto, ProjectDataModelProperty>();
             CreateMap<CreateProjectDataModelPropertyDto, ProjectDataModelPropertyDto>();
             CreateMap<CreateProjectDataModelPropertyDto, ProjectDataModelProperty>();

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectDataModelController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectDataModelController.cs
@@ -29,12 +29,13 @@ namespace Polyrific.Catapult.Api.Controllers
         /// Get project data models for a project
         /// </summary>
         /// <param name="projectId">Id of the project</param>
+        /// <param name="includeProperties">Indicate whether the result should include model's properties. Default to false</param>
         /// <returns>List of project data models</returns>
         [HttpGet("Project/{projectId}/model", Name = "GetProjectDataModels")]
         [Authorize(Policy = AuthorizePolicy.ProjectAccess)]
-        public async Task<IActionResult> GetProjectDataModels(int projectId)
+        public async Task<IActionResult> GetProjectDataModels(int projectId, bool includeProperties = false)
         {
-            var dataModels = await _projectDataModelService.GetProjectDataModels(projectId);
+            var dataModels = await _projectDataModelService.GetProjectDataModels(projectId, includeProperties);
             var results = _mapper.Map<List<ProjectDataModelDto>>(dataModels);
 
             return Ok(results);

--- a/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessHandler.cs
+++ b/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessHandler.cs
@@ -15,7 +15,7 @@ namespace Polyrific.Catapult.Api.Identity
     {
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ProjectAccessRequirement requirement)
         {
-            if (context.User.IsInRole(UserRole.Administrator) || context.User.IsInRole(UserRole.Engine))
+            if (context.User.IsInRole(UserRole.Administrator))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;
@@ -26,7 +26,6 @@ namespace Polyrific.Catapult.Api.Identity
                 
             var expectedProjectId = Convert.ToInt32(mvcContext.RouteData.Values["projectId"]);
             var expectedProjectName = mvcContext.RouteData.Values["projectName"]?.ToString();
-            var expectedMemberRole = requirement.MemberRole;
 
             if (!context.User.HasClaim(c => c.Type == CustomClaimTypes.Projects))
                 return Task.CompletedTask;
@@ -48,41 +47,16 @@ namespace Polyrific.Catapult.Api.Identity
             }
             else
             {
-                projectClaim = userProjects.FirstOrDefault(up => string.IsNullOrEmpty(expectedMemberRole) || IsAllowedByMemberRole(up.MemberRole, expectedMemberRole));
+                projectClaim = userProjects.FirstOrDefault(up => requirement.IsAllowedByMemberRole(up.MemberRole));
             }
 
             if (projectClaim != null)
             {
-                if (string.IsNullOrEmpty(expectedMemberRole) || IsAllowedByMemberRole(projectClaim.MemberRole, expectedMemberRole))
+                if (requirement.IsAllowedByMemberRole(projectClaim.MemberRole))
                     context.Succeed(requirement);
             }
 
             return Task.CompletedTask;
-        }
-
-        private bool IsAllowedByMemberRole(string userRole, string expectedRole)
-        {
-            var userRoleRank = GetMemberRoleRank(userRole);
-            var expectedRoleRank = GetMemberRoleRank(expectedRole);
-
-            return userRoleRank > 0 && userRoleRank <= expectedRoleRank;
-        }
-
-        private int GetMemberRoleRank(string member)
-        {
-            switch (member)
-            {
-                case MemberRole.Owner:
-                    return 1;
-                case MemberRole.Maintainer:
-                    return 2;
-                case MemberRole.Contributor:
-                    return 3;
-                case MemberRole.Member:
-                    return 4;
-                default:
-                    return 0;
-            }
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessHandler.cs
+++ b/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessHandler.cs
@@ -15,7 +15,7 @@ namespace Polyrific.Catapult.Api.Identity
     {
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ProjectAccessRequirement requirement)
         {
-            if (context.User.IsInRole(UserRole.Administrator))
+            if (context.User.IsInRole(UserRole.Administrator) || context.User.IsInRole(UserRole.Engine))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;

--- a/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessRequirement.cs
+++ b/src/API/Polyrific.Catapult.Api/Identity/ProjectAccessRequirement.cs
@@ -17,5 +17,33 @@ namespace Polyrific.Catapult.Api.Identity
         {
             MemberRole = memberRole;
         }
+
+        public bool IsAllowedByMemberRole(string userRole)
+        {
+            if (string.IsNullOrEmpty(MemberRole))
+                return true;
+
+            var userRoleRank = GetMemberRoleRank(userRole);
+            var expectedRoleRank = GetMemberRoleRank(MemberRole);
+
+            return userRoleRank > 0 && userRoleRank <= expectedRoleRank;
+        }
+
+        private int GetMemberRoleRank(string member)
+        {
+            switch (member)
+            {
+                case Shared.Dto.Constants.MemberRole.Owner:
+                    return 1;
+                case Shared.Dto.Constants.MemberRole.Maintainer:
+                    return 2;
+                case Shared.Dto.Constants.MemberRole.Contributor:
+                    return 3;
+                case Shared.Dto.Constants.MemberRole.Member:
+                    return 4;
+                default:
+                    return 0;
+            }
+        }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Identity/ProjectEngineAccessHandler.cs
+++ b/src/API/Polyrific.Catapult.Api/Identity/ProjectEngineAccessHandler.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Polyrific.Catapult.Shared.Dto.Constants;
+
+namespace Polyrific.Catapult.Api.Identity
+{
+    public class ProjectEngineAccessHandler : AuthorizationHandler<ProjectAccessRequirement>
+    {
+        private const string AllowedMemberRole = MemberRole.Contributor;
+
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ProjectAccessRequirement requirement)
+        {
+            if (!(context.Resource is AuthorizationFilterContext mvcContext))
+                return Task.CompletedTask;
+
+            if (context.User.IsInRole(UserRole.Engine) && requirement.IsAllowedByMemberRole(AllowedMemberRole))
+                context.Succeed(requirement);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/Startup.cs
+++ b/src/API/Polyrific.Catapult.Api/Startup.cs
@@ -91,6 +91,7 @@ namespace Polyrific.Catapult.Api
             });
             
             services.AddSingleton<IAuthorizationHandler, ProjectAccessHandler>();
+            services.AddSingleton<IAuthorizationHandler, ProjectEngineAccessHandler>();
 
             services.AddSignalR();
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/GenerateTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/GenerateTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
         public override string Type => JobTaskDefinitionType.Generate;
 
         private List<ProjectDataModelDto> _dataModels;
-        protected List<ProjectDataModelDto> DataModels => _dataModels ?? (_dataModels = _dataModelService.GetProjectDataModels(ProjectId).Result);
+        protected List<ProjectDataModelDto> DataModels => _dataModels ?? (_dataModels = _dataModelService.GetProjectDataModels(ProjectId, true).Result);
 
         [ImportMany(typeof(ICodeGeneratorProvider))]
         public IEnumerable<ICodeGeneratorProvider> GeneratorProviders;

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/AspNetCoreMvc.csproj
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/AspNetCoreMvc.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGeneratorProvider.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGeneratorProvider.cs
@@ -26,6 +26,8 @@ namespace AspNetCoreMvc
         {
             additionalConfigs.TryGetValue("ConnectionString", out var connectionString);
 
+            config.OutputLocation = config.OutputLocation ?? config.WorkingLocation;
+
             var generator = new CodeGenerator(projectName, config.OutputLocation, models, connectionString);
 
             await generator.InitSolution();

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/TextHelper.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/TextHelper.cs
@@ -17,5 +17,10 @@ namespace AspNetCoreMvc.Helpers
         {
             return text.Camelize();
         }
+
+        public static string Pascalize(string text)
+        {
+            return text.Pascalize();
+        }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.ApiClient/ProjectDataModelService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.ApiClient/ProjectDataModelService.cs
@@ -76,9 +76,12 @@ namespace Polyrific.Catapult.Shared.ApiClient
             return await Api.Get<ProjectDataModelPropertyDto>(path);
         }
 
-        public async Task<List<ProjectDataModelDto>> GetProjectDataModels(int projectId)
+        public async Task<List<ProjectDataModelDto>> GetProjectDataModels(int projectId, bool includeProperties = false)
         {
-            var path = $"project/{projectId}/model/";
+            var path = $"project/{projectId}/model";
+
+            if (includeProperties)
+                path += "?includeProperties=true";
 
             return await Api.Get<List<ProjectDataModelDto>>(path);
         }

--- a/src/Shared/Polyrific.Catapult.Shared.Common/DirectoryHelper.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/DirectoryHelper.cs
@@ -14,7 +14,7 @@ namespace Polyrific.Catapult.Shared.Common
                 return new string[0];
 
             var subDirectories = Directory.GetDirectories(path);
-            return subDirectories.Select(sd => sd.Substring(sd.LastIndexOf("\\", StringComparison.Ordinal))).ToArray();
+            return subDirectories;
         }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Service/IProjectDataModelService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Service/IProjectDataModelService.cs
@@ -12,8 +12,9 @@ namespace Polyrific.Catapult.Shared.Service
         /// Get list of project data models
         /// </summary>
         /// <param name="projectId">Id of the project</param>
+        /// <param name="includeProperties">Indicate whether the result should include model's properties. Default to false</param>
         /// <returns>List of Project data models</returns>
-        Task<List<ProjectDataModelDto>> GetProjectDataModels(int projectId);
+        Task<List<ProjectDataModelDto>> GetProjectDataModels(int projectId, bool includeProperties = false);
 
         /// <summary>
         /// Create a project data model

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectDataModelServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectDataModelServiceTests.cs
@@ -167,7 +167,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void GetProjectDataModels_ReturnItems()
         {
             var projectDataModelService = new ProjectDataModelService(_dataModelRepository.Object, _propertyRepository.Object, _projectRepository.Object);
-            var dataModels = await projectDataModelService.GetProjectDataModels(1);
+            var dataModels = await projectDataModelService.GetProjectDataModels(1, false);
 
             Assert.NotEmpty(dataModels);
         }
@@ -176,7 +176,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void GetProjectDataModels_ReturnEmpty()
         {
             var projectDataModelService = new ProjectDataModelService(_dataModelRepository.Object, _propertyRepository.Object, _projectRepository.Object);
-            var dataModels = await projectDataModelService.GetProjectDataModels(2);
+            var dataModels = await projectDataModelService.GetProjectDataModels(2, false);
 
             Assert.Empty(dataModels);
         }

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ModelCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ModelCommandTests.cs
@@ -59,7 +59,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
                 projectModels.Add(newProjectDataModel);
                 return newProjectDataModel;
             });
-            _projectModelService.Setup(p => p.GetProjectDataModels(It.IsAny<int>())).ReturnsAsync(projectModels);
+            _projectModelService.Setup(p => p.GetProjectDataModels(It.IsAny<int>(), It.IsAny<bool>())).ReturnsAsync(projectModels);
             _projectModelService.Setup(p => p.GetProjectDataModelByName(It.IsAny<int>(), It.IsAny<string>())).ReturnsAsync((int projectId, string name) =>
                 projectModels.FirstOrDefault(p => p.ProjectId == projectId && p.Name == name));
         }

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/GenerateTaskTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/GenerateTaskTests.cs
@@ -33,7 +33,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core.JobTasks
                 .ReturnsAsync((int id) => new ProjectDto {Id = id, Name = $"Project {id}"});
 
             _dataModelService = new Mock<IProjectDataModelService>();
-            _dataModelService.Setup(s => s.GetProjectDataModels(It.IsAny<int>())).ReturnsAsync(dataModels);
+            _dataModelService.Setup(s => s.GetProjectDataModels(It.IsAny<int>(), It.IsAny<bool>())).ReturnsAsync(dataModels);
 
             _logger = new Mock<ILogger<GenerateTask>>();
         }


### PR DESCRIPTION
## Summary
Fix several bugs when running engine and generator task

## PR Coverages
- [x] fix authorization error because engine cannot access project policy endpoints -> To fix this, I add the conditional to always pass engine in `ProjectAccessHandler.cs`
- [x] Fix refresh plugin error
- [x] fix nuget dependency not copied into plugin directory for AspNetCoreMvc generator plugin
- [x] Fix error in generate when the project name contains `-`
- [x] Include property and related property when retrieving model to the engine
- [x] misc bugfix in AspNetCoreMvc generator