### PR TITLE
Add dependencies to plugins.core nuspec

### DIFF
--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/Polyrific.Catapult.Plugins.Core.nuspec
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/Polyrific.Catapult.Plugins.Core.nuspec
@@ -19,4 +19,8 @@
     <file src="bin\Release\netstandard2.0\*" target="lib\netstandard2.0"></file>
     <file src="bin\Release\net461\*" target="lib\net461"></file>
   </files>
+  <dependencies>
+    <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" />
+    <dependency id="Newtonsoft.Json" version="11.0.2" />
+  </dependencies>
 </package>

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/Polyrific.Catapult.Plugins.Core.nuspec
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/Polyrific.Catapult.Plugins.Core.nuspec
@@ -14,13 +14,13 @@
     <releaseNotes>Preview release</releaseNotes>
     <copyright>Copyright (c) Polyrific, Inc 2018. All rights reserved</copyright>
     <tags>catapult opencatapult devops plugins</tags>
+    <dependencies>
+      <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" />
+      <dependency id="Newtonsoft.Json" version="11.0.2" />
+    </dependencies>
   </metadata>
   <files>
     <file src="bin\Release\netstandard2.0\*" target="lib\netstandard2.0"></file>
     <file src="bin\Release\net461\*" target="lib\net461"></file>
   </files>
-  <dependencies>
-    <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" />
-    <dependency id="Newtonsoft.Json" version="11.0.2" />
-  </dependencies>
 </package>


### PR DESCRIPTION
## Summary
When testing a plugin that uses dotnet core, I got the runtime error that Newtonsoft.Json is not found. I think it's because the library is not specified in the dependencies, so it's not installed when the `Polyrific.Catapult.Plugins.Core` is installed. 
This PR modify the `.nuspec` file to include the dependencies