### PR TITLE
Use y/n input for boolean config

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -153,20 +154,16 @@ namespace Polyrific.Catapult.Cli.Commands.Task
                                     bool validInput = true;
                                     do
                                     {
-
-                                        if (additionalConfig.IsSecret && (additionalConfig.IsInputMasked ?? true))
+                                        if (additionalConfig.Type == ConfigType.Boolean)
+                                            input = Console.GetYesNoNullable(prompt)?.ToString();
+                                        else if (additionalConfig.IsSecret && (additionalConfig.IsInputMasked ?? true))
                                             input = _consoleReader.GetPassword(prompt);
                                         else
                                             input = Console.GetString(prompt);
 
                                         if (!string.IsNullOrEmpty(input))
                                         {
-                                            if (additionalConfig.Type == PluginAdditionalConfigType.Boolean && !bool.TryParse(input, out var inputBool))
-                                            {
-                                                Console.WriteLine($"Input is not valid. Please enter valid boolean value: true or false");
-                                                validInput = false;
-                                            }
-                                            else if (additionalConfig.Type == PluginAdditionalConfigType.Number && !double.TryParse(input, out var inputNumber))
+                                            if (additionalConfig.Type == ConfigType.Number && !double.TryParse(input, out var inputNumber))
                                             {
                                                 Console.WriteLine($"Input is not valid. Please enter valid number value.");
                                                 validInput = false;

--- a/src/CLI/Polyrific.Catapult.Cli/Extensions/ConsoleExtension.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Extensions/ConsoleExtension.cs
@@ -85,6 +85,57 @@ namespace Polyrific.Catapult.Cli.Extensions
             while (true);
         }
         
+        /// <summary>
+        /// Gets a yes/no response from the console after displaying a <paramref name="prompt" />.
+        /// <para>
+        /// The parsing is case insensitive. Valid responses include: yes, no, y, n.
+        /// </para>
+        /// </summary>
+        /// <param name="prompt">The question to display on the command line</param>
+        /// <param name="defaultAnswer">If the user provides an empty response, which value should be returned</param>
+        /// <param name="promptColor">The console color to display</param>
+        /// <param name="promptBgColor">The console background color for the prompt</param>
+        /// <returns>True is 'yes'</returns>
+        public static bool? GetYesNoNullable(this IConsole console, string prompt, bool? defaultAnswer = null, ConsoleColor? promptColor = null, ConsoleColor? promptBgColor = null)
+        {
+            var answerHint = "[y/n]";
+
+            if (defaultAnswer != null)
+            {
+                answerHint = defaultAnswer.Value ? "[Y/n]" : "[y/N]";
+            }
+
+            do
+            {
+                Write($"{prompt} {answerHint}", promptColor, promptBgColor);
+                Console.Write(' ');
+
+                string resp;
+                using (ShowCursor())
+                {
+                    resp = console.In.ReadLine()?.ToLower()?.Trim();
+                }
+
+                if (string.IsNullOrEmpty(resp))
+                {
+                    return defaultAnswer;
+                }
+
+                if (resp == "n" || resp == "no")
+                {
+                    return false;
+                }
+
+                if (resp == "y" || resp == "yes")
+                {
+                    return true;
+                }
+
+                Console.WriteLine($"Invalid response '{resp}'. Please answer 'y' or 'n' or CTRL+C to exit.");
+            }
+            while (true);
+        }
+
         private static void Write(string value, ConsoleColor? foreground, ConsoleColor? background)
         {
             if (foreground.HasValue)

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/ConfigType.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/ConfigType.cs
@@ -2,7 +2,7 @@
 
 namespace Polyrific.Catapult.Shared.Dto.Constants
 {
-    public static class PluginAdditionalConfigType
+    public static class ConfigType
     {
         public const string String = "string";
         public const string Boolean = "boolean";

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/TaskCommandTest.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/TaskCommandTest.cs
@@ -265,7 +265,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         [Fact]
         public void TaskAdd_Execute_ReturnsServiceNotFoundMessage()
         {
-            var console = new TestConsole(_output, "https://github.com/test/test", "", "dev", "true", "master", "commit", "opencatapult", "test@opencatapult.net", "test");
+            var console = new TestConsole(_output, "https://github.com/test/test", "", "dev", "y", "master", "commit", "opencatapult", "test@opencatapult.net", "test");
             var command = new AddCommand(console, LoggerMock.GetLogger<AddCommand>().Object, _consoleReader.Object, _projectService.Object, _jobDefinitionService.Object, _pluginService.Object, _externalServiceService.Object, _externalServiceTypeService.Object)
             {
                 Project = "Project 1",
@@ -283,7 +283,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         [Fact]
         public void TaskAdd_Execute_ReturnsServiceTypeIncorrectMessage()
         {
-            var console = new TestConsole(_output, "https://github.com/test/test", "", "dev", "true", "master", "commit", "opencatapult", "test@opencatapult.net", "azure-default");
+            var console = new TestConsole(_output, "https://github.com/test/test", "", "dev", "y", "master", "commit", "opencatapult", "test@opencatapult.net", "azure-default");
             var command = new AddCommand(console, LoggerMock.GetLogger<AddCommand>().Object, _consoleReader.Object, _projectService.Object, _jobDefinitionService.Object, _pluginService.Object, _externalServiceService.Object, _externalServiceTypeService.Object)
             {
                 Project = "Project 1",


### PR DESCRIPTION
## Summary
- Allow user to enter (y/n) when inputting boolean value in task config and additional config. 
- Show the [y/n] hint in the input prompt