### PR TITLE
Save output values from engine execution

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/JobQueue.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/JobQueue.cs
@@ -1,31 +1,74 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Collections.Generic;
+
 namespace Polyrific.Catapult.Api.Core.Entities
 {
     public class JobQueue : BaseEntity
     {
+        /// <summary>
+        /// Id of the project
+        /// </summary>
         public int ProjectId { get; set; }
 
+        /// <summary>
+        /// Project object
+        /// </summary>
         public virtual Project Project { get; set; }
 
+        /// <summary>
+        /// Status of the job
+        /// </summary>
         public string Status { get; set; }
 
+        /// <summary>
+        /// Id of the catapult engine
+        /// </summary>
         public string CatapultEngineId { get; set; }
 
+        /// <summary>
+        /// Type of the job
+        /// </summary>
         public string JobType { get; set; }
 
+        /// <summary>
+        /// Machine name of the catapult engine
+        /// </summary>
         public string CatapultEngineMachineName { get; set; }
 
+        /// <summary>
+        /// Ip address of the catapult engine
+        /// </summary>
         public string CatapultEngineIPAddress { get; set; }
 
+        /// <summary>
+        /// Version of the catapult engine
+        /// </summary>
         public string CatapultEngineVersion { get; set; }
 
+        /// <summary>
+        /// Origin url where the job is created
+        /// </summary>
         public string OriginUrl { get; set; }
 
+        /// <summary>
+        /// Code of the job
+        /// </summary>
         public string Code { get; set; }
 
+        /// <summary>
+        /// Id of the job definition
+        /// </summary>
         public int? JobDefinitionId { get; set; }
 
+        /// <summary>
+        /// JSON string of the job task status
+        /// </summary>
         public string JobTasksStatus { get; set; }
+        
+        /// <summary>
+        /// JSON string of the output values
+        /// </summary>
+        public string OutputValues { get; set; }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -93,6 +93,7 @@ namespace Polyrific.Catapult.Api.Core.Services
                 job.Status = updatedJob.Status;
                 job.JobTasksStatus = updatedJob.JobTasksStatus;
                 job.JobType = updatedJob.JobType;
+                job.OutputValues = updatedJob.OutputValues;
                 await _jobQueueRepository.Update(job, cancellationToken);
             }
         }

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20181024021024_JobOutputValues.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20181024021024_JobOutputValues.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181024021024_JobOutputValues")]
+    partial class JobOutputValues
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20181024021024_JobOutputValues.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20181024021024_JobOutputValues.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class JobOutputValues : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OutputValues",
+                table: "JobQueues",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OutputValues",
+                table: "JobQueues");
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Collections.Generic;
 using AutoMapper;
+using Newtonsoft.Json;
 using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Shared.Dto.JobQueue;
 
@@ -10,11 +12,15 @@ namespace Polyrific.Catapult.Api.AutoMapperProfiles
     {
         public JobQueueAutoMapperProfile()
         {
-            CreateMap<JobQueue, JobDto>();
+            CreateMap<JobQueue, JobDto>()
+                .ForMember(dest => dest.JobTasksStatus, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<List<JobTaskStatusDto>>(src.JobTasksStatus)))
+                .ForMember(dest => dest.OutputValues, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<Dictionary<string, string>>(src.OutputValues)));
 
             CreateMap<NewJobDto, JobDto>();
 
-            CreateMap<UpdateJobDto, JobQueue>();
+            CreateMap<UpdateJobDto, JobQueue>()
+                .ForMember(dest => dest.JobTasksStatus, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.JobTasksStatus)))
+                .ForMember(dest => dest.OutputValues, opt => opt.MapFrom(src => JsonConvert.SerializeObject(src.OutputValues)));
         }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/RestartCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/RestartCommand.cs
@@ -52,8 +52,10 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
                         CatapultEngineId = queue.CatapultEngineId,
                         CatapultEngineIPAddress = queue.CatapultEngineIPAddress,
                         CatapultEngineMachineName = queue.CatapultEngineMachineName,
+                        CatapultEngineVersion = queue.CatapultEngineVersion,
                         JobTasksStatus = queue.JobTasksStatus,
-                        JobType = queue.JobType
+                        JobType = queue.JobType,
+                        OutputValues = queue.OutputValues
                     }).Wait();
 
                     message = $"Queue {Number} has been restarted successfully";

--- a/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
@@ -58,10 +58,10 @@ namespace Polyrific.Catapult.Engine.Core
                     var workingLocation = Path.Combine(_engineConfig.WorkingLocation, jobQueue.Code);
                     var result = await _taskRunner.Run(jobQueue.ProjectId, jobQueue, jobTasks, _engineConfig.PluginsLocation, workingLocation);
 
-                    if (result.Values.Any(t => !t.IsSuccess))
-                        jobQueue.Status = JobStatus.Error;
-                    else if (result.Values.Any(t => t.IsSuccess && t.StopTheProcess))
+                    if (result.Values.Any(t => t.IsSuccess && t.StopTheProcess))
                         jobQueue.Status = JobStatus.Pending;
+                    else if (result.Values.Any(t => !t.IsSuccess))
+                        jobQueue.Status = JobStatus.Error;
                     else
                         jobQueue.Status = JobStatus.Completed;
                 }
@@ -80,7 +80,8 @@ namespace Polyrific.Catapult.Engine.Core
                     CatapultEngineVersion = jobQueue.CatapultEngineVersion,
                     JobType = jobQueue.JobType,
                     Status = jobQueue.Status,
-                    JobTasksStatus = jobQueue.JobTasksStatus
+                    JobTasksStatus = jobQueue.JobTasksStatus,
+                    OutputValues = jobQueue.OutputValues
                 });
                 
                 await _jobLogWriter.EndJobLog(jobQueue.Id);

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/JobDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/JobDto.cs
@@ -1,31 +1,74 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Collections.Generic;
+
 namespace Polyrific.Catapult.Shared.Dto.JobQueue
 {
     public class JobDto
     {
+        /// <summary>
+        /// Id of the job
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// Id of the project
+        /// </summary>
         public int ProjectId { get; set; }
-        
+
+        /// <summary>
+        /// Status of the job
+        /// </summary>
         public string Status { get; set; }
 
+        /// <summary>
+        /// Id of the catapult engine
+        /// </summary>
         public string CatapultEngineId { get; set; }
 
+        /// <summary>
+        /// Type of the job
+        /// </summary>
         public string JobType { get; set; }
 
+        /// <summary>
+        /// Machine name of the catapult engine
+        /// </summary>
         public string CatapultEngineMachineName { get; set; }
 
+        /// <summary>
+        /// Ip address of the catapult engine
+        /// </summary>
         public string CatapultEngineIPAddress { get; set; }
 
+        /// <summary>
+        /// Version of the catapult engine
+        /// </summary>
         public string CatapultEngineVersion { get; set; }
 
+        /// <summary>
+        /// Origin url where the job is created
+        /// </summary>
         public string OriginUrl { get; set; }
 
+        /// <summary>
+        /// Code of the job
+        /// </summary>
         public string Code { get; set; }
 
+        /// <summary>
+        /// Id of the job definition
+        /// </summary>
         public int? JobDefinitionId { get; set; }
 
-        public string JobTasksStatus { get; set; }
+        /// <summary>
+        /// Status of the job tasks
+        /// </summary>
+        public List<JobTaskStatusDto> JobTasksStatus { get; set; }
+
+        /// <summary>
+        /// Output values of the job
+        /// </summary>
+        public Dictionary<string, string> OutputValues { get; set; }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/UpdateJobDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/UpdateJobDto.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace Polyrific.Catapult.Shared.Dto.JobQueue
@@ -43,8 +44,13 @@ namespace Polyrific.Catapult.Shared.Dto.JobQueue
         public string CatapultEngineVersion { get; set; }
 
         /// <summary>
-        /// Json string of the job task status
+        /// Status of the job tasks
         /// </summary>
-        public string JobTasksStatus { get; set; }
+        public List<JobTaskStatusDto> JobTasksStatus { get; set; }
+        
+        /// <summary>
+        /// Output values of the job
+        /// </summary>
+        public Dictionary<string, string> OutputValues { get; set; }
     }
 }

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/TaskRunnerTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/TaskRunnerTests.cs
@@ -219,7 +219,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
             Assert.False(results[4].IsProcessed);
             Assert.False(results[5].IsProcessed);
 
-            Assert.Contains(JobTaskStatusType.Pending, job.JobTasksStatus);
+            Assert.Contains(job.JobTasksStatus, j => j.Status == JobTaskStatusType.Pending);
         }
     }
 }


### PR DESCRIPTION
## Summary
- [x] Save output values generated by engine, so the restarted job can pick up the previous output values when re-run by engine
- [x] Refactor `JobDto.JobTasksStatus` to be strong typed object instead of serialized string
- [x] Fix Engine's TaskRunner flow when running restarted job
