### PR TITLE
Fix cli getting 404 when connecting to SignalR

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/JobQueueLogListener/SignalRJobQueueLogListener.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/JobQueueLogListener/SignalRJobQueueLogListener.cs
@@ -22,7 +22,7 @@ namespace Polyrific.Catapult.Cli
         public async Task Listen(int jobQueueId, Action<string> onLogReceived, Action<string> onError)
         {
             var jobQueueCompleted = new TaskCompletionSource<bool>();
-            var connection = GetConnection($"{_config.ApiUrl}/{JobQueueHubEndpoint}?jobQueueId={jobQueueId}");
+            var connection = GetConnection(new Uri(_config.ApiUrl, $"{JobQueueHubEndpoint}?jobQueueId={jobQueueId}").AbsoluteUri);
 
             connection.On<string>("ReceiveInitialMessage", (initialMessage) =>
             {


### PR DESCRIPTION
## Summary
Fix the error that occured when CLI trying to connect to the SignalR hub and getting the http 404 error. It turns out the url it was trying to connect have additional slash ('/'): e.g. https://localhost:44305//jobQueueHub?jobQueueId=1

## Related issue
- #178 