### PR TITLE
Fix build script api does not properly update appsettings

### DIFF
--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -46,7 +46,7 @@ if ($connString -ne $currentConnString) {
     $appSettingsFile.ConnectionStrings.DefaultConnection = $connString
 
     try {
-        $appSettingsFile | ConvertTo-Json | Out-File -FilePath $appSettingsPath -Encoding utf8 -Force    
+        $appSettingsFile | ConvertTo-Json -Depth 10 | Out-File -FilePath $appSettingsPath -Encoding utf8 -Force    
     }
     catch {
         Write-Error -Message "[ERROR] $_" -ErrorAction Stop


### PR DESCRIPTION
## Summary
Fix `build-api.ps1` does not serialize the appsettings properly because the default depth of ConvertTo-Json is 2.