### PR TITLE
Remove the --all option in config command

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Config/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Config/GetCommand.cs
@@ -17,9 +17,6 @@ namespace Polyrific.Catapult.Cli.Commands.Config
             _cliConfig = cliConfig;
         }
 
-        [Option("-a|--all", "Display all configuration items", CommandOptionType.NoValue)]
-        public bool GetAll { get; set; }
-
         [Option("-n|--name <NAME>", "Name of the config", CommandOptionType.SingleValue)]
         public string ConfigName { get; set; }
 
@@ -29,7 +26,13 @@ namespace Polyrific.Catapult.Cli.Commands.Config
 
             _cliConfig.Load();
 
-            if (GetAll)
+            if (!string.IsNullOrEmpty(ConfigName))
+            {
+                var value = _cliConfig.GetValue(ConfigName);
+                if (!string.IsNullOrEmpty(value))
+                    message = $"{ConfigName}: {value}";
+            }
+            else
             {
                 var sb = new StringBuilder();
                 sb.AppendLine("Available CLI configs:");
@@ -39,12 +42,6 @@ namespace Polyrific.Catapult.Cli.Commands.Config
                 }
 
                 message = sb.ToString();
-            }
-            else if (!string.IsNullOrEmpty(ConfigName))
-            {
-                var value = _cliConfig.GetValue(ConfigName);
-                if (!string.IsNullOrEmpty(value))
-                    message = $"{ConfigName}: {value}";
             }
 
             return message;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Config/SetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Config/SetCommand.cs
@@ -22,9 +22,6 @@ namespace Polyrific.Catapult.Cli.Commands.Config
             _cliConfig = cliConfig;
         }
 
-        [Option("-a|--all", "Set all configurations", CommandOptionType.NoValue)]
-        public bool SetAll { get; set; }
-
         [Option("-n|--name <NAME>", "Name of the config", CommandOptionType.SingleValue)]
         public string ConfigName { get; set; }
 
@@ -37,7 +34,20 @@ namespace Polyrific.Catapult.Cli.Commands.Config
 
             _cliConfig.Load();
 
-            if (SetAll)
+            if (!string.IsNullOrEmpty(ConfigName) && !string.IsNullOrEmpty(ConfigValue))
+            {
+
+                _cliConfig.SetValue(ConfigName, ConfigValue);
+                _cliConfig.Save();
+
+                message = $"The value of \"{ConfigName}\" has been set to \"{ConfigValue}\".";
+                Logger.LogInformation(message);
+            }
+            else if (!string.IsNullOrEmpty(ConfigName) || !string.IsNullOrEmpty(ConfigValue))
+            {
+                return message;
+            }
+            else
             {
                 Console.WriteLine("Please enter the value for each config item below, or press ENTER if no changes needed:");
 
@@ -72,15 +82,6 @@ namespace Polyrific.Catapult.Cli.Commands.Config
 
                 message = "Config values have been saved successfully.";
                 Logger.LogInformation($"Config values have been modified: {JsonConvert.SerializeObject(modifiedConfigs)}");
-            }
-            else if (!string.IsNullOrEmpty(ConfigName) && !string.IsNullOrEmpty(ConfigValue))
-            {
-
-                _cliConfig.SetValue(ConfigName, ConfigValue);
-                _cliConfig.Save();
-
-                message = $"The value of \"{ConfigName}\" has been set to \"{ConfigValue}\".";
-                Logger.LogInformation(message);
             }
 
             return message;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/Config/GetCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/Config/GetCommand.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Text;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Engine.Core;
-using Polyrific.Catapult.Engine.Core.Exceptions;
-using System.Text;
 
 namespace Polyrific.Catapult.Engine.Commands.Config
 {
@@ -18,9 +17,6 @@ namespace Polyrific.Catapult.Engine.Commands.Config
         {
             _engineConfig = engineConfig;
         }
-
-        [Option("-a|--all", "Display all configuration items", CommandOptionType.NoValue)]
-        public bool GetAll { get; set; }
         
         [Option("-n|--name <NAME>", "Name of the config", CommandOptionType.SingleValue)]
         public string ConfigName { get; set; }
@@ -31,7 +27,13 @@ namespace Polyrific.Catapult.Engine.Commands.Config
             
             _engineConfig.Load();
 
-            if (GetAll)
+            if (!string.IsNullOrEmpty(ConfigName))
+            {
+                var value = _engineConfig.GetValue(ConfigName);
+                if (!string.IsNullOrEmpty(value))
+                    message = $"{ConfigName}: {value}";
+            }
+            else
             {
                 var sb = new StringBuilder();
                 sb.AppendLine("Available Engine configs:");
@@ -41,12 +43,6 @@ namespace Polyrific.Catapult.Engine.Commands.Config
                 }
 
                 message = sb.ToString();
-            }
-            else if (!string.IsNullOrEmpty(ConfigName))
-            {
-                var value = _engineConfig.GetValue(ConfigName);
-                if (!string.IsNullOrEmpty(value))
-                    message = $"{ConfigName}: {value}";
             }
 
             return message;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/Config/SetCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/Config/SetCommand.cs
@@ -22,9 +22,6 @@ namespace Polyrific.Catapult.Engine.Commands.Config
         {
             _engineConfig = engineConfig;
         }
-
-        [Option("-a|--all", "Set all configurations", CommandOptionType.NoValue)]
-        public bool SetAll { get; set; }
         
         [Option("-n|--name <NAME>", "Name of the config", CommandOptionType.SingleValue)]
         public string ConfigName { get; set; }
@@ -38,7 +35,20 @@ namespace Polyrific.Catapult.Engine.Commands.Config
 
             _engineConfig.Load();
 
-            if (SetAll)
+            if (!string.IsNullOrEmpty(ConfigName) && !string.IsNullOrEmpty(ConfigValue))
+            {
+            
+                _engineConfig.SetValue(ConfigName, ConfigValue);
+                _engineConfig.Save();
+
+                message = $"The value of \"{ConfigName}\" has been set to \"{ConfigValue}\".";
+                Logger.LogInformation(message);
+            }
+            else if (!string.IsNullOrEmpty(ConfigName) || !string.IsNullOrEmpty(ConfigValue))
+            {
+                return message;
+            }
+            else
             {
                 Console.WriteLine("Please enter the value for each config item below, or press ENTER if no changes needed:");
 
@@ -73,15 +83,6 @@ namespace Polyrific.Catapult.Engine.Commands.Config
 
                 message = "Config values have been saved successfully.";
                 Logger.LogInformation($"Config values have been modified: {JsonConvert.SerializeObject(modifiedConfigs)}");
-            }
-            else if (!string.IsNullOrEmpty(ConfigName) && !string.IsNullOrEmpty(ConfigValue))
-            {
-            
-                _engineConfig.SetValue(ConfigName, ConfigValue);
-                _engineConfig.Save();
-
-                message = $"The value of \"{ConfigName}\" has been set to \"{ConfigValue}\".";
-                Logger.LogInformation(message);
             }
 
             return message;

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ConfigCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ConfigCommandTests.cs
@@ -64,10 +64,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         public void ConfigGet_GetAll_Execute_ReturnsItems()
         {
             var console = new TestConsole(_output);
-            var command = new GetCommand(_cliConfig.Object, console, (new Mock<ILogger<GetCommand>>()).Object)
-            {
-                GetAll = true
-            };
+            var command = new GetCommand(_cliConfig.Object, console, (new Mock<ILogger<GetCommand>>()).Object);
 
             var message = command.Execute();
 
@@ -184,10 +181,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         public void ConfigSet_SetAll_Execute_ReturnsSuccess()
         {
             var console = new TestConsole(_output, "config value edited");
-            var command = new SetCommand(_cliConfig.Object, console, (new Mock<ILogger<SetCommand>>()).Object)
-            {
-                SetAll = true
-            };
+            var command = new SetCommand(_cliConfig.Object, console, (new Mock<ILogger<SetCommand>>()).Object);
 
             var message = command.Execute();
 

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Commands/ConfigCommandTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Commands/ConfigCommandTests.cs
@@ -65,10 +65,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Commands
         public void ConfigGet_GetAll_Execute_ReturnsItems()
         {
             var console = new TestConsole(_output);
-            var command = new GetCommand(_engineConfig.Object, console, (new Mock<ILogger<GetCommand>>()).Object)
-            {
-                GetAll = true
-            };
+            var command = new GetCommand(_engineConfig.Object, console, (new Mock<ILogger<GetCommand>>()).Object);
 
             var message = command.Execute();
 
@@ -185,10 +182,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Commands
         public void ConfigSet_SetAll_Execute_ReturnsSuccess()
         {
             var console = new TestConsole(_output, "config value edited");
-            var command = new SetCommand(_engineConfig.Object, console, (new Mock<ILogger<SetCommand>>()).Object)
-            {
-                SetAll = true
-            };
+            var command = new SetCommand(_engineConfig.Object, console, (new Mock<ILogger<SetCommand>>()).Object);
 
             var message = command.Execute();
 


### PR DESCRIPTION
## Summary
Remove the --all option in config command for CLI and Engine. It should automatically get/set all config when `--name` option is not set

## Related issue
- #190 