### PR TITLE
add FlushAsync in stream writer

### DIFF
--- a/src/Shared/Polyrific.Catapult.Shared.Common/FileHelper.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/FileHelper.cs
@@ -26,6 +26,8 @@ namespace Polyrific.Catapult.Shared.Common
             using (var writer = File.CreateText(path))
             {
                 await writer.WriteAsync(content);
+
+                await writer.FlushAsync();
             }
         }
 
@@ -34,6 +36,8 @@ namespace Polyrific.Catapult.Shared.Common
             using (var writer = File.AppendText(path))
             {
                 await writer.WriteAsync(content);
+
+                await writer.FlushAsync();
             }
         }
     }


### PR DESCRIPTION
## Summary
Add `FlushAsync` before disposing stream writer as suggested in https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/93e39b8f48169cce4803615519ef87bb2a969c8e/AsyncGuidance.md#always-call-flushasync-on-streamwriters-or-streams-before-calling-dispose