### PR TITLE
Implement name and provider validation for task API

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/DuplicateJobTaskDefinitionException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/DuplicateJobTaskDefinitionException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class DuplicateJobTaskDefinitionException : Exception
+    {
+        public string Name { get; set; }
+
+        public DuplicateJobTaskDefinitionException(string name)
+            : base($"Job Task Definition \"{name}\" already exists.")
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/InvalidPluginTypeException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/InvalidPluginTypeException.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+using Polyrific.Catapult.Shared.Dto.Constants;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class InvalidPluginTypeException : Exception
+    {
+        public string PluginType { get; }
+        public string PluginName { get; }
+        public string[] TaskTypes { get; }
+
+        public InvalidPluginTypeException(string pluginType, string pluginName) : 
+            base($"Plugin type \"{pluginType}\" of provider \"{pluginName}\" is not valid.")
+        {
+            PluginType = pluginType;
+            PluginName = pluginName;
+        }
+
+        public InvalidPluginTypeException(string pluginType, string pluginName, string[] taskTypes) : 
+            base($"Plugin type \"{pluginType}\" of provider \"{pluginName}\" is not valid. It can only be used for the following task type: {string.Join(DataDelimiter.Comma.ToString(), taskTypes)}")
+        {
+            PluginType = pluginType;
+            PluginName = pluginName;
+            TaskTypes = taskTypes;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -128,11 +128,11 @@ namespace Polyrific.Catapult.Api.Core.Services
         Task<JobTaskDefinition> GetJobTaskDefinitionByName(int jobDefinitionId, string jobTaskDefinitionName, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Validate a task config whether it has satisfy required values
+        /// Validate the task property and config whether it has satisfy required values
         /// </summary>
         /// <param name="jobTaskDefinition">The job task definition object</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns></returns>
-        Task ValidateTaskConfig(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
+        Task ValidateJobTaskDefinition(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -156,6 +156,15 @@ namespace Polyrific.Catapult.Api.Core.Services
                 throw new JobDefinitionNotFoundException(jobDefinitionId);
             }
 
+            var duplicateTasks = jobTaskDefinitions.GroupBy(x => x.Name.ToLower())
+              .Where(g => g.Count() > 1)
+              .Select(y => y.Key)
+              .ToList();
+            if (duplicateTasks.Count > 0)
+            {
+                throw new DuplicateJobTaskDefinitionException(string.Join(DataDelimiter.Comma.ToString(), duplicateTasks));
+            }
+
             foreach (var task in jobTaskDefinitions)
                 await ValidateJobTaskDefinition(task, cancellationToken);
 
@@ -172,6 +181,7 @@ namespace Polyrific.Catapult.Api.Core.Services
 
             if (jobTaskDefinition != null)
             {
+                jobTaskDefinition.Name = editedJobTaskDefinition.Name;
                 jobTaskDefinition.Type = editedJobTaskDefinition.Type;
                 jobTaskDefinition.Provider = editedJobTaskDefinition.Provider;
                 jobTaskDefinition.ConfigString = editedJobTaskDefinition.ConfigString;

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -24,6 +24,17 @@ namespace Polyrific.Catapult.Api.Core.Services
         private readonly IPluginAdditionalConfigRepository _pluginAdditionalConfigRepository;
         private readonly ISecretVault _secretVault;
 
+        private readonly List<(string, string[])> _allowedTaskTypes = new List<(string, string[])>
+            {
+                ( PluginType.GeneratorProvider, new string[] { JobTaskDefinitionType.Generate } ),
+                ( PluginType.RepositoryProvider, new string[] { JobTaskDefinitionType.Clone, JobTaskDefinitionType.Push, JobTaskDefinitionType.Merge } ),
+                ( PluginType.BuildProvider, new string[] { JobTaskDefinitionType.Build,  } ),
+                ( PluginType.StorageProvider, new string[] { JobTaskDefinitionType.PublishArtifact } ),
+                ( PluginType.HostingProvider, new string[] { JobTaskDefinitionType.Deploy } ),
+                ( PluginType.DatabaseProvider, new string[] { JobTaskDefinitionType.DeployDb } ),
+                ( PluginType.TestProvider, new string[] { JobTaskDefinitionType.Test } )
+            };
+
         public JobDefinitionService(IJobDefinitionRepository dataModelRepository,
             IJobTaskDefinitionRepository jobTaskDefinitionRepository,
             IProjectRepository projectRepository,
@@ -130,7 +141,7 @@ namespace Polyrific.Catapult.Api.Core.Services
                 throw new JobDefinitionNotFoundException(jobTaskDefinition.JobDefinitionId);
             }
 
-            await ValidateTaskConfig(jobTaskDefinition, cancellationToken);
+            await ValidateJobTaskDefinition(jobTaskDefinition, cancellationToken);
 
             return await _jobTaskDefinitionRepository.Create(jobTaskDefinition, cancellationToken);
         }
@@ -146,7 +157,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             }
 
             foreach (var task in jobTaskDefinitions)
-                await ValidateTaskConfig(task, cancellationToken);
+                await ValidateJobTaskDefinition(task, cancellationToken);
 
             jobTaskDefinitions.ForEach(j => j.JobDefinitionId = jobDefinitionId);
 
@@ -167,7 +178,7 @@ namespace Polyrific.Catapult.Api.Core.Services
                 jobTaskDefinition.AdditionalConfigString = editedJobTaskDefinition.AdditionalConfigString;
                 jobTaskDefinition.Sequence = editedJobTaskDefinition.Sequence;
                 
-                await ValidateTaskConfig(jobTaskDefinition, cancellationToken);
+                await ValidateJobTaskDefinition(jobTaskDefinition, cancellationToken);
 
                 await _jobTaskDefinitionRepository.Update(jobTaskDefinition, cancellationToken);
             }
@@ -183,7 +194,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             {
                 jobTaskDefinition.ConfigString = JsonConvert.SerializeObject(jobTaskConfig);
 
-                await ValidateTaskConfig(jobTaskDefinition, cancellationToken);
+                await ValidateJobTaskDefinition(jobTaskDefinition, cancellationToken);
 
                 await _jobTaskDefinitionRepository.Update(jobTaskDefinition, cancellationToken);
             }
@@ -222,94 +233,110 @@ namespace Polyrific.Catapult.Api.Core.Services
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var taskDefinition = await _jobTaskDefinitionRepository.GetSingleBySpec(new JobTaskDefinitionFilterSpecification(jobDefinitionId, jobTaskDefinitionName), cancellationToken);
+            var taskDefinition = await _jobTaskDefinitionRepository.GetSingleBySpec(new JobTaskDefinitionFilterSpecification(jobDefinitionId, jobTaskDefinitionName, 0), cancellationToken);
             await DecryptSecretAdditionalConfigs(taskDefinition);
             return taskDefinition;
         }
 
-        public async Task ValidateTaskConfig(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task ValidateJobTaskDefinition(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (!string.IsNullOrEmpty(jobTaskDefinition.Provider))
+            var taskSpec = new JobTaskDefinitionFilterSpecification(jobTaskDefinition.JobDefinitionId, jobTaskDefinition.Name, jobTaskDefinition.Id);
+            if (await _jobTaskDefinitionRepository.CountBySpec(taskSpec, cancellationToken) > 0)
+                throw new DuplicateJobTaskDefinitionException(jobTaskDefinition.Name);
+
+            var pluginSpec = new PluginFilterSpecification(jobTaskDefinition.Provider, null);
+            var plugin = await _pluginRepository.GetSingleBySpec(pluginSpec, cancellationToken);
+
+            if (plugin == null)
             {
-                var pluginSpec = new PluginFilterSpecification(jobTaskDefinition.Provider, null);
-                var plugin = await _pluginRepository.GetSingleBySpec(pluginSpec, cancellationToken);
+                throw new ProviderNotInstalledException(jobTaskDefinition.Provider);
+            }
 
-                if (plugin == null)
+            var allowedTaskType = _allowedTaskTypes.FirstOrDefault(t => t.Item1.ToLower() == plugin.Type.ToLower());
+            if (allowedTaskType.Equals(default((string, string[]))))
+            {
+                throw new InvalidPluginTypeException(plugin.Type, jobTaskDefinition.Provider);
+            }
+            else if (!allowedTaskType.Item2.Any(taskType => jobTaskDefinition.Type.ToLower() == taskType.ToLower()))
+            {
+                throw new InvalidPluginTypeException(plugin.Type, jobTaskDefinition.Provider, allowedTaskType.Item2);
+            }
+
+            if (!string.IsNullOrEmpty(plugin.RequiredServicesString))
+            {
+                var requiredServices = plugin.RequiredServicesString.Split(DataDelimiter.Comma);
+                if (string.IsNullOrEmpty(jobTaskDefinition.ConfigString))
                 {
-                    throw new ProviderNotInstalledException(jobTaskDefinition.Provider);
+                    throw new ExternalServiceRequiredException(requiredServices[0], plugin.Name);
                 }
 
-                if (!string.IsNullOrEmpty(plugin.RequiredServicesString))
+                var config = JsonConvert.DeserializeObject<Dictionary<string, string>>(jobTaskDefinition.ConfigString);
+                foreach (var requiredService in requiredServices)
                 {
-                    var requiredServices = plugin.RequiredServicesString.Split(DataDelimiter.Comma);
-                    if (string.IsNullOrEmpty(jobTaskDefinition.ConfigString))
+                    config.TryGetValue(GetServiceTaskConfigKey(requiredService), out var serviceName);
+
+                    if (string.IsNullOrEmpty(serviceName))
                     {
-                        throw new ExternalServiceRequiredException(requiredServices[0], plugin.Name);
+                        throw new ExternalServiceRequiredException(requiredService, plugin.Name);
                     }
 
-                    var config = JsonConvert.DeserializeObject<Dictionary<string, string>>(jobTaskDefinition.ConfigString);
-                    foreach (var requiredService in requiredServices)
+                    var serviceSpec = new ExternalServiceFilterSpecification(0, serviceName);
+                    serviceSpec.Includes.Add(x => x.ExternalServiceType);
+                    var service = await _externalServiceRepository.GetSingleBySpec(serviceSpec, cancellationToken);
+
+                    if (service == null)
                     {
-                        config.TryGetValue(GetServiceTaskConfigKey(requiredService), out var serviceName);
-
-                        if (string.IsNullOrEmpty(serviceName))
-                        {
-                            throw new ExternalServiceRequiredException(requiredService, plugin.Name);
-                        }
-
-                        var serviceSpec = new ExternalServiceFilterSpecification(0, serviceName);
-                        serviceSpec.Includes.Add(x => x.ExternalServiceType);
-                        var service = await _externalServiceRepository.GetSingleBySpec(serviceSpec, cancellationToken);
-
-                        if (service == null)
-                        {
-                            throw new ExternalServiceNotFoundException(serviceName);
-                        }
-
-                        if (service.ExternalServiceType.Name != requiredService)
-                        {
-                            throw new IncorrectExternalServiceTypeException(serviceName, requiredService);
-                        }
-                    }
-                }
-
-                var additionalConfigsDefinitionSpec = new PluginAdditionalConfigFilterSpecification(plugin.Id);
-                var additionalConfigsDefinition = await _pluginAdditionalConfigRepository.GetBySpec(additionalConfigsDefinitionSpec, cancellationToken);
-                var requiredConfigs = additionalConfigsDefinition.Where(c => c.IsRequired).Select(c => c.Name).ToList();
-                var taskAdditionalConfigs = !string.IsNullOrEmpty(jobTaskDefinition.AdditionalConfigString) ?
-                    JsonConvert.DeserializeObject<Dictionary<string, string>>(jobTaskDefinition.AdditionalConfigString) : null;
-                if (requiredConfigs.Count > 0)
-                {
-                    if (taskAdditionalConfigs == null)
-                    {
-                        throw new PluginAdditionalConfigRequiredException(requiredConfigs[0], plugin.Name);
-                    }
-                    
-                    foreach (var requiredConfig in requiredConfigs)
-                    {
-                        taskAdditionalConfigs.TryGetValue(requiredConfig, out var conf);
-                        if (conf == null)
-                        {
-                            throw new PluginAdditionalConfigRequiredException(requiredConfig, plugin.Name);
-                        }
-                    }
-                }
-
-                var secretConfigs = additionalConfigsDefinition.Where(c => c.IsSecret).Select(c => c.Name).ToList();
-                if (secretConfigs.Count > 0 && taskAdditionalConfigs != null)
-                {            
-                    foreach (var secretConfig in secretConfigs)
-                    {
-                        if (taskAdditionalConfigs.TryGetValue(secretConfig, out var secretConfigValue))
-                        {
-                            var encryptedValue = await _secretVault.Encrypt(secretConfigValue);
-                            taskAdditionalConfigs[secretConfig] = encryptedValue;
-                        }
+                        throw new ExternalServiceNotFoundException(serviceName);
                     }
 
-                    jobTaskDefinition.AdditionalConfigString = JsonConvert.SerializeObject(taskAdditionalConfigs);
+                    if (service.ExternalServiceType.Name != requiredService)
+                    {
+                        throw new IncorrectExternalServiceTypeException(serviceName, requiredService);
+                    }
                 }
             }
+
+            var additionalConfigsDefinitionSpec = new PluginAdditionalConfigFilterSpecification(plugin.Id);
+            var additionalConfigsDefinition = await _pluginAdditionalConfigRepository.GetBySpec(additionalConfigsDefinitionSpec, cancellationToken);
+            var requiredConfigs = additionalConfigsDefinition.Where(c => c.IsRequired).Select(c => c.Name).ToList();
+            var taskAdditionalConfigs = !string.IsNullOrEmpty(jobTaskDefinition.AdditionalConfigString) ?
+                JsonConvert.DeserializeObject<Dictionary<string, string>>(jobTaskDefinition.AdditionalConfigString) : null;
+            if (requiredConfigs.Count > 0)
+            {
+                if (taskAdditionalConfigs == null)
+                {
+                    throw new PluginAdditionalConfigRequiredException(requiredConfigs[0], plugin.Name);
+                }
+
+                foreach (var requiredConfig in requiredConfigs)
+                {
+                    taskAdditionalConfigs.TryGetValue(requiredConfig, out var conf);
+                    if (conf == null)
+                    {
+                        throw new PluginAdditionalConfigRequiredException(requiredConfig, plugin.Name);
+                    }
+                }
+            }
+
+            var secretConfigs = additionalConfigsDefinition.Where(c => c.IsSecret).Select(c => c.Name).ToList();
+            if (secretConfigs.Count > 0 && taskAdditionalConfigs != null)
+            {
+                foreach (var secretConfig in secretConfigs)
+                {
+                    if (taskAdditionalConfigs.TryGetValue(secretConfig, out var secretConfigValue))
+                    {
+                        var encryptedValue = await _secretVault.Encrypt(secretConfigValue);
+                        taskAdditionalConfigs[secretConfig] = encryptedValue;
+                    }
+                }
+
+                jobTaskDefinition.AdditionalConfigString = JsonConvert.SerializeObject(taskAdditionalConfigs);
+            }
+        }
+
+        public static string GetServiceTaskConfigKey(string serviceTypeName)
+        {
+            return $"{serviceTypeName}ExternalService";
         }
 
         private async Task DecryptSecretAdditionalConfigs(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
@@ -341,11 +368,6 @@ namespace Polyrific.Catapult.Api.Core.Services
 
                 jobTaskDefinition.AdditionalConfigString = JsonConvert.SerializeObject(taskAdditionalConfigs);
             }
-        }
-
-        public static string GetServiceTaskConfigKey(string serviceTypeName)
-        {
-            return $"{serviceTypeName}ExternalService";
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
@@ -200,7 +200,7 @@ namespace Polyrific.Catapult.Api.Core.Services
                         foreach (var task in job.Tasks)
                         {
                             task.Created = DateTime.UtcNow;
-                            await _jobDefinitionService.ValidateTaskConfig(task);
+                            await _jobDefinitionService.ValidateJobTaskDefinition(task);
                         }
                     }
                 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
@@ -197,6 +197,15 @@ namespace Polyrific.Catapult.Api.Core.Services
 
                     if (job.Tasks != null)
                     {
+                        var duplicateTasks = job.Tasks.GroupBy(x => x.Name.ToLower())
+                          .Where(g => g.Count() > 1)
+                          .Select(y => y.Key)
+                          .ToList();
+                        if (duplicateTasks.Count > 0)
+                        {
+                            throw new DuplicateJobTaskDefinitionException(string.Join(DataDelimiter.Comma.ToString(), duplicateTasks));
+                        }
+
                         foreach (var task in job.Tasks)
                         {
                             task.Created = DateTime.UtcNow;

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobTaskDefinitionFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobTaskDefinitionFilterSpecification.cs
@@ -7,6 +7,7 @@ namespace Polyrific.Catapult.Api.Core.Specifications
     public class JobTaskDefinitionFilterSpecification : BaseSpecification<JobTaskDefinition>
     {
         public int JobDefinitionId { get; set; }
+        public int ExcludedJobTaskDefinitionId { get; set; }
         public string Name { get; set; }
 
         /// <summary>
@@ -24,11 +25,13 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         /// </summary>
         /// <param name="jobDefinitionId">Id of the job definition</param>
         /// <param name="name">Name of the job task definition</param>
-        public JobTaskDefinitionFilterSpecification(int jobDefinitionId, string name)
-           : base(m => m.JobDefinitionId == jobDefinitionId && m.Name == name)
+        /// <param name="excludedJobTaskDefinitionId">Id of the excluded job task definition</param>
+        public JobTaskDefinitionFilterSpecification(int jobDefinitionId, string name, int excludedJobTaskDefinitionId)
+           : base(m => m.JobDefinitionId == jobDefinitionId && m.Name == name && (excludedJobTaskDefinitionId == 0 || m.Id != excludedJobTaskDefinitionId))
         {
             JobDefinitionId = jobDefinitionId;
             Name = name;
+            ExcludedJobTaskDefinitionId = excludedJobTaskDefinitionId;
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -201,6 +201,16 @@ namespace Polyrific.Catapult.Api.Controllers
                     taskId = newJobTaskDefinitionResponse.Id
                 }, newJobTaskDefinitionResponse);
             }
+            catch (DuplicateJobTaskDefinitionException dupTaskEx)
+            {
+                _logger.LogWarning(dupTaskEx, "Duplicate task name");
+                return BadRequest(dupTaskEx.Message);
+            }
+            catch (InvalidPluginTypeException pluginTypeEx)
+            {
+                _logger.LogWarning(pluginTypeEx, "Invalid provider's plugin type");
+                return BadRequest(pluginTypeEx.Message);
+            }
             catch (JobDefinitionNotFoundException modEx)
             {
                 _logger.LogWarning(modEx, "Job definition not found");
@@ -264,6 +274,16 @@ namespace Polyrific.Catapult.Api.Controllers
                     projectId,
                     jobId,
                 }, newTasksResponse);
+            }
+            catch (DuplicateJobTaskDefinitionException dupTaskEx)
+            {
+                _logger.LogWarning(dupTaskEx, "Duplicate task name");
+                return BadRequest(dupTaskEx.Message);
+            }
+            catch (InvalidPluginTypeException pluginTypeEx)
+            {
+                _logger.LogWarning(pluginTypeEx, "Invalid provider's plugin type");
+                return BadRequest(pluginTypeEx.Message);
             }
             catch (JobDefinitionNotFoundException modEx)
             {
@@ -379,6 +399,16 @@ namespace Polyrific.Catapult.Api.Controllers
                 await _jobDefinitionService.UpdateJobTaskDefinition(entity);
 
                 return Ok();
+            }
+            catch (DuplicateJobTaskDefinitionException dupTaskEx)
+            {
+                _logger.LogWarning(dupTaskEx, "Duplicate task name");
+                return BadRequest(dupTaskEx.Message);
+            }
+            catch (InvalidPluginTypeException pluginTypeEx)
+            {
+                _logger.LogWarning(pluginTypeEx, "Invalid provider's plugin type");
+                return BadRequest(pluginTypeEx.Message);
             }
             catch (ProviderNotInstalledException provEx)
             {

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
@@ -150,6 +150,16 @@ namespace Polyrific.Catapult.Api.Controllers
                 _logger.LogWarning(modelEx, "Project data model not found");
                 return BadRequest(modelEx.Message);
             }
+            catch (DuplicateJobTaskDefinitionException dupTaskEx)
+            {
+                _logger.LogWarning(dupTaskEx, "Duplicate task name");
+                return BadRequest(dupTaskEx.Message);
+            }
+            catch (InvalidPluginTypeException pluginTypeEx)
+            {
+                _logger.LogWarning(pluginTypeEx, "Invalid provider's plugin type");
+                return BadRequest(pluginTypeEx.Message);
+            }
             catch (ProviderNotInstalledException provEx)
             {
                 _logger.LogWarning(provEx, "Provider not installed");

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
@@ -182,7 +182,7 @@ namespace Polyrific.Catapult.Cli.Commands.Task
                             Sequence = Sequence ?? task.Sequence,
                             Configs = properties.Count > 0 ? properties.ToDictionary(x => x.Item1, x => x.Item2) : task.Configs,
                             AdditionalConfigs = task.AdditionalConfigs
-                        });
+                        }).Wait();
 
                         message = $"Task {Name} has been updated successfully";
                         Logger.LogInformation(message);

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobDefinitionDto.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.ComponentModel.DataAnnotations;
+
 namespace Polyrific.Catapult.Shared.Dto.JobDefinition
 {
     public class CreateJobDefinitionDto
@@ -7,6 +9,7 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         /// <summary>
         /// Name of the data model
         /// </summary>
+        [Required]
         public string Name { get; set; }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobTaskDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobTaskDefinitionDto.cs
@@ -16,11 +16,13 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         /// <summary>
         /// Type of the job task definition
         /// </summary>
+        [Required]
         public string Type { get; set; }
 
         /// <summary>
         /// Provider of the job task definition
         /// </summary>
+        [Required]
         public string Provider { get; set; }
 
         /// <summary>

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/UpdateJobDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/UpdateJobDefinitionDto.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.ComponentModel.DataAnnotations;
+
 namespace Polyrific.Catapult.Shared.Dto.JobDefinition
 {
     public class UpdateJobDefinitionDto
@@ -7,11 +9,13 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         /// <summary>
         /// Id of the job definition
         /// </summary>
+        [Required]
         public int Id { get; set; }
-        
+
         /// <summary>
         /// Name of the data model
         /// </summary>
+        [Required]
         public string Name { get; set; }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/UpdateJobTaskDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/UpdateJobTaskDefinitionDto.cs
@@ -22,11 +22,13 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         /// <summary>
         /// Type of the job task definition
         /// </summary>
+        [Required]
         public string Type { get; set; }
 
         /// <summary>
         /// Provider of the job task definition
         /// </summary>
+        [Required]
         public string Provider { get; set; }
 
         /// <summary>

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
@@ -49,6 +49,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                     JobDefinitionId = 1,
                     Name = "Generate",
                     Type = JobTaskDefinitionType.Generate,
+                    Provider = "AspNetCoreMvc",
                     ConfigString = "test"
                 }
             };
@@ -279,7 +280,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void AddJobTaskDefinition_ValidItem()
         {
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider, RequiredServicesString = "GitHub" });
 
             _externalServiceRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<ExternalService>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
@@ -324,7 +325,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobTaskDefinition_ConfigNull_ExternalServiceRequiredException()
         {
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider, RequiredServicesString = "GitHub" });
 
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
@@ -342,7 +343,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobTaskDefinition_ExternalServiceRequiredException()
         {
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider, RequiredServicesString = "GitHub" });
 
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
@@ -360,7 +361,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobTaskDefinition_ExternalServiceNotFoundException()
         {
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider, RequiredServicesString = "GitHub" });
 
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
@@ -378,7 +379,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobTaskDefinition_IncorrectExternalServiceTypeException()
         {
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider, RequiredServicesString = "GitHub" });
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider, RequiredServicesString = "GitHub" });
 
             _externalServiceRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<ExternalService>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
@@ -420,7 +421,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobTaskDefinition_AdditionalConfigNull_AdditionalConfigRequiredException()
         {
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider });
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider });
 
             _pluginAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<PluginAdditionalConfig>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<PluginAdditionalConfig>
@@ -449,7 +450,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobTaskDefinition_AdditionalConfigNotExist_AdditionalConfigRequiredException()
         {
             _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.BuildProvider });
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider });
 
             _pluginAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<PluginAdditionalConfig>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<PluginAdditionalConfig>
@@ -475,22 +476,118 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         }
 
         [Fact]
+        public void AddJobTaskDefinition_DuplicateJobTaskDefinitionException()
+        {
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
+            {
+                JobDefinitionId = 1,
+                Name = "Generate",
+                Type = JobTaskDefinitionType.Push,
+                AdditionalConfigString = "{}",
+                Provider = "GitHubProvider"
+            }));
+
+            Assert.IsType<DuplicateJobTaskDefinitionException>(exception?.Result);
+        }
+
+        [Fact]
+        public void AddJobTaskDefinition_InvalidPluginTypeException()
+        {
+            _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = "InvalidType" });
+
+            _pluginAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<PluginAdditionalConfig>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginAdditionalConfig>
+                {
+                    new PluginAdditionalConfig
+                    {
+                        Id = 1,
+                        Name = "testconfig",
+                        IsRequired = true
+                    }
+                });
+
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
+            {
+                JobDefinitionId = 1,
+                Type = JobTaskDefinitionType.Push,
+                AdditionalConfigString = "{}",
+                Provider = "GitHubProvider"
+            }));
+
+            Assert.IsType<InvalidPluginTypeException>(exception?.Result);
+        }
+
+        [Fact]
+        public void AddJobTaskDefinition_IncorrectTaskType_InvalidPluginTypeException()
+        {
+            _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Plugin { Id = 3, Name = "VstsBuildProvider", Type = PluginType.BuildProvider });
+
+            _pluginAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<PluginAdditionalConfig>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginAdditionalConfig>
+                {
+                    new PluginAdditionalConfig
+                    {
+                        Id = 1,
+                        Name = "testconfig",
+                        IsRequired = true
+                    }
+                });
+
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
+            {
+                JobDefinitionId = 1,
+                Type = JobTaskDefinitionType.Push,
+                AdditionalConfigString = "{}",
+                Provider = "VstsBuildProvider"
+            }));
+
+            Assert.IsType<InvalidPluginTypeException>(exception?.Result);
+
+            var invalidPluginTypeException = exception?.Result as InvalidPluginTypeException;
+            Assert.NotEmpty(invalidPluginTypeException.TaskTypes);
+        }
+
+        [Fact]
         public async void AddJobTaskDefinitions_ValidItem()
         {
+            _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Plugin { Id = 3, Name = "GitHubProvider", Type = PluginType.RepositoryProvider, RequiredServicesString = "GitHub" });
+            
+            _externalServiceRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<ExternalService>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                new ExternalService
+                {
+                    Id = 3,
+                    Name = "github-default",
+                    ExternalServiceTypeId = 1,
+                    ExternalServiceType = new ExternalServiceType
+                    {
+                        Id = 1,
+                        Name = "GitHub"
+                    }
+                });
+
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
             var newIds = await projectJobDefinitionService.AddJobTaskDefinitions(1, new List<JobTaskDefinition>
             {
                 new JobTaskDefinition
                 {
                     JobDefinitionId = 1,
-                    Type = JobTaskDefinitionType.Push,
-                    ConfigString = "test"
+                    Type = JobTaskDefinitionType.Clone,
+                    Provider = "GitHubProvider",
+                    ConfigString = @"{""GitHubExternalService"":""github-default""}"
                 },
                 new JobTaskDefinition
                 {
                     JobDefinitionId = 1,
-                    Type = JobTaskDefinitionType.Build,
-                    ConfigString = "test2"
+                    Type = JobTaskDefinitionType.Push,
+                    Provider = "GitHubProvider",
+                    ConfigString = @"{""GitHubExternalService"":""github-default""}"
                 }
             });
 
@@ -592,12 +689,16 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void UpdateJobTaskDefinition_ValidItem()
         {
+            _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Plugin { Id = 3, Name = "AspMvcNetCore", Type = PluginType.GeneratorProvider });
+
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _pluginRepository.Object, _externalServiceRepository.Object, _pluginAdditionalConfigRepository.Object, _secretVault.Object);
             await projectJobDefinitionService.UpdateJobTaskDefinition(new JobTaskDefinition
             {
                 Id = 1,
                 JobDefinitionId = 1,
                 Type = JobTaskDefinitionType.Generate,
+                Provider = "AspMvcNetCore",
                 ConfigString = "testUpdated"
             });
 
@@ -609,6 +710,9 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public async void UpdateJobTaskConfig_ValidItem()
         {
+            _pluginRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<Plugin>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Plugin { Id = 3, Name = "AspMvcNetCore", Type = PluginType.GeneratorProvider });
+
             var updatedConfig = new Dictionary<string, string>()
             {
                 {"config1", "config 1 value"}

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
@@ -578,6 +578,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 new JobTaskDefinition
                 {
                     JobDefinitionId = 1,
+                    Name = "Clone",
                     Type = JobTaskDefinitionType.Clone,
                     Provider = "GitHubProvider",
                     ConfigString = @"{""GitHubExternalService"":""github-default""}"
@@ -585,6 +586,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 new JobTaskDefinition
                 {
                     JobDefinitionId = 1,
+                    Name = "Push",
                     Type = JobTaskDefinitionType.Push,
                     Provider = "GitHubProvider",
                     ConfigString = @"{""GitHubExternalService"":""github-default""}"


### PR DESCRIPTION
## Summary
Implement the unique name validation and provider validation against the task type, when adding/updating task in the API

## Related issue
- #147 