### PR TITLE
skip dotnet new for existing project/solution

### DIFF
--- a/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/CodeGenerator.cs
+++ b/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/CodeGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -40,6 +41,9 @@ namespace Polyrific.Catapult.Plugins.AspNetCoreMvc
 
         public async Task<string> InitSolution()
         {
+            if (File.Exists(Path.Combine(_outputLocation, $"{_projectName}.sln")))
+                return "";
+
             var args = $"new sln -n {_projectName} -o \"{_outputLocation}\"";
             return await CommandHelper.RunDotnet(args);
         }

--- a/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Helpers/ProjectHelper.cs
+++ b/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Helpers/ProjectHelper.cs
@@ -34,12 +34,15 @@ namespace Polyrific.Catapult.Plugins.AspNetCoreMvc.Helpers
             if (!Directory.Exists(projectFolder))
                 Directory.CreateDirectory(projectFolder);
 
-            var args = $"new {template} -n {projectName} -o \"{projectFolder}\"";
-
-            var message = await CommandHelper.RunDotnet(args, null, _logger);
-            DeleteFileToProject(projectName, "Class1.cs");
-
             var projectFile = GetProjectFullPath(projectName);
+
+            string message = "";
+            if (!File.Exists(projectFile))
+            {
+                var args = $"new {template} -n {projectName} -o \"{projectFolder}\"";
+                message = await CommandHelper.RunDotnet(args, null, _logger);
+                DeleteFileToProject(projectName, "Class1.cs");
+            }
 
             if (projectReferences != null)
                 foreach (var projectReference in projectReferences)


### PR DESCRIPTION
## Summary
Skip running `dotnet new` for exsisting project or solution, so generator plugin does not throw error when it's restarting a previously failed generate task.