### PR TITLE
Clean up CLI output

### DIFF
--- a/Polyrific.Catapult.Cli.sln
+++ b/Polyrific.Catapult.Cli.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polyrific.Catapult.Shared.Common", "src\Shared\Polyrific.Catapult.Shared.Common\Polyrific.Catapult.Shared.Common.csproj", "{71A13F2C-16B6-43E3-9677-A8699F249B74}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,18 @@ Global
 		{EFFE58C6-9857-42E8-A646-8841277130B2}.Release|x64.Build.0 = Release|Any CPU
 		{EFFE58C6-9857-42E8-A646-8841277130B2}.Release|x86.ActiveCfg = Release|Any CPU
 		{EFFE58C6-9857-42E8-A646-8841277130B2}.Release|x86.Build.0 = Release|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Debug|x64.Build.0 = Debug|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Debug|x86.Build.0 = Debug|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Release|x64.ActiveCfg = Release|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Release|x64.Build.0 = Release|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Release|x86.ActiveCfg = Release|Any CPU
+		{71A13F2C-16B6-43E3-9677-A8699F249B74}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -117,6 +131,7 @@ Global
 		{72D30761-85F0-4B38-ACFB-D2AB90B360F8} = {767C09A9-B148-4D89-8853-4EC07E4B8927}
 		{6C4BDA56-763C-4AAD-B36A-3E48C9B98CA4} = {767C09A9-B148-4D89-8853-4EC07E4B8927}
 		{EFFE58C6-9857-42E8-A646-8841277130B2} = {A006B0E4-FC0F-4316-97A6-ADDF607476F3}
+		{71A13F2C-16B6-43E3-9677-A8699F249B74} = {767C09A9-B148-4D89-8853-4EC07E4B8927}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E99636CE-C790-49DC-B73E-68B764F881B9}

--- a/appveyor/cli.appveyor.yml
+++ b/appveyor/cli.appveyor.yml
@@ -10,6 +10,7 @@ only_commits:
     - appveyor/cli.appveyor.yml
     - src/CLI/
     - src/Shared/Polyrific.Catapult.Shared.ApiClient/
+    - src/Shared/Polyrific.Catapult.Shared.Common/
     - src/Shared/Polyrific.Catapult.Shared.Dto/
     - src/Shared/Polyrific.Catapult.Shared.Service/
     - tests/Polyrific.Catapult.Cli.UnitTests/

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Shared.Common;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
@@ -57,7 +58,7 @@ namespace Polyrific.Catapult.Cli.Commands
             }
             catch (Exception ex)
             {
-                errorMessage = ex.Message;
+                errorMessage = ex.GetLastInnerExceptionMessage();
                 Logger.LogError(ex, errorMessage);
             }
 
@@ -66,6 +67,8 @@ namespace Polyrific.Catapult.Cli.Commands
 
             if (!string.IsNullOrEmpty(errorMessage))
                 Console.Error.WriteLine(errorMessage);
+
+            Console.WriteLine();
 
             return 0;
         }

--- a/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj
+++ b/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Polyrific.Catapult.Shared.Common\Polyrific.Catapult.Shared.Common.csproj" />
     <ProjectReference Include="..\Polyrific.Catapult.Cli.Infrastructure\Polyrific.Catapult.Cli.Infrastructure.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Cleanup error message to omit the "One ore more errors occurred" part
- Add spaces between commands