### PR TITLE
Remove ConnectionString additional config for AspNetCoreMvc

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginAdditionalConfigConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginAdditionalConfigConfig.cs
@@ -12,17 +12,27 @@ namespace Polyrific.Catapult.Api.Data.EntityConfigs
         {
             base.Configure(builder);
 
+            // Additional configs for AspNetCoreMvc plugin
             builder.HasData(
-                new PluginAdditionalConfig { Id = 1, PluginId = 1, Name = "AdminEmail", Label = "Admin Email", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382258" },
+                new PluginAdditionalConfig { Id = 1, PluginId = 1, Name = "AdminEmail", Label = "Admin Email", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382258" }
+            );
 
+            // Additional configs for DotNetCoreBuildProvider plugin
+            builder.HasData(
                 new PluginAdditionalConfig { Id = 2, PluginId = 3, Name = "CsprojLocation", Label = "Csproj Location", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382259" },
-                new PluginAdditionalConfig { Id = 3, PluginId = 3, Name = "Configuration", Label = "Configuration", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225a" },
+                new PluginAdditionalConfig { Id = 3, PluginId = 3, Name = "Configuration", Label = "Configuration", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225a" }
+            );
 
+            // Additional configs for EntityFrameworkCore plugin
+            builder.HasData(
                 new PluginAdditionalConfig { Id = 4, PluginId = 5, Name = "StartupProjectName", Label = "Startup Project Name", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225b" },
                 new PluginAdditionalConfig { Id = 5, PluginId = 5, Name = "DatabaseProjectName", Label = "Database Project Name", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225c" },
                 new PluginAdditionalConfig { Id = 6, PluginId = 5, Name = "ConnectionString", Label = "Connection String", Type = "string", IsRequired = true, IsSecret = true, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382262" },
-                new PluginAdditionalConfig { Id = 7, PluginId = 5, Name = "Configuration", Label = "Configuration", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225d" },
+                new PluginAdditionalConfig { Id = 7, PluginId = 5, Name = "Configuration", Label = "Configuration", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225d" }
+            );
 
+            // Additional configs for AzureAppService plugin
+            builder.HasData(
                 new PluginAdditionalConfig { Id = 8, PluginId = 6, Name = "SubscriptionId", Label = "Subscription Id", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225e" },
                 new PluginAdditionalConfig { Id = 9, PluginId = 6, Name = "ResourceGroupName", Label = "Resource Group", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225f" },
                 new PluginAdditionalConfig { Id = 10, PluginId = 6, Name = "AppServiceName", Label = "App Service", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382260" },

--- a/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginAdditionalConfigConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginAdditionalConfigConfig.cs
@@ -13,7 +13,7 @@ namespace Polyrific.Catapult.Api.Data.EntityConfigs
             base.Configure(builder);
 
             builder.HasData(
-                new PluginAdditionalConfig { Id = 1, PluginId = 1, Name = "ConnectionString", Label = "Connection String", Type = "string", IsRequired = true, IsSecret = true, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382258" },
+                new PluginAdditionalConfig { Id = 1, PluginId = 1, Name = "AdminEmail", Label = "Admin Email", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382258" },
 
                 new PluginAdditionalConfig { Id = 2, PluginId = 3, Name = "CsprojLocation", Label = "Csproj Location", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382259" },
                 new PluginAdditionalConfig { Id = 3, PluginId = 3, Name = "Configuration", Label = "Configuration", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225a" },
@@ -26,8 +26,7 @@ namespace Polyrific.Catapult.Api.Data.EntityConfigs
                 new PluginAdditionalConfig { Id = 8, PluginId = 6, Name = "SubscriptionId", Label = "Subscription Id", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225e" },
                 new PluginAdditionalConfig { Id = 9, PluginId = 6, Name = "ResourceGroupName", Label = "Resource Group", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f3040438225f" },
                 new PluginAdditionalConfig { Id = 10, PluginId = 6, Name = "AppServiceName", Label = "App Service", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382260" },
-                new PluginAdditionalConfig { Id = 11, PluginId = 6, Name = "DeploymentSlot", Label = "Deployment Slot", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382261" },
-                new PluginAdditionalConfig { Id = 12, PluginId = 1, Name = "AdminEmail", Label = "Admin Email", Type = "string", IsRequired = true, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382300" }
+                new PluginAdditionalConfig { Id = 11, PluginId = 6, Name = "DeploymentSlot", Label = "Deployment Slot", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382261" }
             );
         }
     }

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20181106003829_RemoveConnStringAdditionalConfig.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20181106003829_RemoveConnStringAdditionalConfig.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181106003829_RemoveConnStringAdditionalConfig")]
+    partial class RemoveConnStringAdditionalConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20181106003829_RemoveConnStringAdditionalConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20181106003829_RemoveConnStringAdditionalConfig.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class RemoveConnStringAdditionalConfig : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "PluginAdditionalConfigs",
+                keyColumns: new[] { "Id", "ConcurrencyStamp" },
+                keyValues: new object[] { 12, "c48cafcc-b3e9-4375-a2c2-f30404382300" });
+
+            migrationBuilder.UpdateData(
+                table: "PluginAdditionalConfigs",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "ConcurrencyStamp", "IsSecret", "Label", "Name" },
+                values: new object[] { "c48cafcc-b3e9-4375-a2c2-f30404382258", false, "Admin Email", "AdminEmail" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "PluginAdditionalConfigs",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "ConcurrencyStamp", "IsSecret", "Label", "Name" },
+                values: new object[] { "c48cafcc-b3e9-4375-a2c2-f30404382258", true, "Connection String", "ConnectionString" });
+
+            migrationBuilder.InsertData(
+                table: "PluginAdditionalConfigs",
+                columns: new[] { "Id", "ConcurrencyStamp", "Created", "IsRequired", "IsSecret", "Label", "Name", "PluginId", "Type", "Updated" },
+                values: new object[] { 12, "c48cafcc-b3e9-4375-a2c2-f30404382300", new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), true, false, "Admin Email", "AdminEmail", 1, "string", null });
+        }
+    }
+}

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/plugin.yml
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/plugin.yml
@@ -3,11 +3,6 @@ type: 'GeneratorProvider'
 author: 'Polyrific'
 version: '1.0'
 additional-configs:
-  - name: ConnectionString
-    label: Connection String
-    type: string
-    is-required: true
-    is-secret: true
   - name: AdminEmail
     label: Admin Email
     type: string

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGenerator.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGenerator.cs
@@ -24,7 +24,7 @@ namespace AspNetCoreMvc
         private readonly MainProjectGenerator _mainProjectGenerator;
         private readonly ILogger _logger;
         
-        public CodeGenerator(string projectName, string outputLocation, List<ProjectDataModelDto> models, string connectionString, 
+        public CodeGenerator(string projectName, string outputLocation, List<ProjectDataModelDto> models,
             string adminEmail, ILogger logger = null)
         {
             _projectName = TextHelper.Pascalize(projectName.Replace("-", "_"));
@@ -34,7 +34,7 @@ namespace AspNetCoreMvc
             _coreProjectGenerator = new CoreProjectGenerator(_projectName, _projectHelper, _models, logger);
             _dataProjectGenerator = new DataProjectGenerator(_projectName, _projectHelper, _models, adminEmail, logger);
             _infrastructureProjectGenerator = new InfrastructureProjectGenerator(_projectName, _projectHelper, _models, logger);
-            _mainProjectGenerator = new MainProjectGenerator(_projectName, _projectHelper, _models, connectionString, logger);
+            _mainProjectGenerator = new MainProjectGenerator(_projectName, _projectHelper, _models, logger);
             _logger = logger;
         }
 

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGeneratorProvider.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/CodeGeneratorProvider.cs
@@ -24,12 +24,11 @@ namespace AspNetCoreMvc
 
         public async Task<(string outputLocation, Dictionary<string, string> outputValues, string errorMessage)> Generate(string projectName, List<ProjectDataModelDto> models, GenerateTaskConfig config, Dictionary<string, string> additionalConfigs, ILogger logger)
         {
-            additionalConfigs.TryGetValue("ConnectionString", out var connectionString);
             additionalConfigs.TryGetValue("AdminEmail", out var adminEmail);
 
             config.OutputLocation = config.OutputLocation ?? config.WorkingLocation;
 
-            var generator = new CodeGenerator(projectName, config.OutputLocation, models, connectionString, adminEmail, logger);
+            var generator = new CodeGenerator(projectName, config.OutputLocation, models, adminEmail, logger);
 
             await generator.InitSolution();
 

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/MainProjectGenerator.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/src/ProjectGenerators/MainProjectGenerator.cs
@@ -19,7 +19,6 @@ namespace AspNetCoreMvc.ProjectGenerators
         private string _projectName;
         private readonly ProjectHelper _projectHelper;
         private readonly List<ProjectDataModelDto> _models;
-        private readonly string _connectionString;
         private readonly ILogger _logger;
 
         private string Name => $"{_projectName}";
@@ -35,12 +34,13 @@ namespace AspNetCoreMvc.ProjectGenerators
             }
         }
 
-        public MainProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models, string connectionString, ILogger logger)
+        private const string _connectionString = "Server=localhost;Database=opencatapult;User ID=sa;Password=samprod;";
+
+        public MainProjectGenerator(string projectName, ProjectHelper projectHelper, List<ProjectDataModelDto> models, ILogger logger)
         {
             _projectName = projectName;
             _projectHelper = projectHelper;
             _models = models;
-            _connectionString = connectionString;
             _logger = logger;
         }
 
@@ -1029,7 +1029,7 @@ namespace AspNetCoreMvc.ProjectGenerators
             sb.AppendLine("}");
             sb.AppendLine();
 
-            _projectHelper.AddFileToProject(Name, $"Startup.cs", sb.ToString());
+            _projectHelper.AddFileToProject(Name, $"Startup.cs", sb.ToString(), true);
             return Task.FromResult("Startup class generated");
         }
 
@@ -1068,7 +1068,7 @@ namespace AspNetCoreMvc.ProjectGenerators
             sb.AppendLine("}");
             sb.AppendLine();
 
-            _projectHelper.AddFileToProject(Name, $"Program.cs", sb.ToString());
+            _projectHelper.AddFileToProject(Name, $"Program.cs", sb.ToString(), true);
             return Task.FromResult("Program class generated");
         }
         #endregion

--- a/src/Plugins/GeneratorProvider/AspNetCoreMvc/tests/CodeGeneratorProviderTests.cs
+++ b/src/Plugins/GeneratorProvider/AspNetCoreMvc/tests/CodeGeneratorProviderTests.cs
@@ -35,10 +35,7 @@ namespace AspNetCoreMvc.Tests
                 OutputLocation = outputLocation
             };
 
-            var additionalConfig = new Dictionary<string, string>
-            {
-                { "ConnectionString", "Server=localhost;Database=generated.db;User ID=sa;Password=samprod;" }
-            };
+            var additionalConfig = new Dictionary<string, string>();
             
             if (Directory.Exists(outputLocation))
                 Directory.Delete(outputLocation, true);


### PR DESCRIPTION
## Summary
Since the connection string in the AspNetCoreMvc is only used for generating the migration script, and it's stored on temporary env variable and not appsettings.json, we can just use a dummy conn string, and free the trouble for user of inputting the conn string in the generator task.

## PR Coverage
- [x] Remove ConnectionString additional config for AspNetCoreMvc
- [x] Fix issue generator not generating migration script