### PR TITLE
Rename output assembly for CLI and Engine

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj
+++ b/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Polyrific.Catapult.Cli</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AssemblyName>PC</AssemblyName>	
+    <AssemblyName>occli</AssemblyName>	
     <LangVersion>7.1</LangVersion>	
     <PackageId>Polyrific.Catapult.Cli</PackageId>	
     <Authors>Polyrific</Authors>	

--- a/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj
+++ b/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Polyrific.Catapult.Engine</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AssemblyName>PCEngine</AssemblyName>
+    <AssemblyName>ocengine</AssemblyName>
     <LangVersion>7.1</LangVersion>
     <PackageId>Polyrific.Catapult.Engine</PackageId>
     <Authors>Polyrific</Authors>


### PR DESCRIPTION
## Summary
Rename output assembly for CLI and Engine.

## Related Issues
- https://github.com/Polyrific-Inc/OpenCatapult/issues/88