### PR TITLE
Fix possible error occured on copying logo

### DIFF
--- a/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Helpers/ProjectHelper.cs
+++ b/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Helpers/ProjectHelper.cs
@@ -90,6 +90,10 @@ namespace Polyrific.Catapult.Plugins.AspNetCoreMvc.Helpers
         public void CopyFileToProject(string projectName, string sourceFile, string targetFile)
         {
             var targetFilePath = Path.Combine(_outputLocation, projectName, targetFile);
+            var fileInfo = new FileInfo(targetFilePath);
+            if (!fileInfo.Directory.Exists)
+                fileInfo.Directory.Create();
+
             File.Copy(sourceFile, targetFilePath, true);
         }
 


### PR DESCRIPTION
## Summary
There's an error in generator related to failing to copy the logo.png into `workingfolder/Project/wwwroot/image` folder. I have not been able to reproduce this even after cloning the opencatapult from scratch. I figure it might be related to VM environment, but I haven't been able to successfully download it.

I push a commit to possibly fix the issue based on the error message in the log. 