### PR TITLE
Fix the catapult engine update repo method

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Data/CatapultEngineRepository.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/CatapultEngineRepository.cs
@@ -139,17 +139,12 @@ namespace Polyrific.Catapult.Api.Data
             cancellationToken.ThrowIfCancellationRequested();
 
             var user = await _userManager.Users.Include(u => u.CatapultEngineProfile).FirstOrDefaultAsync(u => u.Id == entity.Id, cancellationToken);
-            if (user != null)
+            if (user != null && user.CatapultEngineProfile != null)
             {
-                _mapper.Map(entity, user);
-
-                await _userManager.UpdateAsync(user);
-
-                if (user.CatapultEngineProfile != null)
-                {
-                    _mapper.Map(entity, user.CatapultEngineProfile);
-                    await _profileRepository.Update(user.CatapultEngineProfile, cancellationToken);
-                }
+                user.CatapultEngineProfile.LastSeen = entity.LastSeen;
+                user.CatapultEngineProfile.Updated = DateTime.UtcNow;
+                user.CatapultEngineProfile.ConcurrencyStamp = Guid.NewGuid().ToString();
+                await _profileRepository.Update(user.CatapultEngineProfile, cancellationToken);
             }
         }
 

--- a/src/API/Polyrific.Catapult.Api.Data/CatapultEngineRepository.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/CatapultEngineRepository.cs
@@ -141,7 +141,7 @@ namespace Polyrific.Catapult.Api.Data
             var user = await _userManager.Users.Include(u => u.CatapultEngineProfile).FirstOrDefaultAsync(u => u.Id == entity.Id, cancellationToken);
             if (user != null && user.CatapultEngineProfile != null)
             {
-                user.CatapultEngineProfile.LastSeen = entity.LastSeen;
+                _mapper.Map(entity, user.CatapultEngineProfile);
                 user.CatapultEngineProfile.Updated = DateTime.UtcNow;
                 user.CatapultEngineProfile.ConcurrencyStamp = Guid.NewGuid().ToString();
                 await _profileRepository.Update(user.CatapultEngineProfile, cancellationToken);

--- a/src/API/Polyrific.Catapult.Api.Data/Identity/IdentityAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Identity/IdentityAutoMapperProfile.cs
@@ -41,7 +41,13 @@ namespace Polyrific.Catapult.Api.Data.Identity
                 .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.UserName))
                 .ForMember(dest => dest.LastSeen, opt => opt.MapFrom(src => src.CatapultEngineProfile.LastSeen));
             CreateMap<CatapultEngine, CatapultEngineProfile>()
-                .ForMember(dest => dest.LastSeen, opt => opt.MapFrom(src => src.LastSeen));
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.Created, opt => opt.Ignore())
+                .ForMember(dest => dest.Updated, opt => opt.Ignore())
+                .ForMember(dest => dest.ConcurrencyStamp, opt => opt.Ignore())
+                .ForMember(dest => dest.IsActive, opt => opt.Ignore())
+                .ForMember(dest => dest.CatapultEngineId, opt => opt.Ignore())
+                .ForMember(dest => dest.CatapultEngine, opt => opt.Ignore());
         }
     }
 }


### PR DESCRIPTION
## Summary
Fix the issue when updating engine's `LastSeen` in `CheckJob` endpoint.
The update catapult engine repository should only be for `LastSeen`, since the `IsActive` is being modified by `Suspend`/`Activate`, and the Engine's name is the Identity username, and should not be changed.

## Related issue
- #167 