### PR TITLE
Rearrange cli output indentation

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Member/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Member/AddCommand.cs
@@ -57,7 +57,7 @@ namespace Polyrific.Catapult.Cli.Commands.Member
                     ProjectMemberRoleId = roleId
                 }).Result;
 
-                message = projectMember.ToCliString($"User has been added to project {Project}:", null, 1);
+                message = projectMember.ToCliString($"User has been added to project {Project}:");
                 Logger.LogInformation(message);
             }
             else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/AddCommand.cs
@@ -52,7 +52,7 @@ namespace Polyrific.Catapult.Cli.Commands.Model
                     Label = Label
                 }).Result;
 
-                message = model.ToCliString($"Model has been added:", null, 1);
+                message = model.ToCliString($"Model has been added:");
                 Logger.LogInformation(message);
             }
             else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CloneCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CloneCommand.cs
@@ -49,7 +49,7 @@ namespace Polyrific.Catapult.Cli.Commands.Project
                     NewProjectName = Name
                 }).Result;
 
-                message = clonedProject.ToCliString("Project cloned:", null, 1);
+                message = clonedProject.ToCliString("Project cloned:");
                 Logger.LogInformation(message);
             }
             else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
@@ -80,7 +80,7 @@ namespace Polyrific.Catapult.Cli.Commands.Project
 
             var project = _projectService.CreateProject(projectDto).Result;
 
-            message = project.ToCliString("Project created:", null, 1);
+            message = project.ToCliString("Project created:");
             Logger.LogInformation(message);
             
             return message;

--- a/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
@@ -12,15 +12,15 @@ namespace Polyrific.Catapult.Cli.Extensions
 {
     public static class CatapultCliExtensions
     {
-        public static string ToCliString<T>(this T obj, string openingLine = "", string[] obfuscatedFields = null, int indentation = 0)
+        public static string ToCliString<T>(this T obj, string openingLine = "", string[] obfuscatedFields = null, int indentation = 1)
         {
+            string indentationString = String.Concat(Enumerable.Repeat("  ", indentation));
+
             if (obj is string stringValue)
-                return stringValue;
+                return $"{indentationString}{stringValue}";
 
             PropertyInfo[] propertyInfos = null;
             propertyInfos = obj.GetType().GetProperties();
-
-            string indentationString = String.Concat(Enumerable.Repeat("  ", indentation));
 
             var sb = new StringBuilder(openingLine);
             sb.AppendLine();
@@ -64,7 +64,7 @@ namespace Polyrific.Catapult.Cli.Extensions
                 empty = false;
                 sb.Append(listitem.ToCliString("", obfuscatedFields, indentation + 1));
             }
-
+            
             if (empty)
             {
                 string indentationString = String.Concat(Enumerable.Repeat("  ", indentation));


### PR DESCRIPTION
## Summary
Change the default value of indentation for `.ToCliString()` extension method to 1. This will make all of the displayed object have indentation as default. This will affect the displayed entities both in `add` and `get` commands.

## Related issue
- #141 