### PR TITLE
Change libgit2sharp version to fix issue in ubuntu

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -136,7 +136,7 @@ namespace Polyrific.Catapult.Engine.Core
             if (isExeFile)
                 fileName = pluginStartFile;
 
-            var arguments = $"\"\"{pluginArgs}\" {(Debugger.IsAttached ? "--attach" : "")}";
+            var arguments = $"\"{pluginArgs}\" {(Debugger.IsAttached ? "--attach" : "")}";
             var securedArguments = $"\"\"{securedPluginArgs}\" {(Debugger.IsAttached ? "--attach" : "")}";
             if (!isExeFile)
             {

--- a/src/Plugins/RepositoryProvider/Polyrific.Catapult.Plugins.GitHub/src/Polyrific.Catapult.Plugins.GitHub.csproj
+++ b/src/Plugins/RepositoryProvider/Polyrific.Catapult.Plugins.GitHub/src/Polyrific.Catapult.Plugins.GitHub.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0070" />
     <PackageReference Include="Octokit" Version="0.32.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Upgrade the library to version 0.26.0-preview-0070. ref: https://github.com/terrajobst/git-istage/issues/13
- Fix issue in composing the command argument when running plugin