### PR TITLE
Fix signalR logger hub

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Hubs/JobQueueHub.cs
+++ b/src/API/Polyrific.Catapult.Api/Hubs/JobQueueHub.cs
@@ -28,7 +28,7 @@ namespace Polyrific.Catapult.Api.Hubs
         {
             var group = GetGroupName(jobQueueId.ToString());
             List<string> groups = new List<string>() { group };
-            await _textWriter.Write($"{JobQueueLog.FolderNamePrefix}{jobQueueId}", taskName, message);
+            await _textWriter.Write($"{JobQueueLog.FolderNamePrefix}{jobQueueId}", taskName ?? "job", message);
             await Clients.Groups(groups).SendAsync("ReceiveMessage", taskName, message);
         }
 


### PR DESCRIPTION
## Summary
Fix occational error that occured in SignalR  `SendMessage` hub. The error occured when engine try to log a message outside of task scope (job scope only)
![image](https://user-images.githubusercontent.com/5100736/47421883-b7554b80-d7ab-11e8-9ba2-7b0bafab90d8.png)
