### PR TITLE
Engine: Fix issue in clone and push task

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/BaseJobTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/BaseJobTask.cs
@@ -89,6 +89,14 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             TaskConfig = JsonConvert.DeserializeObject<TTaskConfig>(configString) ?? new TTaskConfig();
             TaskConfig.WorkingLocation = workingLocation;
         }
+
+        /// <summary>
+        /// Reload the project of task instance
+        /// </summary>
+        public void ReloadProject()
+        {
+            _project = null;
+        }
         
         /// <summary>
         /// Type of the job task

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IJobTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IJobTask.cs
@@ -45,6 +45,11 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
         void SetConfig(Dictionary<string, string> configs, string workingLocation);
 
         /// <summary>
+        /// Reload the project of task instance
+        /// </summary>
+        void ReloadProject();
+
+        /// <summary>
         /// Run the main task
         /// </summary>
         /// <param name="previousTasksOutputValues">Output values from the previous tasks</param>

--- a/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
@@ -177,6 +177,7 @@ namespace Polyrific.Catapult.Engine.Core
                     throw new InvalidJobTaskTypeException(jobTask.Type);
             }
 
+            task.ReloadProject();
             task.ProjectId = projectId;
             task.JobTaskId = jobTask.Id;
             task.Provider = jobTask.Provider;

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/ProjectHelper.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/Helpers/ProjectHelper.cs
@@ -62,7 +62,7 @@ namespace AspNetCoreMvc.Helpers
         public void CopyFileToProject(string projectName, string sourceFile, string targetFile)
         {
             var targetFilePath = Path.Combine(_outputLocation, projectName, targetFile);
-            File.Copy(sourceFile, targetFilePath);
+            File.Copy(sourceFile, targetFilePath, true);
         }
 
         public void DeleteFileToProject(string projectName, string filePath)

--- a/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Configs/CloneTaskConfig.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Configs/CloneTaskConfig.cs
@@ -8,10 +8,20 @@ namespace Polyrific.Catapult.Plugins.Abstraction.Configs
         /// Remote repository
         /// </summary>
         public string Repository { get; set; }
+        
+        /// <summary>
+        /// Whether the repository is private
+        /// </summary>
+        public bool IsPrivateRepository { get; set; }
 
         /// <summary>
         /// Location where the source code needs to cloned to
         /// </summary>
         public string CloneLocation { get; set; }
+
+        /// <summary>
+        /// Initial branch that will be worked on
+        /// </summary>
+        public string BaseBranch { get; set; }
     }
 }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Configs/PushTaskConfig.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Configs/PushTaskConfig.cs
@@ -28,5 +28,20 @@ namespace Polyrific.Catapult.Plugins.Abstraction.Configs
         /// Branch which will be the target of the pull request
         /// </summary>
         public string PullRequestTargetBranch { get; set; }
+
+        /// <summary>
+        /// Message set when committing changes
+        /// </summary>
+        public string CommitMessage { get; set; }
+               
+        /// <summary>
+        /// Author of the commit
+        /// </summary>
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Email of the commiters
+        /// </summary>
+        public string Email { get; set; }
     }
 }

--- a/src/Plugins/RepositoryProvider/GitHub/src/GitAutomation.cs
+++ b/src/Plugins/RepositoryProvider/GitHub/src/GitAutomation.cs
@@ -52,6 +52,32 @@ namespace GitHub
             return $"Failed to clone source code from remote repository after {MaxAttempt} attempts.";
         }
 
+        public async Task<bool> CheckoutBranch(string branch)
+        {
+            var success = await _gitHubUtils.CheckoutBranch(_config.LocalRepository, branch);
+
+            if (success)
+            {
+                _logger.LogInformation("Checking out base branch to {branch}", branch);
+                return true;
+            }
+
+            return false;
+        }
+
+        public async Task<string> Commit(string baseBranch, string branch, string commitMessage, string author, string email)
+        {
+            var success = await _gitHubUtils.Commit(_config.LocalRepository, baseBranch, branch, commitMessage, author, email);
+
+            if (success)
+            {
+                _logger.LogInformation("All changes has been commited into branch {branch}", branch);
+                return "";
+            }
+
+            return "Failed committing changes";
+        }
+
         public async Task<string> Push(string branch)
         {
             var attempt = 1;

--- a/src/Plugins/RepositoryProvider/GitHub/src/IGitAutomation.cs
+++ b/src/Plugins/RepositoryProvider/GitHub/src/IGitAutomation.cs
@@ -13,6 +13,24 @@ namespace GitHub
         Task<string> Clone();
 
         /// <summary>
+        /// Checkout a branch
+        /// </summary>
+        /// <param name="branch">Branch to be checked out</param>
+        /// <returns></returns>
+        Task<bool> CheckoutBranch(string branch);
+
+        /// <summary>
+        /// Commit changes into a branch
+        /// </summary>
+        /// <param name="baseBranch">Base branch that will be used as Head for the new branch</param>
+        /// <param name="branch">branch of the commit</param>
+        /// <param name="commitMessage">Message of the commit</param>
+        /// <param name="author">Author of the commit</param>
+        /// <param name="email">Email of the comitter</param>
+        /// <returns></returns>
+        Task<string> Commit(string baseBranch, string branch, string commitMessage, string author, string email);
+
+        /// <summary>
         /// Push local changes into remote repository
         /// </summary>
         /// <param name="branch">Remote branch</param>

--- a/src/Plugins/RepositoryProvider/GitHub/src/IGitHubUtils.cs
+++ b/src/Plugins/RepositoryProvider/GitHub/src/IGitHubUtils.cs
@@ -16,6 +16,25 @@ namespace GitHub
         Task<string> Clone(string remoteUrl, string localRepository, bool isPrivateRepository);
 
         /// <summary>
+        /// Commit changes into a branch
+        /// </summary>
+        /// <param name="baseBranch">Base branch that will be used as Head for the new branch</param>
+        /// <param name="branch">Branch of the commit</param>
+        /// <param name="commitMessage">Message of the commit</param>
+        /// <param name="author">Author of the commit</param>
+        /// <param name="email">Email of the comitter</param>
+        /// <returns></returns>
+        Task<bool> Commit(string localRepository, string baseBranch, string branch, string commitMessage, string author, string email);
+
+        /// <summary>
+        /// Checkout a branch
+        /// </summary>
+        /// <param name="localRepository">Location of the local repository</param>
+        /// <param name="branch">Branch to be checked out</param>
+        /// <returns></returns>
+        Task<bool> CheckoutBranch(string localRepository, string branch);
+
+        /// <summary>
         /// Push source code changes to remote repository
         /// </summary>
         /// <param name="remoteUrl">URL of the remote repository</param>

--- a/src/Plugins/RepositoryProvider/GitHub/tests/CodeRepositoryProviderTests.cs
+++ b/src/Plugins/RepositoryProvider/GitHub/tests/CodeRepositoryProviderTests.cs
@@ -52,6 +52,8 @@ namespace GitHub.Tests
 
             _gitHubUtils.Setup(u => u.Push(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(true);
+            _gitHubUtils.Setup(u => u.Commit(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
             _gitHubUtils.Setup(u => u.CreatePullRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync("100");
 


### PR DESCRIPTION
## Summary
Fix several issue in engine clone and push
- [x] Fix project data not reloaded when a project is being run for a second time
- [x] Fix clone task error for private repository
- [x] Add commit step in Push task
- [x] Allow clone task to define the base branch, so that the changes in `Generate` task will be done on the target branch (this will avoid conflict that happened if we do the changes in master, and try to checkout the target branch later in push task)
- [x] Fix push task does not have ProjectName and RepoOwner info

