### PR TITLE
Add `-environment` parameter to the build script

### DIFF
--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -6,11 +6,12 @@ param(
     [string]$connString = "",
     [string]$http = "http://localhost:8005",
     [string]$https = "https://localhost:44305",
-    [switch]$noRun = $false
-
+    [switch]$noRun = $false,
+    [string]$environment = "Development"
 )
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = $true
+$env:ASPNETCORE_ENVIRONMENT = $environment
 
 # define paths
 $rootPath = Split-Path $PSScriptRoot


### PR DESCRIPTION
## Summary
Add `-environment` parameter to the API build script which will set the `ASPNETCORE_ENVIRONMENT` env var.