### PR TITLE
Update job queue API and CLI

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
@@ -62,6 +62,14 @@ namespace Polyrific.Catapult.Api.Core.Services
         Task<JobQueue> GetJobQueueById(int jobQueueId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Get a job queue by code
+        /// </summary>
+        /// <param name="jobQueueCode">Code of the job queue</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
+        /// <returns>job queue entity</returns>
+        Task<JobQueue> GetJobQueueByCode(string jobQueueCode, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Get the execution status of a job
         /// </summary>
         /// <param name="id">The id of the job queue</param>

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -149,7 +149,7 @@ namespace Polyrific.Catapult.Api.Core.Services
 
         public async Task<List<JobQueue>> GetJobQueuesByStatus(string status, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var queueSpec = new JobQueueFilterSpecification(status);
+            var queueSpec = new JobQueueFilterSpecification(null, status);
             var jobQueues = await _jobQueueRepository.GetBySpec(queueSpec, cancellationToken);
             return jobQueues.ToList();
         }
@@ -159,6 +159,16 @@ namespace Polyrific.Catapult.Api.Core.Services
             cancellationToken.ThrowIfCancellationRequested();
 
             return await _jobQueueRepository.GetById(id, cancellationToken);
+        }
+
+        public async Task<JobQueue> GetJobQueueByCode(string jobQueueCode, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var queueSpec = new JobQueueFilterSpecification(jobQueueCode, null);
+            var queue = await _jobQueueRepository.GetSingleBySpec(queueSpec, cancellationToken);
+
+            return queue;
         }
 
         public async Task<List<JobTaskStatus>> GetJobTaskStatus(int id, string filter, CancellationToken cancellationToken = default(CancellationToken))
@@ -203,7 +213,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             {
                 if (job == null)
                 {
-                    var pendingJobSpec = new JobQueueFilterSpecification(JobStatus.Queued, engine);
+                    var pendingJobSpec = new JobQueueFilterSpecification(null, JobStatus.Queued, engine);
                     job = await _jobQueueRepository.GetSingleBySpec(pendingJobSpec, cancellationToken);
                 }
 

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
@@ -9,6 +9,7 @@ namespace Polyrific.Catapult.Api.Core.Specifications
     public class JobQueueFilterSpecification : BaseSpecification<JobQueue>
     {
         public int ProjectId { get; set; }
+        public string QueueCode { get; set; }
         public string Status { get; set; }
         public string[] StatusArray { get; set; }
         public bool UnassignedOnly { get; set; }
@@ -35,17 +36,6 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         }
 
         /// <summary>
-        /// Filter by the status
-        /// </summary>
-        /// <param name="status"></param>
-        public JobQueueFilterSpecification(string status, string engineId = null)
-            : base(m => m.Status == status && (engineId == null || m.CatapultEngineId == engineId), m => m.Created)
-        {
-            Status = status;
-            EngineId = engineId;
-        }
-
-        /// <summary>
         /// Filter by the project and certain status
         /// </summary>
         /// <param name="projectId"></param>
@@ -67,6 +57,20 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         {
             ProjectId = projectId;
             StatusArray = statusArray;
+        }
+
+        /// <summary>
+        /// Filter by the queue code or status
+        /// </summary>
+        /// <param name="queueCode">Code of the job queue</param>
+        /// <param name="status">Status of the job queue</param>
+        /// <param name="engineId">Id of the Catapult Engine which executes the queue</param>
+        public JobQueueFilterSpecification(string queueCode, string status, string engineId = null)
+            : base(m => (queueCode == null || m.Code == queueCode) && (status == null || m.Status == status) && (engineId == null || m.CatapultEngineId == engineId), m => m.Created)
+        {
+            QueueCode = queueCode;
+            Status = status;
+            EngineId = engineId;
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
@@ -73,6 +73,23 @@ namespace Polyrific.Catapult.Api.Controllers
         }
 
         /// <summary>
+        /// Get a job queue by code
+        /// </summary>
+        /// <param name="projectId">Id of the project</param>
+        /// <param name="queueCode">Code of the job queue</param>
+        /// <returns>The job queue object</returns>
+        [HttpGet("Project/{projectId}/queue/code/{queueCode}", Name = "GetJobQueueByCode")]
+        [Authorize(Policy = AuthorizePolicy.ProjectMaintainerAccess)]
+        public async Task<IActionResult> GetJobQueueByCode(int projectId, string queueCode)
+        {
+            _logger.LogInformation("Getting job queue {queueCode} in project {projectId}", queueCode, projectId);
+
+            var job = await _jobQueueService.GetJobQueueByCode(queueCode);
+            var result = _mapper.Map<JobDto>(job);
+            return Ok(result);
+        }
+
+        /// <summary>
         /// Create a job queue
         /// </summary>
         /// <param name="projectId">Id of the project</param>

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/LogCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/LogCommand.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Shared.Dto.Constants;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Cli.Commands.Queue
+{
+    [Command(Description = "Get complete logs of a queued job")]
+    public class LogCommand : BaseCommand
+    {
+        private readonly IProjectService _projectService;
+        private readonly IJobQueueService _jobQueueService;
+        private readonly IJobQueueLogListener _jobQueueLogListener;
+
+        public LogCommand(IConsole console, ILogger<LogCommand> logger, IProjectService projectService, IJobQueueService jobQueueService, IJobQueueLogListener jobQueueLogListener) : base(console, logger)
+        {
+            _projectService = projectService;
+            _jobQueueService = jobQueueService;
+            _jobQueueLogListener = jobQueueLogListener;
+        }
+
+        [Required]
+        [Option("-p|--project <PROJECT>", "Name of the project", CommandOptionType.SingleValue)]
+        public string Project { get; set; }
+
+        [Required]
+        [Option("-n|--number <NUMBER>", "Queue number", CommandOptionType.SingleValue)]
+        public string Number { get; set; }
+
+        public override string Execute()
+        {
+            Console.WriteLine($"Trying to get queue \"{Number}\" in project {Project}...");
+
+            string message;
+
+            var code = "";
+            if (!int.TryParse(Number, out var id))
+                code = Number;
+
+            var project = _projectService.GetProjectByName(Project).Result;
+            if (project != null)
+            {
+                var queue = !string.IsNullOrEmpty(code) ? _jobQueueService.GetJobQueue(project.Id, code).Result : _jobQueueService.GetJobQueue(project.Id, id).Result;
+                if (queue != null)
+                {
+                    switch (queue.Status)
+                    {
+                        case JobStatus.Processing:
+                            _jobQueueLogListener.Listen(queue.Id, OnLogReceived, OnLogError).Wait();
+                            message = "";
+                            return message;
+                        case JobStatus.Completed:
+                        case JobStatus.Error:
+                        case JobStatus.Pending:
+                        case JobStatus.Cancelled:
+                            message = _jobQueueService.GetJobLogs(project.Id, queue.Id).Result;
+                            return message;
+                        case JobStatus.Queued:
+                            message = $"Queue {Number} is queued";
+                            return message;
+                        default:
+                            message = $"Queue {Number} has unknown status";
+                            return message;
+                    }
+                }
+            }
+
+            message = $"Failed getting queue {Number}. Make sure the project name and queue number are correct.";
+
+            return message;
+        }
+        
+        private void OnLogReceived(string logMessage)
+        {
+            Console.WriteLine(logMessage);
+        }
+
+        private void OnLogError(string errorMessage)
+        {
+            Console.WriteLine(errorMessage);
+        }
+    }
+}

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
@@ -9,6 +9,7 @@ namespace Polyrific.Catapult.Cli.Commands
     [Command(Description = "Job queue related command")]
     [Subcommand("add", typeof(AddCommand))]
     [Subcommand("get", typeof(GetCommand))]
+    [Subcommand("log", typeof(LogCommand))]
     [Subcommand("list", typeof(ListCommand))]
     [Subcommand("restart", typeof(RestartCommand))]
     public class QueueCommand : BaseCommand

--- a/src/Shared/Polyrific.Catapult.Shared.ApiClient/JobQueueService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.ApiClient/JobQueueService.cs
@@ -48,6 +48,13 @@ namespace Polyrific.Catapult.Shared.ApiClient
             return await Api.Get<JobDto>(path);
         }
 
+        public async Task<JobDto> GetJobQueue(int projectId, string queueCode)
+        {
+            var path = $"project/{projectId}/queue/code/{queueCode}";
+
+            return await Api.Get<JobDto>(path);
+        }
+
         public async Task<List<JobDto>> GetJobQueues(int projectId, string filter)
         {
             var path = $"project/{projectId}/queue?filter={filter}";

--- a/src/Shared/Polyrific.Catapult.Shared.Service/IJobQueueService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Service/IJobQueueService.cs
@@ -25,6 +25,14 @@ namespace Polyrific.Catapult.Shared.Service
         Task<JobDto> GetJobQueue(int projectId, int queueId);
 
         /// <summary>
+        /// Get a job in queue
+        /// </summary>
+        /// <param name="projectId">Id of the project</param>
+        /// <param name="queueCode">Code of the job queue</param>
+        /// <returns></returns>
+        Task<JobDto> GetJobQueue(int projectId, string queueCode);
+
+        /// <summary>
         /// Add a job to queue
         /// </summary>
         /// <param name="projectId">Id of the project</param>

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -32,6 +32,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 new JobQueue
                 {
                     Id = 1,
+                    Code = "20180817.1",
                     ProjectId = 1,
                     JobType = JobType.Create,
                     Status = JobStatus.Completed
@@ -220,6 +221,25 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             var jobQueue = await jobQueueService.GetJobQueueById(2);
 
             Assert.Null(jobQueue);
+        }
+
+        [Fact]
+        public async void GetJobQueueByCode_ReturnItem()
+        {
+            var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
+            var entity = await jobQueueService.GetJobQueueByCode("20180817.1");
+
+            Assert.NotNull(entity);
+            Assert.Equal(1, entity.Id);
+        }
+
+        [Fact]
+        public async void GetJobQueueByCode_ReturnNull()
+        {
+            var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
+            var entity = await jobQueueService.GetJobQueueByCode("20180817.2");
+
+            Assert.Null(entity);
         }
 
         [Fact]

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/QueueCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/QueueCommandTests.cs
@@ -119,12 +119,40 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         }
 
         [Fact]
-        public void QueueGet_Execute_JobQueuedReturnsSuccessMessage()
+        public void QueueGet_Execute_ReturnsSuccessMessage()
         {
-            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
+            var command = new GetCommand(_projectService.Object, _jobQueueService.Object, _console, LoggerMock.GetLogger<GetCommand>().Object)
             {
                 Project = "Project 1",
-                Number = 1
+                Number = "1"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.StartsWith("Job Queue 1", resultMessage);
+        }
+
+        [Fact]
+        public void QueueGet_Execute_ReturnsNotFoundMessage()
+        {
+            var command = new GetCommand(_projectService.Object, _jobQueueService.Object, _console, LoggerMock.GetLogger<GetCommand>().Object)
+            {
+                Project = "Project 1",
+                Number = "2"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.Equal("Failed getting queue 2. Make sure the project name and queue number are correct.", resultMessage);
+        }
+
+        [Fact]
+        public void QueueLog_Execute_JobQueuedReturnsSuccessMessage()
+        {
+            var command = new LogCommand(_console, LoggerMock.GetLogger<LogCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
+            {
+                Project = "Project 1",
+                Number = "1"
             };
 
             var resultMessage = command.Execute();
@@ -133,7 +161,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         }
 
         [Fact]
-        public void QueueGet_Execute_JobCompletedReturnsSuccessMessage()
+        public void QueueLog_Execute_JobCompletedReturnsSuccessMessage()
         {
             _jobQueueService.Setup(s => s.GetJobQueue(It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync(new JobDto
             {
@@ -143,10 +171,10 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
             });
             _jobQueueService.Setup(s => s.GetJobLogs(It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync("test logs");
 
-            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
+            var command = new LogCommand(_console, LoggerMock.GetLogger<LogCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
             {
                 Project = "Project 1",
-                Number = 1
+                Number = "1"
             };
 
             var resultMessage = command.Execute();
@@ -155,7 +183,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         }
 
         [Fact]
-        public void QueueGet_Execute_JobProcessingReturnsSuccessMessage()
+        public void QueueLog_Execute_JobProcessingReturnsSuccessMessage()
         {
             _jobQueueService.Setup(s => s.GetJobQueue(It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync(new JobDto
             {
@@ -165,24 +193,24 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
             });
             _jobQueueLogListener.Setup(s => s.Listen(1, It.IsAny<Action<string>>(), It.IsAny<Action<string>>())).Returns(Task.CompletedTask);
 
-            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
+            var command = new LogCommand(_console, LoggerMock.GetLogger<LogCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
             {
                 Project = "Project 1",
-                Number = 1
+                Number = "1"
             };
 
-            var resultMessage = command.Execute();
+            command.Execute();
 
             _jobQueueLogListener.Verify(s => s.Listen(1, It.IsAny<Action<string>>(), It.IsAny<Action<string>>()), Times.Once);
         }
 
         [Fact]
-        public void QueueGet_Execute_ReturnsNotFoundMessage()
+        public void QueueLog_Execute_ReturnsNotFoundMessage()
         {
-            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
+            var command = new LogCommand(_console, LoggerMock.GetLogger<LogCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
             {
                 Project = "Project 1",
-                Number = 2
+                Number = "2"
             };
 
             var resultMessage = command.Execute();


### PR DESCRIPTION
## Summary
- Add API endpoint `Project/{projectId}/queue/code/{queueCode}`
- Add `queue log` command in CLI
- Update `queue get` command

Note: instead of adding new option "`--code`", I keep the existing "`--number`" option which will allow user to enter either `Id` or `Code`.

## Related issue
- https://github.com/Polyrific-Inc/OpenCatapult/issues/149
