### PR TITLE
Fix build scripts

### DIFF
--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -4,7 +4,9 @@ param(
     [switch]$noPrompt = $false,
     [string]$configuration = "Release",
     [string]$connString = "",
-    [string]$url = "https://localhost:44305"
+    [string]$url = "https://localhost:44305",
+    [switch]$noRun = $false
+
 )
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = $true
@@ -83,11 +85,12 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # run the API
-Write-Output "Running API..."
-Write-Output "dotnet $apiDll --urls $url"
-Set-Location $apiPublishPath
-$result = dotnet $apiDll --urls $url
-if ($LASTEXITCODE -ne 0) {
-    Write-Error -Message "[ERROR] $result"
-    break
+if ($noRun) {
+    Set-Location $apiPublishPath
+    Write-Output "API is ready. Please run: dotnet $apiDll --urls $url"
+} else {
+    Write-Output "Running API..."
+    Write-Output "dotnet $apiDll --urls $url"
+    Set-Location $apiPublishPath
+    dotnet $apiDll --urls $url
 }

--- a/builds/build-cli.ps1
+++ b/builds/build-cli.ps1
@@ -1,9 +1,9 @@
 # Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 param(
-    [switch]$noPrompt = $false,
     [string]$configuration = "Release",
-    [string]$url = "https://localhost:44305"
+    [string]$url = "https://localhost:44305",
+    [switch]$noConfig = $false
 )
 
 $rootPath = Split-Path $PSScriptRoot
@@ -21,12 +21,14 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Set ApiUrl
-Write-Output "Set ApiUrl config..."
-Write-Output "dotnet $cliDll config set -n ApiUrl -v $url"
-$result = dotnet $cliDll config set -n ApiUrl -v $url
-if ($LASTEXITCODE -ne 0) {
-    Write-Error -Message "[ERROR] $result"
-    break
+if (!$noConfig) {
+    Write-Output "Set ApiUrl config..."
+    Write-Output "dotnet $cliDll config set -n ApiUrl -v $url"
+    $result = dotnet $cliDll config set -n ApiUrl -v $url
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error -Message "[ERROR] $result"
+        break
+    }
 }
 
 Write-Output "CLI is ready. Please run: dotnet $cliDll [command] [options]"

--- a/builds/build-engine.ps1
+++ b/builds/build-engine.ps1
@@ -1,9 +1,9 @@
 # Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 param(
-    [switch]$noPrompt = $false,
     [string]$configuration = "Release",
-    [string]$url = "https://localhost:44305"
+    [string]$url = "https://localhost:44305",
+    [switch]$noConfig = $false
 )
 
 $rootPath = Split-Path $PSScriptRoot
@@ -28,12 +28,14 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Set ApiUrl
-Write-Output "Set ApiUrl config..."
-Write-Output "dotnet $engineDll config set -n ApiUrl -v $url"
-$result = dotnet $engineDll config set -n ApiUrl -v $url
-if ($LASTEXITCODE -ne 0) {
-    Write-Error -Message "[ERROR] $result"
-    break
+if (!$noConfig) {
+    Write-Output "Set ApiUrl config..."
+    Write-Output "dotnet $engineDll config set -n ApiUrl -v $url"
+    $result = dotnet $engineDll config set -n ApiUrl -v $url
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error -Message "[ERROR] $result"
+        break
+    }
 }
 
 # publish plugins


### PR DESCRIPTION
## Summary

`build-api.ps1`
- add `-noRun` option to not run the api directly after the build process complete

`build-engine.ps1`:
- add `-noConfig` option to skip the config setup
- remove unused `-noPrompt` option

`build-cli.ps1`:
- add `-noConfig` option to skip the config setup
- remove unused `-noPrompt` option