### PR TITLE
Improve console messages in cli and engine

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/AddCommand.cs
@@ -291,7 +291,7 @@ namespace Polyrific.Catapult.Cli.Commands.Task
             string input = null;
             bool validInput;
 
-            string prompt = $"{propertyName}{(required ? " (Required):" : ":")}";
+            string prompt = $"{propertyName}{(required ? " (Required):" : " (Leave blank to use default value):")}";
             if (!properties.Any(p => p.Item1 == propertyName))
             {
                 if (!_firstConfigPrompt)

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
@@ -61,7 +61,20 @@ namespace Polyrific.Catapult.Engine.Commands
             {
                 Console.WriteLine($"Job queue {jobQueue.Code} is ready to be executed.");
                 _engine.ExecuteJob(jobQueue).Wait();
-                Console.WriteLine($"Job queue {jobQueue.Code} execution has completed {(jobQueue.Status == JobStatus.Error ? "with error. Please check the job queue's log." : ".")}");
+
+                switch (jobQueue.Status)
+                {
+                    case JobStatus.Pending:
+                        Console.WriteLine($"Job queue {jobQueue.Code} execution is being halted. Please restart the job when it's ready.");
+                        break;
+                    case JobStatus.Completed:
+                        Console.WriteLine($"Job queue {jobQueue.Code} execution has completed.");
+                        break;
+                    default:
+                        Console.WriteLine($"Job queue {jobQueue.Code} execution has completed with error. Please check the job queue's log.");
+                        break;
+                }
+
                 Console.WriteLine("Engine is waiting for a job to execute..");
             }
             else

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
@@ -3,6 +3,7 @@
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Engine.Core;
+using Polyrific.Catapult.Shared.Dto.Constants;
 using System;
 using System.Timers;
 
@@ -60,7 +61,8 @@ namespace Polyrific.Catapult.Engine.Commands
             {
                 Console.WriteLine($"Job queue {jobQueue.Code} is ready to be executed.");
                 _engine.ExecuteJob(jobQueue).Wait();
-                Console.WriteLine($"Job queue {jobQueue.Code} execution has completed.");
+                Console.WriteLine($"Job queue {jobQueue.Code} execution has completed {(jobQueue.Status == JobStatus.Error ? "with error. Please check the job queue's log." : ".")}");
+                Console.WriteLine("Engine is waiting for a job to execute..");
             }
             else
             {


### PR DESCRIPTION
## Summary
- Add remarks in task config prompt ("Leave blank to use default value)")
- Show "Engine is waiting for a job to execute.." message after a job has been executed
- Modify the job completed message when there's an error with the job, or the job is pending