### PR TITLE
Add get commands for several entities

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -86,16 +86,17 @@ namespace Polyrific.Catapult.Api.Core.Services
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var projectMemberByProjectSpec = new JobDefinitionFilterSpecification(jobDefinitionName, projectId);
-            return await _jobDefinitionRepository.GetSingleBySpec(projectMemberByProjectSpec, cancellationToken);
+            var jobDefinitionSpec = new JobDefinitionFilterSpecification(jobDefinitionName, projectId);
+            jobDefinitionSpec.Includes.Add(j => j.Tasks);
+            return await _jobDefinitionRepository.GetSingleBySpec(jobDefinitionSpec, cancellationToken);
         }
 
         public async Task<List<JobDefinition>> GetJobDefinitions(int projectId, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var projectMemberByProjectSpec = new JobDefinitionFilterSpecification(projectId);
-            var projectMembers = await _jobDefinitionRepository.GetBySpec(projectMemberByProjectSpec, cancellationToken);
+            var jobDefinitionSpec = new JobDefinitionFilterSpecification(projectId);
+            var projectMembers = await _jobDefinitionRepository.GetBySpec(jobDefinitionSpec, cancellationToken);
 
             return projectMembers.ToList();
         }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
@@ -126,7 +126,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _dataModelRepository.GetSingleBySpec(new ProjectDataModelFilterSpecification(modelName, projectId), cancellationToken);
+            var dataModelByNameSpec = new ProjectDataModelFilterSpecification(modelName, projectId);
+            dataModelByNameSpec.Includes.Add(d => d.Properties);
+
+            return await _dataModelRepository.GetSingleBySpec(dataModelByNameSpec, cancellationToken);
         }
 
         public async Task<ProjectDataModelProperty> GetProjectDataModelPropertyById(int dataModelPropertyId, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/GetCommand.cs
@@ -58,7 +58,11 @@ namespace Polyrific.Catapult.Cli.Commands.Job
                         }
                     }
 
-                    message = job.ToCliString($"Job definition {Name}", secretConfig.ToArray());
+                    message = job.ToCliString($"Job definition {Name}", secretConfig.ToArray(), excludedFields: new string[]
+                        {
+                            "ProjectId",
+                            "JobDefinitionId"
+                        });
                     return message;
                 }
             }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/GetCommand.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Cli.Extensions;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Cli.Commands.Job
+{
+    [Command(Description = "Get a single job definition record")]
+    public class GetCommand : BaseCommand
+    {
+        private readonly IProjectService _projectService;
+        private readonly IJobDefinitionService _jobDefinitionService;
+        private readonly IPluginService _pluginService;
+
+        public GetCommand(IConsole console, ILogger<GetCommand> logger,
+            IProjectService projectService, IJobDefinitionService jobDefinitionService, IPluginService pluginService) : base(console, logger)
+        {
+            _projectService = projectService;
+            _jobDefinitionService = jobDefinitionService;
+            _pluginService = pluginService;
+        }
+
+        [Required]
+        [Option("-p|--project <PROJECT>", "Name of the project", CommandOptionType.SingleValue)]
+        public string Project { get; set; }
+
+        [Required]
+        [Option("-n|--name <NAME>", "Name of the job definition", CommandOptionType.SingleValue)]
+        public string Name { get; set; }
+
+        public override string Execute()
+        {
+            Console.WriteLine($"Trying to get job definition {Name} in project {Project}...");
+
+            string message;
+
+            var project = _projectService.GetProjectByName(Project).Result;
+
+            if (project != null)
+            {
+                var job = _jobDefinitionService.GetJobDefinitionByName(project.Id, Name).Result;
+
+                if (job != null)
+                {
+                    var secretConfig = new List<string>();
+
+                    if (job.Tasks?.Count > 0)
+                    {
+                        foreach (var task in job.Tasks)
+                        {
+                            var configs = _pluginService.GetPluginAdditionalConfigByPluginName(task.Provider).Result;
+                            secretConfig.AddRange(configs.Where(c => c.IsSecret).Select(c => c.Name));
+                        }
+                    }
+
+                    message = job.ToCliString($"Job definition {Name}", secretConfig.ToArray());
+                    return message;
+                }
+            }
+
+            message = $"Failed to get job definition {Name}. Make sure the project and job definition names are correct.";
+
+            return message;
+        }
+    }
+}

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/ListCommand.cs
@@ -37,7 +37,8 @@ namespace Polyrific.Catapult.Cli.Commands.Job
             {
                 var jobs = _jobDefinitionService.GetJobDefinitions(project.Id).Result;
                 message = jobs.ToListCliString($"Found {jobs.Count} job definition(s):", excludedFields: new string[] {
-                    "ProjectId"
+                    "ProjectId",
+                    "Tasks"
                 });
             }
             else

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
@@ -8,6 +8,7 @@ namespace Polyrific.Catapult.Cli.Commands
 {
     [Command(Description = "Job definition related command")]
     [Subcommand("add", typeof(AddCommand))]
+    [Subcommand("get", typeof(GetCommand))]
     [Subcommand("list", typeof(ListCommand))]
     [Subcommand("remove", typeof(RemoveCommand))]
     public class JobCommand : BaseCommand

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/GetCommand.cs
@@ -42,7 +42,12 @@ namespace Polyrific.Catapult.Cli.Commands.Model
 
                 if (model != null)
                 {
-                    message = model.ToCliString($"Data model {Name}");
+                    message = model.ToCliString($"Data model {Name}", excludedFields: new string[]
+                        {
+                            "ProjectId",
+                            "ProjectDataModelId",
+                            "RelatedProjectDataModelId"
+                        });
                     return message;
                 }                
             }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/GetCommand.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Cli.Extensions;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Cli.Commands.Model
+{
+    [Command(Description = "Get a single project data model record")]
+    public class GetCommand : BaseCommand
+    {
+        private readonly IProjectService _projectService;
+        private readonly IProjectDataModelService _projectDataModelService;
+
+        public GetCommand(IConsole console, ILogger<GetCommand> logger,
+            IProjectService projectService, IProjectDataModelService projectDataModelService) : base(console, logger)
+        {
+            _projectService = projectService;
+            _projectDataModelService = projectDataModelService;
+        }
+
+        [Required]
+        [Option("-p|--project <PROJECT>", "Name of the project", CommandOptionType.SingleValue)]
+        public string Project { get; set; }
+
+        [Required]
+        [Option("-n|--name <NAME>", "Name of the data model", CommandOptionType.SingleValue)]
+        public string Name { get; set; }
+
+        public override string Execute()
+        {
+            Console.WriteLine($"Trying to get data model {Name} in project {Project}...");
+
+            string message;
+
+            var project = _projectService.GetProjectByName(Project).Result;
+            if (project != null)
+            {
+                var model = _projectDataModelService.GetProjectDataModelByName(project.Id, Name).Result;
+
+                if (model != null)
+                {
+                    message = model.ToCliString($"Data model {Name}");
+                    return message;
+                }                
+            }
+
+            message = $"Failed to get model {Name}. Make sure the project and model names are correct.";
+
+            return message;
+        }
+    }
+}

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ModelCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ModelCommand.cs
@@ -8,6 +8,7 @@ namespace Polyrific.Catapult.Cli.Commands
 {
     [Command(Description = "Project data model related command")]
     [Subcommand("add", typeof(AddCommand))]
+    [Subcommand("get", typeof(GetCommand))]
     [Subcommand("list", typeof(ListCommand))]
     [Subcommand("remove", typeof(RemoveCommand))]
     [Subcommand("update", typeof(UpdateCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/GetCommand.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Cli.Extensions;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Cli.Commands.Project
+{
+    [Command(Description = "Get a single project record")]
+    public class GetCommand : BaseCommand
+    {
+        private readonly IProjectService _projectService;
+
+        public GetCommand(IConsole console, ILogger<GetCommand> logger, IProjectService projectService) : base(console, logger)
+        {
+            _projectService = projectService;
+        }
+
+        [Required]
+        [Option("-n|--name <NAME>", "Name of the project", CommandOptionType.SingleValue)]
+        public string Name { get; set; }
+
+        public override string Execute()
+        {
+            Console.WriteLine("Trying to get project {Name}...");
+
+            string message;
+
+            var project = _projectService.GetProjectByName(Name).Result;
+
+            if (project != null)
+                message = project.ToCliString($"Project {Name}");
+            else
+                message = $"Project {Name} was not found";
+
+            return message;
+        }
+    }
+}

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ProjectCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ProjectCommand.cs
@@ -9,6 +9,7 @@ namespace Polyrific.Catapult.Cli.Commands
     [Command(Description = "Project related command")]
     [Subcommand("archive", typeof(ArchiveCommand))]
     [Subcommand("create", typeof(CreateCommand))]
+    [Subcommand("get", typeof(GetCommand))]
     [Subcommand("list", typeof(ListCommand))]
     [Subcommand("remove", typeof(RemoveCommand))]
     [Subcommand("restore", typeof(RestoreCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/GetCommand.cs
@@ -56,7 +56,10 @@ namespace Polyrific.Catapult.Cli.Commands.Task
                     {
                         var configs = _pluginService.GetPluginAdditionalConfigByPluginName(task.Provider).Result;
                         var secretConfigs = configs.Where(c => c.IsSecret).Select(c => c.Name).ToArray();
-                        message = task.ToCliString($"Task {Name} in job {Job}:", secretConfigs);
+                        message = task.ToCliString($"Task {Name} in job {Job}:", secretConfigs, excludedFields: new string[]
+                        {
+                            "JobDefinitionId"
+                        });
                         return message;
                     }
                 }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/ListCommand.cs
@@ -56,7 +56,12 @@ namespace Polyrific.Catapult.Cli.Commands.Task
                         secretConfig.AddRange(configs.Where(c => c.IsSecret).Select(c => c.Name));
                     }
 
-                    message = tasks.ToListCliString($"Found {tasks.Count} task(s):", secretConfig.ToArray());
+                    message = tasks.ToListCliString($"Found {tasks.Count} task(s):", secretConfig.ToArray(), excludedFields: new string[]
+                        {
+                            "JobDefinitionId",
+                            "Configs",
+                            "AdditionalConfigs"
+                        });
                     return message;
                 }
             }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobDefinitionDto.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Collections.Generic;
+
 namespace Polyrific.Catapult.Shared.Dto.JobDefinition
 {
     public class JobDefinitionDto
@@ -18,5 +20,10 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         /// Name of the data model
         /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Name of the data model
+        /// </summary>
+        public List<JobTaskDefinitionDto> Tasks { get; set; }
     }
 }

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/JobCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/JobCommandTests.cs
@@ -172,7 +172,8 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
 
             Assert.Equal("Failed to remove job definition Default. Make sure the project and job definition names are correct.", resultMessage);
         }
-      
+
+        [Fact]
         public void JobUpdate_Execute_ReturnsSuccessMessage()
         {
             var command = new UpdateCommand(_console, LoggerMock.GetLogger<UpdateCommand>().Object, _projectService.Object, _jobDefinitionService.Object)

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/JobCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/JobCommandTests.cs
@@ -21,6 +21,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         private readonly IConsole _console;
         private readonly Mock<IProjectService> _projectService;
         private readonly Mock<IJobDefinitionService> _jobDefinitionService;
+        private readonly Mock<IPluginService> _pluginService;
         private readonly ITestOutputHelper _output;
 
         public JobCommandTests(ITestOutputHelper output)
@@ -41,7 +42,16 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
                 {
                     Id = 1,
                     ProjectId = 1,
-                    Name = "Default"
+                    Name = "Default",
+                    Tasks = new List<JobTaskDefinitionDto>
+                    {
+                        new JobTaskDefinitionDto
+                        {
+                            Id = 1,
+                            Name = "Generate",
+                            Type = "Generate"
+                        }
+                    }
                 }
             };
 
@@ -65,6 +75,9 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
 
             _projectService = new Mock<IProjectService>();
             _projectService.Setup(p => p.GetProjectByName(It.IsAny<string>())).ReturnsAsync((string name) => projects.FirstOrDefault(p => p.Name == name));
+
+            _pluginService = new Mock<IPluginService>();
+            _pluginService.Setup(s => s.GetPluginAdditionalConfigByPluginName(It.IsAny<string>())).ReturnsAsync(new List<Shared.Dto.Plugin.PluginAdditionalConfigDto>());
         }
 
         [Fact]
@@ -158,6 +171,34 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
             var resultMessage = command.Execute();
 
             Assert.Equal("Failed to remove job definition Default. Make sure the project and job definition names are correct.", resultMessage);
+        }
+
+        [Fact]
+        public void JobGet_Execute_ReturnsSuccessMessage()
+        {
+            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _jobDefinitionService.Object, _pluginService.Object)
+            {
+                Project = "Project 1",
+                Name = "Default"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.StartsWith("Job definition Default", resultMessage);
+        }
+
+        [Fact]
+        public void JobGet_Execute_ReturnsNotFoundMessage()
+        {
+            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _jobDefinitionService.Object, _pluginService.Object)
+            {
+                Project = "Project 2",
+                Name = "Default"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.Equal("Failed to get job definition Default. Make sure the project and job definition names are correct.", resultMessage);
         }
     }
 }

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ModelCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ModelCommandTests.cs
@@ -189,5 +189,33 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
 
             Assert.Equal("Failed to update model Tag. Make sure the project and model names are correct.", resultMessage);
         }
+
+        [Fact]
+        public void ModelGet_Execute_ReturnsSuccessMessage()
+        {
+            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _projectModelService.Object)
+            {
+                Project = "Project 1",
+                Name = "Product"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.StartsWith("Data model Product", resultMessage);
+        }
+
+        [Fact]
+        public void ModelGet_Execute_ReturnsNotFoundMessage()
+        {
+            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object, _projectModelService.Object)
+            {
+                Project = "Project 1",
+                Name = "Tag"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.Equal("Failed to get model Tag. Make sure the project and model names are correct.", resultMessage);
+        }
     }
 }

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ProjectCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ProjectCommandTests.cs
@@ -479,5 +479,31 @@ jobs:
 
             Assert.Equal("Project Project 2 was not found", resultMessage);
         }
+
+        [Fact]
+        public void ProjectGet_Execute_ReturnsSuccessMessage()
+        {
+            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object)
+            {
+                Name = "Project 1"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.StartsWith("Project Project 1", resultMessage);
+        }
+
+        [Fact]
+        public void ProjectGete_Execute_ReturnsNotFoundMessage()
+        {
+            var command = new GetCommand(_console, LoggerMock.GetLogger<GetCommand>().Object, _projectService.Object)
+            {
+                Name = "Project 2"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.Equal("Project Project 2 was not found", resultMessage);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Add `get` sub-commands for `job`, `model`, and `project` commands

## Related issue
- #144 