### PR TITLE
Add validation for plugins and external services when creating project

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
@@ -185,12 +185,14 @@ namespace Polyrific.Catapult.Cli.Commands.Project
 
             if (notExistPlugins.Count == 0)
             {
-                Console.WriteLine("All required plugins are registered.");
+                Logger.LogInformation("All required plugins are registered.");
                 return true;
             }
 
-            Console.WriteLine(
-                $"The following plugins need to be registered before continuing the project creation: {string.Join(", ", notExistPlugins)}");
+            var message = $"The following plugins need to be registered before continuing the project creation: {string.Join(", ", notExistPlugins)}";
+            Logger.LogInformation(message);
+            Console.WriteLine(message);
+
             return false;
         }
 
@@ -231,12 +233,14 @@ namespace Polyrific.Catapult.Cli.Commands.Project
 
             if (notExistServices.Count == 0)
             {
-                Console.WriteLine("All required external services are found.");
+                Logger.LogInformation("All required external services are found.");
                 return true;
             }
 
-            Console.WriteLine(
-                $"The following external services need to be added before continuing to create the project: {string.Join(", ", notExistServices)}");
+            var message = $"The following external services need to be added before continuing to create the project: {string.Join(", ", notExistServices)}";
+            Logger.LogInformation(message);
+            Console.WriteLine(message);
+                
             return false;
         }
 

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
@@ -9,6 +9,7 @@ using Polyrific.Catapult.Cli.Extensions;
 using Polyrific.Catapult.Shared.Dto;
 using Polyrific.Catapult.Shared.Dto.Constants;
 using Polyrific.Catapult.Shared.Dto.JobDefinition;
+using Polyrific.Catapult.Shared.Dto.Plugin;
 using Polyrific.Catapult.Shared.Dto.Project;
 using Polyrific.Catapult.Shared.Dto.ProjectDataModel;
 using Polyrific.Catapult.Shared.Service;
@@ -95,22 +96,25 @@ namespace Polyrific.Catapult.Cli.Commands.Project
 
         private string ValidateTask(List<CreateJobDefinitionWithTasksDto> jobs)
         {
-            string message = string.Empty;
+            var tasks = jobs.SelectMany(j => j.Tasks).ToArray();
 
-            var tasks = jobs.SelectMany(j => j.Tasks);
+            var isPluginOk = ValidatePlugins(tasks.Select(t => t.Provider), out var plugins);
+            if (!isPluginOk)
+                return "Please register the required plugins first by using \"plugin register\" command.";
+
+            var serviceTypeNames = plugins.SelectMany(p => p.RequiredServices);
+            var taskConfigs = tasks.Where(t => t.Configs != null)
+                .SelectMany(t => t.Configs)
+                .Where(tc => tc.Key.EndsWith("ExternalService"));
+            
+            var isExternalServiceOk = ValidateExternalServices(serviceTypeNames, taskConfigs.ToList());
+            if (!isExternalServiceOk)
+                return "Please add the required external services first by using \"service add\" command.";
 
             string repository = null;
             string isPrivateRepository = null;
             foreach (var task in tasks)
             {
-                var plugin = _pluginService.GetPluginByName(task.Provider).Result;
-
-                if (plugin == null)
-                {
-                    message = $"The provider \"{task.Provider}\" is not installed";
-                    return message;
-                }
-
                 // prompt for Repository config
                 if ((task.Type.ToLower() == JobTaskDefinitionType.Clone.ToLower() ||
                     task.Type.ToLower() == JobTaskDefinitionType.Push.ToLower() ||
@@ -126,56 +130,25 @@ namespace Polyrific.Catapult.Cli.Commands.Project
                 if (task.Type.ToLower() == JobTaskDefinitionType.Clone.ToLower() && !task.Configs.ContainsKey("IsPrivateRepository"))
                 {
                     if (string.IsNullOrEmpty(isPrivateRepository))
-                        isPrivateRepository = PromptTaskConfig("IsPrivateRepository", allowedValues: new string[] { "true", "false" });
+                        isPrivateRepository = PromptTaskConfig("IsPrivateRepository", allowedValues: new[] { "true", "false" });
 
                     task.Configs["IsPrivateRepository"] = isPrivateRepository;
                 }
 
-                if (plugin.RequiredServices != null && plugin.RequiredServices.Length > 0)
-                {
-                    foreach (var service in plugin.RequiredServices)
-                    {
-                        var externalServiceKey = $"{service}ExternalService";
-                        var externalServiceName = task.Configs.GetValueOrDefault(externalServiceKey);
-
-                        if (string.IsNullOrEmpty(externalServiceName))
-                        {
-                            message = $"The {service} external service is required for the provider {task.Provider}. Please check the template file";
-                            return message;
-                        }
-
-                        var externalService = _externalServiceService.GetExternalServiceByName(externalServiceName).Result;
-
-                        if (externalService == null)
-                        {
-                            message = $"The external service {externalServiceName} is not found. Please add them using \"service add\" command";
-                            return message;
-                        }
-
-                        if (externalService.ExternalServiceTypeName != service)
-                        {
-                            message = $"The external service {externalServiceName} is not a {service} service";
-                            return message;
-                        }
-                    }
-                }
-
-                if (plugin.AdditionalConfigs != null && plugin.AdditionalConfigs.Length > 0)
+                // prompt for plugin additional configs
+                var plugin = plugins.FirstOrDefault(p => p.Name == task.Provider);
+                if (plugin?.AdditionalConfigs != null && plugin.AdditionalConfigs.Length > 0)
                 {
                     task.AdditionalConfigs = new Dictionary<string, string>();
                     Console.WriteLine($"The provider \"{plugin.Name}\" have some additional config(s):");
                     foreach (var additionalConfig in plugin.AdditionalConfigs)
                     {
-                        string input = string.Empty;
+                        string input;
                         string prompt = $"{(!string.IsNullOrEmpty(additionalConfig.Label) ? additionalConfig.Label : additionalConfig.Name)}{(additionalConfig.IsRequired ? " (Required):" : " (Leave blank to use default value):")}";
 
                         do
                         {
-                            if (additionalConfig.IsSecret)
-                                input = _consoleReader.GetPassword(prompt);
-                            else
-                                input = Console.GetString(prompt);
-
+                            input = additionalConfig.IsSecret ? _consoleReader.GetPassword(prompt) : Console.GetString(prompt);
                         } while (additionalConfig.IsRequired && string.IsNullOrEmpty(input));
 
                         if (!string.IsNullOrEmpty(input))
@@ -184,12 +157,92 @@ namespace Polyrific.Catapult.Cli.Commands.Project
                 }
             }
 
-            return message;
+            return "";
+        }
+
+        private bool ValidatePlugins(IEnumerable<string> pluginNames, out List<PluginDto> plugins)
+        {
+            plugins = new List<PluginDto>();
+            var notExistPlugins = new List<string>();
+
+            if (Verbose)
+                Console.WriteLine("The project requires the following plugins:");
+            
+            foreach (var pluginName in pluginNames.Distinct())
+            {
+                var plugin = _pluginService.GetPluginByName(pluginName).Result;
+                if (plugin == null)
+                    notExistPlugins.Add(pluginName);
+                else
+                    plugins.Add(plugin);
+
+                if (Verbose)
+                {
+                    var status = plugin != null ? "OK" : "NOT REGISTERED";
+                    Console.WriteLine($"- {pluginName}: {status}");
+                }
+            }
+
+            if (notExistPlugins.Count == 0)
+            {
+                Console.WriteLine("All required plugins are registered.");
+                return true;
+            }
+
+            Console.WriteLine(
+                $"The following plugins need to be registered before continuing the project creation: {string.Join(", ", notExistPlugins)}");
+            return false;
+        }
+
+        private bool ValidateExternalServices(IEnumerable<string> serviceTypeNames, List<KeyValuePair<string, string>> taskConfigs)
+        {
+            var notExistServices = new List<string>();
+            
+            if (Verbose)
+                Console.WriteLine("The project requires the following external services:");
+
+            foreach (var serviceType in serviceTypeNames.Distinct())
+            {
+                var extServiceKey = $"{serviceType}ExternalService";
+                var extServiceValue = "";
+                if (taskConfigs.Exists(tc => tc.Key == extServiceKey))
+                    extServiceValue = taskConfigs.First(tc => tc.Key == extServiceKey).Value;
+
+                if (string.IsNullOrEmpty(extServiceValue))
+                {
+                    notExistServices.Add($"(type = {serviceType})");
+
+                    if (Verbose)
+                        Console.WriteLine($"- (type = {serviceType}): NOT FOUND");
+                }
+                else
+                {
+                    var extService = _externalServiceService.GetExternalServiceByName(extServiceValue).Result;
+                    if (extService == null)
+                        notExistServices.Add($"{extServiceValue} (type = {serviceType})");
+
+                    if (Verbose)
+                    {
+                        var status = extService != null ? "OK" : "NOT FOUND";
+                        Console.WriteLine($"- {extServiceValue} (type = {serviceType}): {status}");
+                    }
+                }
+            }
+
+            if (notExistServices.Count == 0)
+            {
+                Console.WriteLine("All required external services are found.");
+                return true;
+            }
+
+            Console.WriteLine(
+                $"The following external services need to be added before continuing to create the project: {string.Join(", ", notExistServices)}");
+            return false;
         }
 
         private string PromptTaskConfig(string propertyName, string[] allowedValues = null)
         {
-            string input = null;
+            string input;
             bool validInput;
 
             string prompt = $"{propertyName} (Required):";

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
@@ -102,7 +102,7 @@ namespace Polyrific.Catapult.Cli.Commands.Project
             if (!isPluginOk)
                 return "Please register the required plugins first by using \"plugin register\" command.";
 
-            var serviceTypeNames = plugins.SelectMany(p => p.RequiredServices);
+            var serviceTypeNames = plugins.Where(p => p.RequiredServices != null).SelectMany(p => p.RequiredServices);
             var taskConfigs = tasks.Where(t => t.Configs != null)
                 .SelectMany(t => t.Configs)
                 .Where(tc => tc.Key.EndsWith("ExternalService"));

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ProjectCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/ProjectCommandTests.cs
@@ -273,7 +273,7 @@ jobs:
 
             var resultMessage = command.Execute();
 
-            Assert.Equal("The provider \"AspNetCoreMvc2\" is not installed", resultMessage);
+            Assert.Equal("Please register the required plugins first by using \"plugin register\" command.", resultMessage);
         }
 
         [Fact]
@@ -305,75 +305,9 @@ jobs:
 
             var resultMessage = command.Execute();
 
-            Assert.Equal("The GitHub external service is required for the provider GitHubRepositoryProvider. Please check the template file", resultMessage);
+            Assert.Equal("Please add the required external services first by using \"service add\" command.", resultMessage);
         }
-
-        [Fact]
-        public void ProjectCreate_Execute_WithTemplateReturnsExternalServiceNotFound()
-        {
-            _templateWriter.Setup(t => t.Read(It.IsAny<string>())).Returns(
-@"name: Project 2
-models:
-    - name: Product
-jobs:
-- name: Default
-  tasks:
-  - name: Generate
-    type: Generate
-    provider: AspNetCoreMvc
-  - name: Push
-    type: Generate
-    provider: GitHubRepositoryProvider
-    configs:
-      Branch: master
-      GitHubExternalService: github-default2"
-            );
-
-            var command = new CreateCommand(_console, LoggerMock.GetLogger<CreateCommand>().Object, _consoleReader.Object, _projectService.Object, _pluginService.Object, _externalServiceService.Object, _templateWriter.Object)
-            {
-                Name = "Project 2",
-                Client = "Company",
-                Template = "Test"
-            };
-
-            var resultMessage = command.Execute();
-
-            Assert.Equal("The external service github-default2 is not found. Please add them using \"service add\" command", resultMessage);
-        }
-
-        [Fact]
-        public void ProjectCreate_Execute_WithTemplateReturnsIncorrectType()
-        {
-            _templateWriter.Setup(t => t.Read(It.IsAny<string>())).Returns(
-@"name: Project 2
-models:
-    - name: Product
-jobs:
-- name: Default
-  tasks:
-  - name: Generate
-    type: Generate
-    provider: AspNetCoreMvc
-  - name: Push
-    type: Generate
-    provider: GitHubRepositoryProvider
-    configs:
-      Branch: master
-      GitHubExternalService: azure-default"
-            );
-
-            var command = new CreateCommand(_console, LoggerMock.GetLogger<CreateCommand>().Object, _consoleReader.Object, _projectService.Object, _pluginService.Object, _externalServiceService.Object, _templateWriter.Object)
-            {
-                Name = "Project 2",
-                Client = "Company",
-                Template = "Test"
-            };
-
-            var resultMessage = command.Execute();
-
-            Assert.Equal("The external service azure-default is not a GitHub service", resultMessage);
-        }
-
+        
         [Fact]
         public void ProjectExport_Execute_ReturnsSuccessMessage()
         {


### PR DESCRIPTION
## Summary
I want to validate plugins and external services up front before any other process when creating new project with template. It makes the user to be aware about the pre-requisites as early as possible.