### PR TITLE
Adjust update password and reset password

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Controllers/AccountController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/AccountController.cs
@@ -248,22 +248,17 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <summary>
         /// Update user's password
         /// </summary>
-        /// <param name="userId">Id of the user</param>
         /// <param name="dto">The request body for update password</param>
         /// <returns></returns>
-        [HttpPost("{userId}/password")]
+        [HttpPut("password")]
         [Authorize]
-        public async Task<IActionResult> UpdatePassword(int userId, UpdatePasswordDto dto)
+        public async Task<IActionResult> UpdatePassword(UpdatePasswordDto dto)
         {
             try
             {
                 var currentUserId = User.GetUserId();
-                if (currentUserId != userId && !User.IsInRole(UserRole.Administrator))
-                {
-                    return Unauthorized();
-                }
 
-                await _userService.UpdatePassword(userId, dto.OldPassword, dto.NewPassword);
+                await _userService.UpdatePassword(currentUserId, dto.OldPassword, dto.NewPassword);
 
                 return Ok("Password updated");
             }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetCommand.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Cli.Commands.Account.Password
         {
             Console.WriteLine($"Trying to reset password for user {User}...");
 
-            string message;
+            string message = "Reset password failed. Please make sure to input the correct reset password token";
 
             var user = _accountService.GetUserByEmail(User).Result;
             if (user != null)
@@ -51,7 +51,7 @@ namespace Polyrific.Catapult.Cli.Commands.Account.Password
             }
             else
             {
-                message = $"User {User} is not found";
+                Logger.LogWarning($"Reset password was attempted for a user {User} that doesn't exist");
             }
 
             return message;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetTokenCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetTokenCommand.cs
@@ -25,18 +25,17 @@ namespace Polyrific.Catapult.Cli.Commands.Account.Password
         {
             Console.WriteLine($"Requesting reset password token for user {User}...");
 
-            string message;
+            string message = $"Reset password token has been sent to {User}";
 
             var user = _accountService.GetUserByEmail(User).Result;
             if (user != null)
             {
                 var userId = int.Parse(user.Id);
                 _accountService.RequestResetPassword(userId).Wait();
-                message = $"Reset password token has been sent to {User}";
             }
             else
             {
-                message = $"User {User} is not found";
+                Logger.LogWarning($"A reset password token was requested for user {User} that doesn't exist");
             }
 
             return message;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/UpdateCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account.Password
 {
-    [Command(Description = "Update user password")]
+    [Command(Description = "Update current user's password")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/UpdateCommand.cs
@@ -19,36 +19,21 @@ namespace Polyrific.Catapult.Cli.Commands.Account.Password
             _accountService = accountService;
             _consoleReader = consoleReader;
         }
-
-        [Required]
-        [Option("-u|--user <USER>", "Username (email) of the user", CommandOptionType.SingleValue)]
-        public string User { get; set; }
         
         public override string Execute()
         {
-            Console.WriteLine($"Trying to update password for user {User}...");
+            Console.WriteLine($"Trying to update password for current user...");
 
             string message;
 
-            var user = _accountService.GetUserByEmail(User).Result;
-            if (user != null)
+            _accountService.UpdatePassword(new UpdatePasswordDto
             {
-                var userId = int.Parse(user.Id);
-                _accountService.UpdatePassword(userId, new UpdatePasswordDto
-                {
-                    Id = userId,
-                    OldPassword = _consoleReader.GetPassword("Enter old password:"),
-                    NewPassword = _consoleReader.GetPassword("Enter new password:"),
-                    ConfirmNewPassword = _consoleReader.GetPassword("Re-enter new password:")
-                }).Wait();
-
-                message = $"Password for user {User} has been updated";
-                Logger.LogInformation(message);
-            }
-            else
-            {
-                message = $"User {User} is not found";
-            }
+                OldPassword = _consoleReader.GetPassword("Enter old password:"),
+                NewPassword = _consoleReader.GetPassword("Enter new password:"),
+                ConfirmNewPassword = _consoleReader.GetPassword("Re-enter new password:")
+            }).Wait();
+            message = $"Password for current user has been updated";
+            Logger.LogInformation(message);
 
             return message;
         }

--- a/src/Shared/Polyrific.Catapult.Shared.ApiClient/AccountService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.ApiClient/AccountService.cs
@@ -97,11 +97,11 @@ namespace Polyrific.Catapult.Shared.ApiClient
             await Api.Put(path, dto);
         }
 
-        public async Task UpdatePassword(int userId, UpdatePasswordDto dto)
+        public async Task UpdatePassword(UpdatePasswordDto dto)
         {
-            var path = $"account/{userId}/password";
+            var path = $"account/password";
 
-            await Api.Post(path, dto);
+            await Api.Put(path, dto);
         }
 
         public async Task RequestResetPassword(int userId)

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/User/UpdatePasswordDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/User/UpdatePasswordDto.cs
@@ -7,12 +7,6 @@ namespace Polyrific.Catapult.Shared.Dto.User
     public class UpdatePasswordDto
     {
         /// <summary>
-        /// Id of the user
-        /// </summary>
-        [Required]
-        public int Id { get; set; }
-
-        /// <summary>
         /// Old password of the user
         /// </summary>
         [Required]

--- a/src/Shared/Polyrific.Catapult.Shared.Service/IAccountService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Service/IAccountService.cs
@@ -98,10 +98,9 @@ namespace Polyrific.Catapult.Shared.Service
         /// <summary>
         /// Update user password
         /// </summary>
-        /// <param name="userId">Id of the user</param>
         /// <param name="dto">DTO containing required details</param>
         /// <returns></returns>
-        Task UpdatePassword(int userId, UpdatePasswordDto dto);
+        Task UpdatePassword(UpdatePasswordDto dto);
 
         /// <summary>
         /// Request reset password token to be sent to user

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/AccountCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/AccountCommandTests.cs
@@ -181,27 +181,11 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         [Fact]
         public void AccountUpdatePassword_Execute_ReturnsSuccessMessage()
         {
-            var command = new Cli.Commands.Account.Password.UpdateCommand(_console, LoggerMock.GetLogger<Cli.Commands.Account.Password.UpdateCommand>().Object, _accountService.Object, _consoleReader.Object)
-            {
-                User = "user1@opencatapult.net"
-            };
+            var command = new Cli.Commands.Account.Password.UpdateCommand(_console, LoggerMock.GetLogger<Cli.Commands.Account.Password.UpdateCommand>().Object, _accountService.Object, _consoleReader.Object);
 
             var resultMessage = command.Execute();
 
-            Assert.Equal("Password for user user1@opencatapult.net has been updated", resultMessage);
-        }
-
-        [Fact]
-        public void AccountUpdatePassword_Execute_ReturnsNotFoundMessage()
-        {
-            var command = new Cli.Commands.Account.Password.UpdateCommand(_console, LoggerMock.GetLogger<Cli.Commands.Account.Password.UpdateCommand>().Object, _accountService.Object, _consoleReader.Object)
-            {
-                User = "user2@opencatapult.net"
-            };
-
-            var resultMessage = command.Execute();
-
-            Assert.Equal("User user2@opencatapult.net is not found", resultMessage);
+            Assert.Equal("Password for current user has been updated", resultMessage);
         }
 
         [Fact]
@@ -218,7 +202,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         }
 
         [Fact]
-        public void AccountPasswordResetToken_Execute_ReturnsNotFoundMessage()
+        public void AccountPasswordResetToken_Execute_ReturnsSuccessWhenEmailNotFound()
         {
             var command = new ResetTokenCommand(_console, LoggerMock.GetLogger<ResetTokenCommand>().Object, _accountService.Object)
             {
@@ -227,7 +211,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
 
             var resultMessage = command.Execute();
 
-            Assert.Equal("User user2@opencatapult.net is not found", resultMessage);
+            Assert.Equal("Reset password token has been sent to user2@opencatapult.net", resultMessage);
         }
 
         [Fact]
@@ -244,7 +228,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         }
 
         [Fact]
-        public void AccountPasswordReset_Execute_ReturnsNotFoundMessage()
+        public void AccountPasswordReset_Execute_ReturnsFailedMessage()
         {
             var command = new ResetCommand(_console, LoggerMock.GetLogger<ResetCommand>().Object, _accountService.Object, _consoleReader.Object)
             {
@@ -253,7 +237,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
 
             var resultMessage = command.Execute();
 
-            Assert.Equal("User user2@opencatapult.net is not found", resultMessage);
+            Assert.Equal("Reset password failed. Please make sure to input the correct reset password token", resultMessage);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
Adjust the update password and reset password command.

## PR Coverage
- [x] make `password update` to only update current user's password
- [x] In `password resettoken` `password reset`, don't show "User was not found" if the user doesn't exist

## Related issue
- #94 