### PR TITLE
Update to recommended dotnet version

### DIFF
--- a/builds/build-prerequisites.ps1
+++ b/builds/build-prerequisites.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
-$dotnetSdkVersion = [System.Version]"2.1.301"
+$dotnetSdkVersion = [System.Version]"2.1.402"
 $allGood = $true
 
 $currentSdkVersion = dotnet --version

--- a/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
+++ b/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="AutoMapper" Version="7.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="CorrelationId" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.2" />


### PR DESCRIPTION
## Summary
Apparently Asp.Net version `2.1.1 (sdk 2.1.301)` is known to have vulnerability. This PR updates the version to `2.1.4 (sdk 2.1.402)`.