### PR TITLE
Exclude foreign key/child property in CLI

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/JobQueue.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/JobQueue.cs
@@ -61,6 +61,8 @@ namespace Polyrific.Catapult.Api.Core.Entities
         /// </summary>
         public int? JobDefinitionId { get; set; }
 
+        public virtual JobDefinition JobDefinition { get; set; }
+
         /// <summary>
         /// JSON string of the job task status
         /// </summary>

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
@@ -110,6 +110,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             cancellationToken.ThrowIfCancellationRequested();
 
             var propertyByDataModelSpec = new ProjectDataModelPropertyFilterSpecification(dataModelId);
+            propertyByDataModelSpec.Includes.Add(p => p.RelatedProjectDataModel);
             var properties = await _dataModelPropertyRepository.GetBySpec(propertyByDataModelSpec, cancellationToken);
 
             return properties.ToList();

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
@@ -9,6 +9,7 @@ namespace Polyrific.Catapult.Api.Core.Specifications
     public class JobQueueFilterSpecification : BaseSpecification<JobQueue>
     {
         public int ProjectId { get; set; }
+        public int JobQueueId { get; set; }
         public string QueueCode { get; set; }
         public string Status { get; set; }
         public string[] StatusArray { get; set; }
@@ -26,25 +27,13 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         }
 
         /// <summary>
-        /// Filter by the project
+        /// Filter by the job queue id
         /// </summary>
-        /// <param name="projectId"></param>
-        public JobQueueFilterSpecification(int projectId)
-            : base(m => m.ProjectId == projectId)
+        /// <param name="jobQueueId"></param>
+        public JobQueueFilterSpecification(int jobQueueId)
+            : base(m => m.Id == jobQueueId)
         {
-            ProjectId = projectId;
-        }
-
-        /// <summary>
-        /// Filter by the project and certain status
-        /// </summary>
-        /// <param name="projectId"></param>
-        /// <param name="status"></param>
-        public JobQueueFilterSpecification(int projectId, string status)
-            : base(m => m.ProjectId == projectId && m.Status == status)
-        {
-            ProjectId = projectId;
-            Status = status;
+            JobQueueId = jobQueueId;
         }
 
         /// <summary>
@@ -53,7 +42,7 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         /// <param name="projectId"></param>
         /// <param name="statusArray"></param>
         public JobQueueFilterSpecification(int projectId, string[] statusArray)
-            : base(m => m.ProjectId == projectId && statusArray.Contains(m.Status))
+            : base(m => m.ProjectId == projectId && (statusArray == null || statusArray.Contains(m.Status)))
         {
             ProjectId = projectId;
             StatusArray = statusArray;

--- a/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
@@ -14,7 +14,8 @@ namespace Polyrific.Catapult.Api.AutoMapperProfiles
         {
             CreateMap<JobQueue, JobDto>()
                 .ForMember(dest => dest.JobTasksStatus, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<List<JobTaskStatusDto>>(src.JobTasksStatus)))
-                .ForMember(dest => dest.OutputValues, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<Dictionary<string, string>>(src.OutputValues)));
+                .ForMember(dest => dest.OutputValues, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<Dictionary<string, string>>(src.OutputValues)))
+                .ForMember(dest => dest.JobDefinitionName, opt => opt.MapFrom(src => src.JobDefinition.Name));
 
             CreateMap<NewJobDto, JobDto>();
 

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/AddCommand.cs
@@ -45,7 +45,9 @@ namespace Polyrific.Catapult.Cli.Commands.Job
                     Name = Name
                 }).Result;
 
-                message = job.ToCliString($"Job definition has been added:");
+                message = job.ToCliString($"Job definition has been added:", excludedFields: new string[] {
+                    "ProjectId"
+                });
                 Logger.LogInformation(message);
             }
             else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/ListCommand.cs
@@ -36,7 +36,9 @@ namespace Polyrific.Catapult.Cli.Commands.Job
             if (project != null)
             {
                 var jobs = _jobDefinitionService.GetJobDefinitions(project.Id).Result;
-                message = jobs.ToListCliString($"Found {jobs.Count} job definition(s):");
+                message = jobs.ToListCliString($"Found {jobs.Count} job definition(s):", excludedFields: new string[] {
+                    "ProjectId"
+                });
             }
             else
             {

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Member/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Member/AddCommand.cs
@@ -57,7 +57,14 @@ namespace Polyrific.Catapult.Cli.Commands.Member
                     ProjectMemberRoleId = roleId
                 }).Result;
 
-                message = projectMember.ToCliString($"User has been added to project {Project}:");
+                var addedMember = new MemberViewModel
+                {
+                    UserId = projectMember.UserId,
+                    Username = projectMember.Username,
+                    Role = projectMember.ProjectMemberRoleName
+                };
+
+                message = addedMember.ToCliString($"User has been added to project {Project}:");
                 Logger.LogInformation(message);
             }
             else
@@ -66,6 +73,13 @@ namespace Polyrific.Catapult.Cli.Commands.Member
             }
 
             return message;
+        }
+
+        public class MemberViewModel
+        {
+            public int UserId { get; set; }
+            public string Username { get; set; }
+            public string Role { get; set; }
         }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/AddCommand.cs
@@ -52,7 +52,10 @@ namespace Polyrific.Catapult.Cli.Commands.Model
                     Label = Label
                 }).Result;
 
-                message = model.ToCliString($"Model has been added:");
+                message = model.ToCliString($"Model has been added:", excludedFields: new string[]
+                    {
+                        "ProjectId"
+                    });
                 Logger.LogInformation(message);
             }
             else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/ListCommand.cs
@@ -36,7 +36,11 @@ namespace Polyrific.Catapult.Cli.Commands.Model
             {
                 var models = _projectDataModelService.GetProjectDataModels(project.Id).Result;
                 
-                message = models.ToListCliString($"Found {models.Count} data model(s):");
+                message = models.ToListCliString($"Found {models.Count} data model(s):", excludedFields: new string[]
+                    {
+                        "ProjectId",
+                        "Properties"
+                    });
             }
             else
             {

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Plugin/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Plugin/ListCommand.cs
@@ -41,7 +41,10 @@ namespace Polyrific.Catapult.Cli.Commands.Plugin
             if (!plugins.Any())
                 return PluginType == "all" ? "No registered plugins found." : $"No registered plugins with type {PluginType} found.";
             
-            return plugins.ToListCliString($"Found {plugins.Count} plugin(s):");
+            return plugins.ToListCliString($"Found {plugins.Count} plugin(s):", excludedFields: new string[]
+                {
+                    "AdditionalConfigs"
+                });
         }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ListCommand.cs
@@ -31,7 +31,10 @@ namespace Polyrific.Catapult.Cli.Commands.Project
 
             var projects = _projectService.GetProjects(Status, GetAll).Result;
 
-            return projects.ToListCliString($"Found {projects.Count} project(s):");
+            return projects.ToListCliString($"Found {projects.Count} project(s):", excludedFields: new string[]
+                {
+                    "Config"
+                });
         }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Property/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Property/AddCommand.cs
@@ -101,7 +101,11 @@ namespace Polyrific.Catapult.Cli.Commands.Property
                             RelationalType = relationalType
                         }).Result;
 
-                    message = newProperty.ToCliString($"Property {Name} was added to model {Model}:");
+                    message = newProperty.ToCliString($"Property {Name} was added to model {Model}:", excludedFields: new string[]
+                        {
+                            "ProjectDataModelId",
+                            "RelatedProjectDataModelId"
+                        });
                     Logger.LogInformation(message);
                     return message;
                 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Property/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Property/ListCommand.cs
@@ -45,7 +45,11 @@ namespace Polyrific.Catapult.Cli.Commands.Property
                     var properties = _projectDataModelService.GetProjectDataModelProperties(project.Id, model.Id).Result;
 
                     message = properties.ToListCliString(properties.Count == 1 ? 
-                        "Found 1 property:" : $"Found {properties.Count} properties:");
+                        "Found 1 property:" : $"Found {properties.Count} properties:", excludedFields: new string[]
+                        {
+                            "ProjectDataModelId",
+                            "RelatedProjectDataModelId"
+                        });
                     return message;
                 }
             }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddCommand.cs
@@ -55,7 +55,11 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
                         OriginUrl = Dns.GetHostEntry(Dns.GetHostName()).AddressList.Last(a => a.AddressFamily == AddressFamily.InterNetwork).ToString()
                     }).Result;
 
-                    message = queue.ToCliString($"Job {Job} has been queued successfully:");
+                    message = queue.ToCliString($"Job {Job} has been queued successfully:", excludedFields: new string[]
+                    {
+                        "ProjectId",
+                        "JobDefinitionId"
+                    });
                     Logger.LogInformation(message);
                     return message;
                 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/GetCommand.cs
@@ -47,7 +47,11 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
                 queue = !string.IsNullOrEmpty(code) ? _jobQueueService.GetJobQueue(project.Id, code).Result : _jobQueueService.GetJobQueue(project.Id, id).Result;
                 if (queue != null)
                 {
-                    message = queue.ToCliString($"Job Queue {Number}");
+                    message = queue.ToCliString($"Job Queue {Number}", excludedFields: new string[]
+                    {
+                        "ProjectId",
+                        "JobDefinitionId"
+                    });
                 }
             }
 

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/ListCommand.cs
@@ -41,7 +41,13 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
             {
                 var queueList = _jobQueueService.GetJobQueues(project.Id, Status).Result;
 
-                message = queueList.ToListCliString($"Found {queueList.Count} queue(s):");
+                message = queueList.ToListCliString($"Found {queueList.Count} queue(s):", excludedFields: new string[]
+                    {
+                        "ProjectId",
+                        "JobDefinitionId",
+                        "JobTasksStatus",
+                        "OutputValues"
+                    });
                 return message;
             }
             else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
@@ -91,7 +91,11 @@ namespace Polyrific.Catapult.Cli.Commands.Service
                         Config = config
                     }).Result;
 
-                    message = service.ToCliString($"External service has been added:", secretProperties.ToArray());
+                    message = service.ToCliString($"External service has been added:", secretProperties.ToArray(), excludedFields: new string[]
+                    {
+                        "ExternalServiceTypeId"
+                    });
+
                     Logger.LogInformation(message);
                 }
                 else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/GetCommand.cs
@@ -36,7 +36,10 @@ namespace Polyrific.Catapult.Cli.Commands.Service
             if (service != null)
             {
                 var serviceType = _externalServiceTypeService.GetExternalServiceType(service.ExternalServiceTypeId).Result;
-                message = service.ToCliString($"External Service {Name}:", serviceType?.ExternalServiceProperties?.Where(x => x.IsSecret).Select(x => x.Name).ToArray());
+                message = service.ToCliString($"External Service {Name}:", serviceType?.ExternalServiceProperties?.Where(x => x.IsSecret).Select(x => x.Name).ToArray(), excludedFields: new string[]
+                {
+                    "ExternalServiceTypeId"
+                });
             }
             else
             {

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/ListCommand.cs
@@ -25,7 +25,11 @@ namespace Polyrific.Catapult.Cli.Commands.Service
 
             var services = _externalServiceService.GetExternalServices().Result;
 
-            message = services.ToListCliString($"Found {services.Count} external service(s):");
+            message = services.ToListCliString($"Found {services.Count} external service(s):", excludedFields: new string[]
+                {
+                    "Config",
+                    "ExternalServiceTypeId"
+                });
 
             return message;
         }

--- a/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
@@ -12,7 +12,7 @@ namespace Polyrific.Catapult.Cli.Extensions
 {
     public static class CatapultCliExtensions
     {
-        public static string ToCliString<T>(this T obj, string openingLine = "", string[] obfuscatedFields = null, int indentation = 1)
+        public static string ToCliString<T>(this T obj, string openingLine = "", string[] obfuscatedFields = null, int indentation = 1, string[] excludedFields = null)
         {
             string indentationString = String.Concat(Enumerable.Repeat("  ", indentation));
 
@@ -26,6 +26,9 @@ namespace Polyrific.Catapult.Cli.Extensions
             sb.AppendLine();
             foreach (var item in propertyInfos)
             {
+                if (excludedFields?.Contains(item.Name) ?? false)
+                    continue;
+
                 var prop = item.GetValue(obj);
 
                 if (prop == null)
@@ -42,7 +45,7 @@ namespace Polyrific.Catapult.Cli.Extensions
                 }
                 else if (prop is IEnumerable enumProp && !(prop is string))
                 {
-                    sb.AppendLine(enumProp.ToListCliString($"{indentationString}{item.Name}:", obfuscatedFields, indentation));
+                    sb.AppendLine(enumProp.ToListCliString($"{indentationString}{item.Name}:", obfuscatedFields, indentation, excludedFields));
                 }
                 else
                 {
@@ -53,7 +56,7 @@ namespace Polyrific.Catapult.Cli.Extensions
             return sb.ToString();
         }
 
-        public static string ToListCliString(this IEnumerable list, string openingLine = "", string[] obfuscatedFields = null, int indentation = 0)
+        public static string ToListCliString(this IEnumerable list, string openingLine = "", string[] obfuscatedFields = null, int indentation = 0, string[] excludedFields = null)
         {
             var sb = new StringBuilder(openingLine);
             sb.AppendLine();
@@ -62,7 +65,7 @@ namespace Polyrific.Catapult.Cli.Extensions
             foreach (var listitem in list)
             {
                 empty = false;
-                sb.Append(listitem.ToCliString("", obfuscatedFields, indentation + 1));
+                sb.Append(listitem.ToCliString("", obfuscatedFields, indentation + 1, excludedFields));
             }
             
             if (empty)

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/JobDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/JobDto.cs
@@ -62,6 +62,11 @@ namespace Polyrific.Catapult.Shared.Dto.JobQueue
         public int? JobDefinitionId { get; set; }
 
         /// <summary>
+        /// Name of the job definition
+        /// </summary>
+        public string JobDefinitionName { get; set; }
+
+        /// <summary>
         /// Status of the job tasks
         /// </summary>
         public List<JobTaskStatusDto> JobTasksStatus { get; set; }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -207,6 +207,11 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobQueueById_ReturnItem()
         {
+            _jobQueueRepository.Setup(r =>
+                    r.GetSingleBySpec(It.IsAny<JobQueueFilterSpecification>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((JobQueueFilterSpecification spec, CancellationToken cancellationToken) =>
+                    _data.FirstOrDefault(spec.Criteria.Compile()));
+
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
             var entity = await jobQueueService.GetJobQueueById(1);
 
@@ -217,6 +222,11 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void GetJobQueueById_ReturnNull()
         {
+            _jobQueueRepository.Setup(r =>
+                    r.GetSingleBySpec(It.IsAny<JobQueueFilterSpecification>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((JobQueueFilterSpecification spec, CancellationToken cancellationToken) =>
+                    _data.FirstOrDefault(spec.Criteria.Compile()));
+
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
             var jobQueue = await jobQueueService.GetJobQueueById(2);
 


### PR DESCRIPTION
## Summary
- Show name property instead of FK Id for FK property in all commands
- Hide detail properties in list
- Fix add member error

## Related issue
- #142 