### PR TITLE
Rename API assembly to ocapi.dll

### DIFF
--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -17,7 +17,7 @@ $rootPath = Split-Path $PSScriptRoot
 $appSettingsPath = "$rootPath\src\API\Polyrific.Catapult.Api\appsettings.json"
 $apiCsprojPath = "$rootPath\src\API\Polyrific.Catapult.Api\Polyrific.Catapult.Api.csproj"
 $apiPublishPath = "$rootPath\publish\api"
-$apiDll = "$apiPublishPath\Polyrific.Catapult.Api.dll"
+$apiDll = "$apiPublishPath\ocapi.dll"
 $dataCsprojPath = "$rootPath\src\API\Polyrific.Catapult.Api.Data\Polyrific.Catapult.Api.Data.csproj"
 
 # read connection string in appsettings.json

--- a/src/API/Polyrific.Catapult.Api/Dockerfile
+++ b/src/API/Polyrific.Catapult.Api/Dockerfile
@@ -24,4 +24,4 @@ RUN dotnet publish Polyrific.Catapult.Api.csproj -c Release -o /app
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app .
-ENTRYPOINT ["dotnet", "Polyrific.Catapult.Api.dll"]
+ENTRYPOINT ["dotnet", "ocapi.dll"]

--- a/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
+++ b/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
@@ -59,5 +59,6 @@
     <Version>1.0.0-alpha</Version>
     <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>5260e463-1c3d-462e-b95e-a7ef6ab89e3b</UserSecretsId>
+    <AssemblyName>ocapi</AssemblyName>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
I'd like to rename the API assembly to `ocapi.dll`. This is done to maintain consistency with other component's assembly, i.e. `occli.dll` and `ocengine.dll`.