### PR TITLE
Enable exe file as plugin start file

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/BuildTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/BuildTask.cs
@@ -33,7 +33,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
 
@@ -49,7 +49,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -73,7 +73,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/CloneTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/CloneTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error") && !string.IsNullOrEmpty(result["error"].ToString()))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
 
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -72,7 +72,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error") && !string.IsNullOrEmpty(result["error"].ToString()))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeployDbTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeployDbTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
             
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -72,7 +72,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeployTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeployTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
             
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -72,7 +72,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
             

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/GenerateTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/GenerateTask.cs
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
             
@@ -64,7 +64,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -88,7 +88,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/MergeTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/MergeTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error") && !string.IsNullOrEmpty(result["error"].ToString()))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
 
@@ -55,7 +55,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
                 return new TaskRunnerResult("PR Number was undefined.", !TaskConfig.ContinueWhenError);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -79,7 +79,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error") && !string.IsNullOrEmpty(result["error"].ToString()))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/PublishArtifactTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/PublishArtifactTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
             
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -72,7 +72,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
             

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/PushTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/PushTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error") && !string.IsNullOrEmpty(result["error"].ToString()))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
 
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -73,7 +73,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error") && !string.IsNullOrEmpty(result["error"].ToString()))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/TestTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/TestTask.cs
@@ -32,7 +32,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("pre");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PreProcessMustSucceed);
             
@@ -48,7 +48,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("main");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
@@ -72,7 +72,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
 
             var arg = GetArgString("post");
-            var result = await PluginManager.InvokeTaskProvider(provider.DllPath, arg.argString, arg.securedArgString);
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
             if (result.ContainsKey("error"))
                 return new TaskRunnerResult(result["error"].ToString(), TaskConfig.PostProcessMustSucceed);
             

--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginItem.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginItem.cs
@@ -9,10 +9,10 @@ namespace Polyrific.Catapult.Engine.Core
             
         }
 
-        public PluginItem(string name, string dllPath, string[] requiredServices)
+        public PluginItem(string name, string startFilePath, string[] requiredServices)
         {
             Name = name;
-            DllPath = dllPath;
+            StartFilePath = startFilePath;
             RequiredServices = requiredServices;
         }
 
@@ -22,9 +22,9 @@ namespace Polyrific.Catapult.Engine.Core
         public string Name { get; set; }
 
         /// <summary>
-        /// Path location to the plugin DLL file
+        /// Path location to the plugin start file (.exe or .dll)
         /// </summary>
-        public string DllPath { get; set; }
+        public string StartFilePath { get; set; }
 
         /// <summary>
         /// Names of the required external service connections

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/PluginManagerTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/PluginManagerTests.cs
@@ -101,18 +101,15 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
 
             var newPlugin = pluginManager.GetPlugin(pluginType, pluginName);
             Assert.NotNull(newPlugin);
-            Assert.Equal(Path.Combine(publishLocation, $"{pluginName}.dll"), newPlugin.DllPath);
+            Assert.Equal(Path.Combine(publishLocation, $"{pluginName}.dll"), newPlugin.StartFilePath);
         }
 
         [Fact]
         public async void InvokeTaskProvider_Success()
         {
-            _pluginProcess.Setup(p => p.Start(It.IsAny<ProcessStartInfo>())).Returns((ProcessStartInfo startInfo) =>
+            _pluginProcess.Setup(p => p.Start(It.IsAny<ProcessStartInfo>())).Returns((ProcessStartInfo startInfo) => new Process
             {
-                return new Process
-                {
-                    StartInfo = startInfo
-                };
+                StartInfo = startInfo
             });
             _pluginProcess.Setup(p => p.GetStandardOutput(It.IsAny<Process>()))
                 .Returns(new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes("[OUTPUT] {\"output\":\"success\"}\n[LOG][Information]Logged"))));
@@ -177,10 +174,10 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
                
         private void AddDllReference(string projectFile, string dllFile)
         {
-            string line = null;
             var updatedContent = new StringBuilder();
             using (var reader = new StreamReader(projectFile))
             {
+                string line;
                 while ((line = reader.ReadLine()) != null)
                 {
                     switch (line.Trim())


### PR DESCRIPTION
## Summary
We need to allow the plugin manager to invoke either `.exe` or `.dll` file as the plugin start file.