### PR TITLE
Some adjustments for development

### DIFF
--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -4,7 +4,8 @@ param(
     [switch]$noPrompt = $false,
     [string]$configuration = "Release",
     [string]$connString = "",
-    [string]$url = "https://localhost:44305",
+    [string]$http = "http://localhost:8005",
+    [string]$https = "https://localhost:44305",
     [switch]$noRun = $false
 
 )
@@ -87,10 +88,10 @@ if ($LASTEXITCODE -ne 0) {
 # run the API
 if ($noRun) {
     Set-Location $apiPublishPath
-    Write-Output "API is ready. Please run: dotnet $apiDll --urls $url"
+    Write-Output "API is ready. Please run: dotnet $apiDll --urls `"$http;$https`""
 } else {
     Write-Output "Running API..."
-    Write-Output "dotnet $apiDll --urls $url"
+    Write-Output "dotnet $apiDll --urls `"$http;$https`""
     Set-Location $apiPublishPath
-    dotnet $apiDll --urls $url
+    dotnet $apiDll --urls "$http;$https"
 }

--- a/builds/build-prerequisites.ps1
+++ b/builds/build-prerequisites.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
-$dotnetSdkVersion = [System.Version]"2.1.403"
+$dotnetSdkVersion = [System.Version]"2.1.301"
 $allGood = $true
 
 $currentSdkVersion = dotnet --version

--- a/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
+++ b/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="AutoMapper" Version="7.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="CorrelationId" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.2" />

--- a/src/API/Polyrific.Catapult.Api/Startup.cs
+++ b/src/API/Polyrific.Catapult.Api/Startup.cs
@@ -121,12 +121,11 @@ namespace Polyrific.Catapult.Api
             }
             else
             {
+                app.UseHttpsRedirection();
                 app.UseHsts();
             }
 
             app.UseCorrelationId();
-
-            app.UseHttpsRedirection();
             app.UseAuthentication();
 
             // enrich log with request context


### PR DESCRIPTION
## Summary
- add option `-http` and `-https` to `build-api.ps1` script
- set minimum dotnet sdk version to `2.1.301`
- set minimum `Microsoft.AspNetCore.App` package version to `2.1.1`
- set `UseHttpsRedirection` config for `Production` environment only