### PR TITLE
Add unit tests for Account controller

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Infrastructure/NotificationInjection.cs
+++ b/src/API/Polyrific.Catapult.Api.Infrastructure/NotificationInjection.cs
@@ -23,7 +23,7 @@ namespace Polyrific.Catapult.Api.Infrastructure
 
             NotificationConfig.InitConfigFile().Wait();
             services.AddTransient<NotificationConfig>();
-            services.AddTransient<NotificationProvider>();
+            services.AddTransient<INotificationProvider, NotificationProvider>();
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Controllers/AccountController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/AccountController.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System.Collections.Generic;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Web;
 using AutoMapper;
@@ -25,10 +24,10 @@ namespace Polyrific.Catapult.Api.Controllers
     {
         private readonly IUserService _userService;
         private readonly IMapper _mapper;
-        private readonly NotificationProvider _notificationProvider;
+        private readonly INotificationProvider _notificationProvider;
         private readonly ILogger _logger;
 
-        public AccountController(IUserService service, IMapper mapper, NotificationProvider notificationProvider, ILogger<AccountController> logger)
+        public AccountController(IUserService service, IMapper mapper, INotificationProvider notificationProvider, ILogger<AccountController> logger)
         {
             _userService = service;
             _mapper = mapper;

--- a/src/Shared/Polyrific.Catapult.Shared.Common/Notification/INotificationProvider.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/Notification/INotificationProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Polyrific.Catapult.Shared.Common.Notification
+{
+    public interface INotificationProvider
+    {
+        /// <summary>
+        /// Send the notification
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="messageParameters"></param>
+        /// <returns></returns>
+        Task SendNotification(SendNotificationRequest request, Dictionary<string, string> messageParameters);
+    }
+}

--- a/src/Shared/Polyrific.Catapult.Shared.Common/Notification/NotificationProvider.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/Notification/NotificationProvider.cs
@@ -11,7 +11,7 @@ using Polyrific.Catapult.Shared.Common.Interface;
 
 namespace Polyrific.Catapult.Shared.Common.Notification
 {
-    public class NotificationProvider
+    public class NotificationProvider : INotificationProvider
     {
         private readonly IEnumerable<INotificationSender> _notificationSenders;
         private readonly NotificationConfig _notificationConfig;
@@ -26,7 +26,7 @@ namespace Polyrific.Catapult.Shared.Common.Notification
             _logger = loggerFactory.CreateLogger<NotificationProvider>();
         }
 
-        public async Task SendNotification(SendNotificationRequest request, Dictionary<string, string> messageParameters)
+        public virtual async Task SendNotification(SendNotificationRequest request, Dictionary<string, string> messageParameters)
         {
             foreach (var sender in _notificationSenders)
             {

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -14,6 +15,7 @@ using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Api.Core.Services;
 using Polyrific.Catapult.Api.UnitTests.Utilities;
 using Polyrific.Catapult.Shared.Common.Notification;
+using Polyrific.Catapult.Shared.Dto.Constants;
 using Polyrific.Catapult.Shared.Dto.User;
 using Xunit;
 
@@ -78,8 +80,356 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
             var result = await controller.RegisterUser(dto);
             
             var okActionResult = Assert.IsType<OkObjectResult>(result);
-            Assert.IsType<RegisterUserResultDto>(okActionResult.Value);
+            var returnValue = Assert.IsType<RegisterUserResultDto>(okActionResult.Value);
+            Assert.Equal(1, returnValue.UserId);
             _notificationProvider.Verify(n => n.SendNotification(It.IsAny<SendNotificationRequest>(), It.IsAny<Dictionary<string, string>>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ConfirmEmail_ReturnSuccessMessage()
+        {
+            _userService.Setup(s => s.ConfirmEmail(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.ConfirmEmail(1, "xxx");
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("Email confirmed.", okActionResult.Value);
+        }
+
+        [Fact]
+        public async void GetUsers_ReturnUserList()
+        {
+            _userService.Setup(s => s.GetUsers(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<User>
+                {
+                    new User("test@example.com")
+                });
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.GetUsers(null, null);
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            var returnValue = Assert.IsType<List<UserDto>>(okActionResult.Value);
+            Assert.NotEmpty(returnValue);
+        }
+
+        [Fact]
+        public async void GetCurrentUser_ReturnUser()
+        {
+            _userService.Setup(s => s.GetUserById(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(
+                (int id, CancellationToken cancellationToken) => new User
+                {
+                    Id = id
+                });
+            
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[] {new Claim(ClaimTypes.NameIdentifier, "1")})
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.GetCurrentUser();
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            var returnValue = Assert.IsType<UserDto>(okActionResult.Value);
+            Assert.Equal("1", returnValue.Id);
+        }
+
+        [Fact]
+        public async void GetUserByName_ReturnUser()
+        {
+            _userService.Setup(s => s.GetUser(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string username, CancellationToken cancellationToken) => new User(username));
+
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.Name, "admin@example.com"),
+                        new Claim(ClaimTypes.Role, UserRole.Administrator) 
+                    })
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.GetUserByName("test@example.com");
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            var returnValue = Assert.IsType<UserDto>(okActionResult.Value);
+            Assert.Equal("test@example.com", returnValue.UserName);
+        }
+
+        [Fact]
+        public async void GetUserByName_ReturnUnauthorized()
+        {
+            _userService.Setup(s => s.GetUser(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string username, CancellationToken cancellationToken) => new User(username));
+
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.Name, "basic@example.com"),
+                        new Claim(ClaimTypes.Role, UserRole.Basic), 
+                    })
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.GetUserByName("test@example.com");
+
+            Assert.IsType<UnauthorizedResult>(result);
+        }
+
+        [Fact]
+        public async void GetUserByEmail_ReturnUser()
+        {
+            _userService.Setup(s => s.GetUserEmail(It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ClaimsPrincipal principal, CancellationToken cancellationToken) => principal.Identity.Name);
+            _userService.Setup(s => s.GetUserByEmail(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string email, CancellationToken cancellationToken) => new User(email));
+
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.Name, "admin@example.com"),
+                        new Claim(ClaimTypes.Role, UserRole.Administrator), 
+                    })
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.GetUserByEmail("test@example.com");
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            var returnValue = Assert.IsType<UserDto>(okActionResult.Value);
+            Assert.Equal("test@example.com", returnValue.UserName);
+        }
+
+        [Fact]
+        public async void UpdateUser_ReturnSuccess()
+        {
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.NameIdentifier, "1"),
+                        new Claim(ClaimTypes.Role, UserRole.Administrator)
+                    })
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.UpdateUser(2, new UpdateUserDto() { Id = 2});
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
+        public async void UpdateUser_ReturnBadRequest()
+        {
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.NameIdentifier, "1"),
+                        new Claim(ClaimTypes.Role, UserRole.Administrator)
+                    })
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.UpdateUser(2, new UpdateUserDto() { Id = 3 });
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async void SuspendUser_ReturnSuccess()
+        {
+            _userService.Setup(s => s.Suspend(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.SuspendUser(1);
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("User suspended", okActionResult.Value);
+        }
+
+        [Fact]
+        public async void ReactivateUser_ReturnSuccess()
+        {
+            _userService.Setup(s => s.Reactivate(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.ReactivateUser(1);
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("User activated", okActionResult.Value);
+        }
+
+        [Fact]
+        public async void UpdatePassword_ReturnSuccess()
+        {
+            _userService
+                .Setup(s => s.UpdatePassword(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[] {new Claim(ClaimTypes.NameIdentifier, "1")})
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.UpdatePassword(new UpdatePasswordDto());
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("Password updated", okActionResult.Value);
+        }
+
+        [Fact]
+        public async void ResetPassword_GET_ReturnSuccess()
+        {
+            _userService.Setup(s => s.GetResetPasswordToken(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync("xxx");
+            _userService.Setup(s => s.GetUserById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int id, CancellationToken cancellationToken) => new User() {Id = id});
+            _notificationProvider.Setup(n => n.SendNotification(It.IsAny<SendNotificationRequest>(), It.IsAny<Dictionary<string, string>>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.ResetPassword(1);
+
+            Assert.IsType<OkResult>(result);
+            _notificationProvider.Verify(n => n.SendNotification(It.IsAny<SendNotificationRequest>(), It.IsAny<Dictionary<string, string>>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ResetPassword_POST_ReturnSuccess()
+        {
+            _userService
+                .Setup(s => s.ResetPassword(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.ResetPassword(1, new ResetPasswordDto());
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("Reset password success", okActionResult.Value);
+        }
+
+        [Fact]
+        public async void RemoveUser_ReturnsNoContent()
+        {
+            _userService.Setup(s => s.DeleteUser(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.RemoveUser(1);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async void SetUserRole_ReturnsSuccess()
+        {
+            _userService
+                .Setup(s => s.SetUserRole(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.SetUserRole(1, new SetUserRoleDto() {UserId = 1});
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<SetUserRoleDto>(okActionResult.Value);
+        }
+
+        [Fact]
+        public async void SetUserRole_ReturnsBadRequest()
+        {
+            _userService
+                .Setup(s => s.SetUserRole(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = new AccountController(_userService.Object, _mapper, _notificationProvider.Object,
+                _logger.Object);
+
+            var result = await controller.SetUserRole(1, new SetUserRoleDto() {UserId = 2});
+
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("User Id doesn't match.", badRequestResult.Value);
         }
     }
 }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Polyrific.Catapult.Api.AutoMapperProfiles;
 using Polyrific.Catapult.Api.Controllers;
 using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Api.Core.Services;
@@ -31,13 +30,8 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         public AccountControllerTests()
         {
             _userService = new Mock<IUserService>();
-
-            Mapper.Reset();
-            Mapper.Initialize(cfg =>
-            {
-                cfg.AddProfile<UserAutoMapperProfile>();
-            });
-            _mapper = Mapper.Instance;
+            
+            _mapper = AutoMapperUtils.GetMapper();
             
             _notificationProvider = new Mock<INotificationProvider>();
 

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Polyrific.Catapult.Api.AutoMapperProfiles;
+using Polyrific.Catapult.Api.Controllers;
+using Polyrific.Catapult.Api.Core.Entities;
+using Polyrific.Catapult.Api.Core.Services;
+using Polyrific.Catapult.Api.UnitTests.Utilities;
+using Polyrific.Catapult.Shared.Common.Notification;
+using Polyrific.Catapult.Shared.Dto.User;
+using Xunit;
+
+namespace Polyrific.Catapult.Api.UnitTests.Controllers
+{
+    public class AccountControllerTests
+    {
+        private readonly Mock<IUserService> _userService;
+        private readonly IMapper _mapper;
+        private readonly Mock<INotificationProvider> _notificationProvider;
+        private readonly Mock<ILogger<AccountController>> _logger;
+
+        public AccountControllerTests()
+        {
+            _userService = new Mock<IUserService>();
+
+            Mapper.Reset();
+            Mapper.Initialize(cfg =>
+            {
+                cfg.AddProfile<UserAutoMapperProfile>();
+            });
+            _mapper = Mapper.Instance;
+            
+            _notificationProvider = new Mock<INotificationProvider>();
+
+            _logger = LoggerMock.GetLogger<AccountController>();
+        }
+
+        [Fact]
+        public async void RegisterUser_ReturnsRegisteredUser()
+        {
+            _userService.Setup(s => s.GeneratePassword(It.IsAny<int>())).ReturnsAsync("0123456789");
+            _userService
+                .Setup(s => s.CreateUser(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string email, string firstName, string lastName, string password, CancellationToken cancellationToken) => 
+                    new User
+                    {
+                        Id = 1,
+                        Email = email,
+                        UserName = email,
+                        FirstName = firstName,
+                        LastName = lastName
+                    });
+            _userService.Setup(s => s.GenerateConfirmationToken(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync("xxx");
+            _notificationProvider.Setup(n => n.SendNotification(It.IsAny<SendNotificationRequest>(), It.IsAny<Dictionary<string, string>>()))
+                .Returns(Task.CompletedTask);
+
+            var httpContext = new DefaultHttpContext()
+            {
+                Request = {Scheme = "https", Host = new HostString("localhost")}
+            };
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var dto = new RegisterUserDto
+            {
+                Email = "user@example.com"
+            };
+            var result = await controller.RegisterUser(dto);
+            
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<RegisterUserResultDto>(okActionResult.Value);
+            _notificationProvider.Verify(n => n.SendNotification(It.IsAny<SendNotificationRequest>(), It.IsAny<Dictionary<string, string>>()), Times.Once);
+        }
+    }
+}

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/AccountControllerTests.cs
@@ -120,6 +120,40 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         }
 
         [Fact]
+        public async void GetUser_ReturnUser()
+        {
+            _userService.Setup(s => s.GetUserById(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(
+                (int id, CancellationToken cancellationToken) => new User
+                {
+                    Id = id
+                });
+            
+            var httpContext = new DefaultHttpContext()
+            {
+                User = new ClaimsPrincipal(new[]
+                {
+                    new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.NameIdentifier, "1"),
+                        new Claim(ClaimTypes.Role, UserRole.Administrator)
+                    })
+                })
+            };
+
+            var controller =
+                new AccountController(_userService.Object, _mapper, _notificationProvider.Object, _logger.Object)
+                {
+                    ControllerContext = new ControllerContext {HttpContext = httpContext}
+                };
+
+            var result = await controller.GetUser(2);
+
+            var okActionResult = Assert.IsType<OkObjectResult>(result);
+            var returnValue = Assert.IsType<UserDto>(okActionResult.Value);
+            Assert.Equal("2", returnValue.Id);
+        }
+
+        [Fact]
         public async void GetCurrentUser_ReturnUser()
         {
             _userService.Setup(s => s.GetUserById(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectServiceTests.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using AutoMapper;
 using Moq;
-using Polyrific.Catapult.Api.Core.AutoMapperProfiles;
 using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Api.Core.Exceptions;
 using Polyrific.Catapult.Api.Core.Repositories;
 using Polyrific.Catapult.Api.Core.Services;
 using Polyrific.Catapult.Api.Core.Specifications;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+using Polyrific.Catapult.Api.UnitTests.Utilities;
 using Xunit;
 
 namespace Polyrific.Catapult.Api.UnitTests.Core.Services
@@ -99,13 +99,8 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             _projectDataModelPropertyRepository = new Mock<IProjectDataModelPropertyRepository>();
 
             _jobDefinitionService = new Mock<IJobDefinitionService>();
-
-            Mapper.Reset();
-            Mapper.Initialize(cfg =>
-            {
-                cfg.AddProfile<ProjectTemplateAutoMapperProfile>();
-            });
-            _mapper = Mapper.Instance;
+            
+            _mapper = AutoMapperUtils.GetMapper();
         }
 
         [Fact]

--- a/tests/Polyrific.Catapult.Api.UnitTests/Polyrific.Catapult.Api.UnitTests.csproj
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Polyrific.Catapult.Api.UnitTests.csproj
@@ -10,8 +10,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/tests/Polyrific.Catapult.Api.UnitTests/Polyrific.Catapult.Api.UnitTests.csproj
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Polyrific.Catapult.Api.UnitTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\API\Polyrific.Catapult.Api.Core\Polyrific.Catapult.Api.Core.csproj" />
+    <ProjectReference Include="..\..\src\API\Polyrific.Catapult.Api\Polyrific.Catapult.Api.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Polyrific.Catapult.Api.UnitTests/Utilities/AutoMapperUtils.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Utilities/AutoMapperUtils.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using AutoMapper;
+using Polyrific.Catapult.Api.AutoMapperProfiles;
+using Polyrific.Catapult.Api.Core.AutoMapperProfiles;
+
+namespace Polyrific.Catapult.Api.UnitTests.Utilities
+{
+    public static class AutoMapperUtils
+    {
+        private static readonly object Lock = new object();
+        private static bool _isInitialized;
+
+        public static IMapper GetMapper()
+        {
+            lock (Lock)
+            {
+                if (!_isInitialized)
+                {
+                    Mapper.Initialize(cfg =>
+                    {
+                        cfg.AddProfile<ProjectTemplateAutoMapperProfile>();
+                        cfg.AddProfile<UserAutoMapperProfile>();
+                    });
+
+                    _isInitialized = true;
+                }
+            }
+
+            return Mapper.Instance;
+        }
+    }
+}

--- a/tests/Polyrific.Catapult.Api.UnitTests/Utilities/LoggerMock.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Utilities/LoggerMock.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Polyrific.Catapult.Api.UnitTests.Utilities
+{
+    public static class LoggerMock
+    {
+        public static Mock<ILogger<T>> GetLogger<T>()
+        {
+            var logger = new Mock<ILogger<T>>();
+
+            return logger;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- [x] RegisterUser
- [x] ConfirmEmail
- [x] GetUsers
- [x] GetUser
- [x] GetCurrentUser
- [x] GetUserByName
- [x] GetUserByEmail
- [x] UpdateUser
- [x] SuspendUser
- [x] ReactivateUser
- [x] UpdatePassword
- [x] ResetPassword (Get)
- [x] ResetPassword (Post)
- [x] RemoveUser
- [x] SetUserRole

## Related Issue
- https://github.com/Polyrific-Inc/OpenCatapult/issues/162