### PR TITLE
Use published dll instead of source code when running db update

### DIFF
--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseCommand.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseCommand.cs
@@ -68,7 +68,7 @@ namespace EntityFrameworkCore
             }
 
             string pathToDotnet = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", "sdk");
-            var latestDotnet = Directory.EnumerateDirectories(pathToDotnet, "2.1*").LastOrDefault();
+            var latestDotnet = Directory.Exists(pathToDotnet) ? Directory.EnumerateDirectories(pathToDotnet, "2.1*").LastOrDefault() : null;
 
             if (latestDotnet != null)
             {
@@ -82,17 +82,15 @@ namespace EntityFrameworkCore
                     return pathToEf;
                 }
             }
-            else
-            {             
-                // option 3
-                dotnetEfFolder = Path.Combine(pathToDotnet, "NuGetFallbackFolder", "microsoft.entityframeworkcore.tools.dotnet");
-                latestEf = Directory.Exists(dotnetEfFolder) ? Directory.EnumerateDirectories(dotnetEfFolder).LastOrDefault() : null;
-                pathToEf = latestEf != null ? Path.Combine(latestEf, "tools\\netcoreapp2.0", "ef.dll") : null;
 
-                if (pathToEf != null && File.Exists(pathToEf))
-                {
-                    return pathToEf;
-                }
+            // option 3
+            dotnetEfFolder = Path.Combine(pathToDotnet, "NuGetFallbackFolder", "microsoft.entityframeworkcore.tools.dotnet");
+            latestEf = Directory.Exists(dotnetEfFolder) ? Directory.EnumerateDirectories(dotnetEfFolder).LastOrDefault() : null;
+            pathToEf = latestEf != null ? Path.Combine(latestEf, "tools\\netcoreapp2.0", "ef.dll") : null;
+
+            if (pathToEf != null && File.Exists(pathToEf))
+            {
+                return pathToEf;
             }
 
             return null;

--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseCommand.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseCommand.cs
@@ -57,28 +57,39 @@ namespace EntityFrameworkCore
 
         private string GetPathToEfDll()
         {
+            // option 1
+            string pathToNuget = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+            var dotnetEfFolder = Path.Combine(pathToNuget, "microsoft.entityframeworkcore.tools.dotnet");
+            var latestEf = Directory.Exists(dotnetEfFolder) ? Directory.EnumerateDirectories(dotnetEfFolder).LastOrDefault() : null;
+            var pathToEf = latestEf != null ? Path.Combine(latestEf, "tools\\netcoreapp2.0", "ef.dll") : null;
+            if (pathToEf != null && File.Exists(pathToEf))
+            {
+                return pathToEf;
+            }
+
             string pathToDotnet = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", "sdk");
             var latestDotnet = Directory.EnumerateDirectories(pathToDotnet, "2.1*").LastOrDefault();
-            string pathToEf = "";
 
             if (latestDotnet != null)
             {
-                // option 1
-                var dotnetEfFolder = Path.Combine(latestDotnet, "DotnetTools", "dotnet-ef");
-                var latestEf = Directory.EnumerateDirectories(dotnetEfFolder).LastOrDefault();
-                pathToEf = Path.Combine(latestEf, "tools\\netcoreapp2.1\\any\\tools\\netcoreapp2.0\\any", "ef.dll");
+                // option 2
+                dotnetEfFolder = Path.Combine(latestDotnet, "DotnetTools", "dotnet-ef");
+                latestEf = Directory.Exists(dotnetEfFolder) ? Directory.EnumerateDirectories(dotnetEfFolder).LastOrDefault() : null;
+                pathToEf = latestEf != null ? Path.Combine(latestEf, "tools\\netcoreapp2.1\\any\\tools\\netcoreapp2.0\\any", "ef.dll") : null;
 
-                if (File.Exists(pathToEf))
+                if (pathToEf != null && File.Exists(pathToEf))
                 {
                     return pathToEf;
                 }
-
-                // option 2
+            }
+            else
+            {             
+                // option 3
                 dotnetEfFolder = Path.Combine(pathToDotnet, "NuGetFallbackFolder", "microsoft.entityframeworkcore.tools.dotnet");
-                latestEf = Directory.EnumerateDirectories(dotnetEfFolder).LastOrDefault();
-                pathToEf = Path.Combine(latestEf, "tools\\netcoreapp2.0", "ef.dll");
+                latestEf = Directory.Exists(dotnetEfFolder) ? Directory.EnumerateDirectories(dotnetEfFolder).LastOrDefault() : null;
+                pathToEf = latestEf != null ? Path.Combine(latestEf, "tools\\netcoreapp2.0", "ef.dll") : null;
 
-                if (File.Exists(pathToEf))
+                if (pathToEf != null && File.Exists(pathToEf))
                 {
                     return pathToEf;
                 }

--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseProvider.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/src/DatabaseProvider.cs
@@ -39,8 +39,9 @@ namespace EntityFrameworkCore
             var startupProjectName = projectName;
             if (additionalConfigs != null && additionalConfigs.ContainsKey("StartupProjectName") && !string.IsNullOrEmpty(additionalConfigs["StartupProjectName"]))
                 startupProjectName = additionalConfigs["StartupProjectName"];
+            startupProjectName = $"{startupProjectName}.dll";
 
-            var migrationLocation = config.MigrationLocation ?? config.WorkingLocation;
+            var migrationLocation = config.MigrationLocation ?? Path.Combine(config.WorkingLocation, "publish");
 
             var startupProjectPath = Path.Combine(migrationLocation, startupProjectName);
             if (!Path.IsPathRooted(startupProjectPath))
@@ -49,6 +50,7 @@ namespace EntityFrameworkCore
             var dataProjectName = $"{projectName}.Data";
             if (additionalConfigs != null && additionalConfigs.ContainsKey("DatabaseProjectName") && !string.IsNullOrEmpty(additionalConfigs["DatabaseProjectName"]))
                 dataProjectName = additionalConfigs["DatabaseProjectName"];
+            dataProjectName = $"{dataProjectName}.dll";
 
             var dataProjectPath = Path.Combine(migrationLocation, dataProjectName);
             if (!Path.IsPathRooted(dataProjectPath))

--- a/src/Plugins/DatabaseProvider/EntityFrameworkCore/tests/DatabaseProviderTests.cs
+++ b/src/Plugins/DatabaseProvider/EntityFrameworkCore/tests/DatabaseProviderTests.cs
@@ -43,7 +43,7 @@ namespace DotNetCore.Tests
             var result = await provider.DeployDatabase("MyProject", taskConfig, additionalConfig, _logger.Object);
 
             Assert.Equal("", result.errorMessage);
-            Assert.Equal("MyProject.Data", result.databaseLocation);
+            Assert.Equal("MyProject.Data.dll", result.databaseLocation);
         }
     }
 }


### PR DESCRIPTION
## Summary
Use published dll instead of the source code to perform update database in DeployDb plugin