### PR TITLE
Add nuspec for plugins abstraction

### DIFF
--- a/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Polyrific.Catapult.Plugins.Abstraction.csproj
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Polyrific.Catapult.Plugins.Abstraction.csproj
@@ -13,6 +13,8 @@
     <PackageProjectUrl>https://opencatapult.net</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Polyrific-Inc/OpenCatapult/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/Polyrific-Inc/OpenCatapult</RepositoryUrl>
+    <PackageIconUrl>https://opencatapult.net/img/opencatapult-logo.png</PackageIconUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Polyrific.Catapult.Plugins.Abstraction.nuspec
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Abstraction/Polyrific.Catapult.Plugins.Abstraction.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Polyrific.Catapult.Plugins.Abstraction</id>
+    <version>1.0.0</version>
+    <title>Polyrific.Catapult.Plugins.Abstraction</title>
+    <authors>frandi-polyrific</authors>
+    <owners>frandi-polyrific</owners>
+    <licenseUrl>https://github.com/Polyrific-Inc/OpenCatapult/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://opencatapult.net</projectUrl>
+    <iconUrl>https://opencatapult.net/img/opencatapult-logo.png</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Abstraction for OpenCatapult plugins, to be used as a contract between Engine and the plugins.</description>
+    <releaseNotes>Stable release</releaseNotes>
+    <copyright>Copyright (c) Polyrific, Inc 2018. All rights reserved</copyright>
+    <tags>catapult opencatapult devops plugins</tags>
+  </metadata>
+  <files>
+    <file src="bin\Release\Polyrific.Catapult.Shared.Dto.*"></file>
+  </files>
+</package>


### PR DESCRIPTION
## Summary
Add `nuspec` for `Polyrific.Catapult.Plugins.Abstraction`, to be packed as NuGet package.