### PR TITLE
Add stack trace to the plugin log

### DIFF
--- a/src/Plugins/BuildProvider/Polyrific.Catapult.Plugins.DotNetCore/src/Program.cs
+++ b/src/Plugins/BuildProvider/Polyrific.Catapult.Plugins.DotNetCore/src/Program.cs
@@ -9,15 +9,17 @@ namespace Polyrific.Catapult.Plugins.DotNetCore
 {
     public class Program : BuildProvider
     {
+        private const string TaskProviderName = "Polyrific.Catapult.Plugins.DotNetCore";
+
         private IBuilder _builder;
 
-        public override string Name => "Polyrific.Catapult.Plugins.DotNetCore";
+        public override string Name => TaskProviderName;
 
-        public Program() : base(new string[0])
+        public Program() : base(new string[0], TaskProviderName)
         {
         }
 
-        public Program(string[] args) : base(args)
+        public Program(string[] args) : base(args, TaskProviderName)
         {
         }
         

--- a/src/Plugins/DatabaseProvider/Polyrific.Catapult.Plugins.EntityFrameworkCore/src/Program.cs
+++ b/src/Plugins/DatabaseProvider/Polyrific.Catapult.Plugins.EntityFrameworkCore/src/Program.cs
@@ -9,13 +9,15 @@ namespace Polyrific.Catapult.Plugins.EntityFrameworkCore
 {
     public class Program : DatabaseProvider
     {
+        private const string TaskProviderName = "Polyrific.Catapult.Plugins.EntityFrameworkCore";
+
         private IDatabaseCommand _databaseCommand;
 
-        public Program() : base(new string[0])
+        public Program() : base(new string[0], TaskProviderName)
         {
         }
 
-        public Program(string[] args) : base(args)
+        public Program(string[] args) : base(args, TaskProviderName)
         {
         }
 
@@ -24,7 +26,7 @@ namespace Polyrific.Catapult.Plugins.EntityFrameworkCore
             _databaseCommand = databaseCommand;
         }
 
-        public override string Name => "Polyrific.Catapult.Plugins.EntityFrameworkCore";
+        public override string Name => TaskProviderName;
         
         public override async Task<(string databaseLocation, Dictionary<string, string> outputValues, string errorMessage)> DeployDatabase()
         {

--- a/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Program.cs
+++ b/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Program.cs
@@ -8,13 +8,15 @@ namespace Polyrific.Catapult.Plugins.AspNetCoreMvc
 {
     public class Program : CodeGeneratorProvider
     {
-        public override string Name => "Polyrific.Catapult.Plugins.AspNetCoreMvc";
+        private const string TaskProviderName = "Polyrific.Catapult.Plugins.AspNetCoreMvc";
 
-        public Program() : base(new string[0])
+        public override string Name => TaskProviderName;
+
+        public Program() : base(new string[0], TaskProviderName)
         {
         }
 
-        public Program(string[] args) : base(args)
+        public Program(string[] args) : base(args, TaskProviderName)
         {
         }
         

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/Program.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/Program.cs
@@ -7,15 +7,17 @@ namespace Polyrific.Catapult.Plugins.AzureAppService
 {
     public class Program : HostingProvider
     {
+        private const string TaskProviderName = "Polyrific.Catapult.Plugins.AzureAppService";
+
         private IAzureAutomation _azure;
         private readonly IAzureUtils _azureUtils;
         private readonly IDeployUtils _deployUtils;
 
-        public Program() : base(new string[0])
+        public Program() : base(new string[0], TaskProviderName)
         {
         }
 
-        public Program(string[] args) : base(args)
+        public Program(string[] args) : base(args, TaskProviderName)
         {
         }
 
@@ -26,7 +28,7 @@ namespace Polyrific.Catapult.Plugins.AzureAppService
             _deployUtils = deployUtils;
         }
 
-        public override string Name => "Polyrific.Catapult.Plugins.AzureAppService";
+        public override string Name => TaskProviderName;
 
         public override string[] RequiredServices => new[] { "AzureAppService" };
 

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/BuildProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/BuildProvider.cs
@@ -10,7 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class BuildProvider : TaskProvider
     {
-        protected BuildProvider(string[] args) : base(args)
+        protected BuildProvider(string[] args, string taskProviderName) 
+            : base(args, taskProviderName)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/CodeGeneratorProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/CodeGeneratorProvider.cs
@@ -11,7 +11,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class CodeGeneratorProvider : TaskProvider
     {
-        protected CodeGeneratorProvider(string[] args) : base(args)
+        protected CodeGeneratorProvider(string[] args, string taskProviderName) 
+            : base(args, taskProviderName)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/DatabaseProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/DatabaseProvider.cs
@@ -10,7 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class DatabaseProvider : TaskProvider
     {
-        protected DatabaseProvider(string[] args) : base(args)
+        protected DatabaseProvider(string[] args, string taskProviderName) 
+            : base(args, taskProviderName)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/HostingProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/HostingProvider.cs
@@ -10,7 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class HostingProvider : TaskProvider
     {
-        protected HostingProvider(string[] args) : base(args)
+        protected HostingProvider(string[] args, string taskProviderName) 
+            : base(args, taskProviderName)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/RepositoryProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/RepositoryProvider.cs
@@ -10,7 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class RepositoryProvider : TaskProvider
     {
-        protected RepositoryProvider(string[] args) : base(args)
+        protected RepositoryProvider(string[] args, string taskProviderName) 
+            : base(args, taskProviderName)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/StorageProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/StorageProvider.cs
@@ -10,7 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class StorageProvider : TaskProvider
     {
-        protected StorageProvider(string[] args) : base(args)
+        protected StorageProvider(string[] args, string taskProviderName) 
+            : base(args, taskProviderName)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/TaskLogger.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/TaskLogger.cs
@@ -7,6 +7,13 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public class TaskLogger : ILogger
     {
+        private readonly string _taskProviderName;
+
+        public TaskLogger(string taskProviderName)
+        {
+            _taskProviderName = taskProviderName;
+        }
+
         public IDisposable BeginScope<TState>(TState state)
         {
             throw new NotImplementedException();
@@ -21,7 +28,11 @@ namespace Polyrific.Catapult.Plugins.Core
         {
             var message = formatter?.Invoke(state, exception);
 
-            Console.WriteLine($"[LOG][{Enum.GetName(typeof(LogLevel), logLevel)}]{message}");
+            var logMessage = $"[LOG][{Enum.GetName(typeof(LogLevel), logLevel)}][{_taskProviderName}] {message}";
+            if (exception != null)
+                logMessage += $" {exception.StackTrace}";
+
+            Console.WriteLine(logMessage);
         }
         
     }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/TaskProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/TaskProvider.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Polyrific.Catapult.Plugins.Core.Extensions;
 using Polyrific.Catapult.Shared.Dto.Constants;
 
 namespace Polyrific.Catapult.Plugins.Core
@@ -17,13 +16,13 @@ namespace Polyrific.Catapult.Plugins.Core
         protected Dictionary<string, object> ParsedArguments;
         protected ILogger Logger;
 
-        protected TaskProvider(string[] args)
+        protected TaskProvider(string[] args, string taskProviderName)
         {
             if (args.Contains("--attach") && Debugger.IsAttached == false)
                 Debugger.Launch();
             
             ParsedArguments = args.Length > 0 ? JsonConvert.DeserializeObject<Dictionary<string, object>>(args[0]) : new Dictionary<string, object>();
-            Logger = new TaskLogger();
+            Logger = new TaskLogger(taskProviderName);
         }
 
         /// <summary>

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/TestProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/TestProvider.cs
@@ -10,7 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class TestProvider : TaskProvider
     {
-        protected TestProvider(string[] args) : base(args)
+        protected TestProvider(string[] args, string taskProviderName) 
+            : base(args, taskProviderName)
         {
             ParseArguments();
         }

--- a/src/Plugins/RepositoryProvider/Polyrific.Catapult.Plugins.GitHub/src/Program.cs
+++ b/src/Plugins/RepositoryProvider/Polyrific.Catapult.Plugins.GitHub/src/Program.cs
@@ -9,6 +9,8 @@ namespace Polyrific.Catapult.Plugins.GitHub
 {
     public class Program : RepositoryProvider
     {
+        private const string TaskProviderName = "Polyrific.Catapult.Plugins.GitHub";
+
         private IGitAutomation _gitAutomation;
         private readonly IGitHubUtils _gitHubUtils;
 
@@ -18,15 +20,15 @@ namespace Polyrific.Catapult.Plugins.GitHub
         private const string DefaultBaseBranch = "master";
         private const string DefaultWorkingBranch = "OpenCatapultGenerated";
 
-        public override string Name => "Polyrific.Catapult.Plugins.GitHub";
+        public override string Name => TaskProviderName;
 
         public override string[] RequiredServices => new[] { "GitHub" };
 
-        public Program() : base(new string[0])
+        public Program() : base(new string[0], TaskProviderName)
         {
         }
 
-        public Program(string[] args) : base(args)
+        public Program(string[] args) : base(args, TaskProviderName)
         {
         }
 

--- a/src/Plugins/TestProvider/Polyrific.Catapult.Plugins.DotNetCoreTest/src/Program.cs
+++ b/src/Plugins/TestProvider/Polyrific.Catapult.Plugins.DotNetCoreTest/src/Program.cs
@@ -9,17 +9,19 @@ namespace Polyrific.Catapult.Plugins.DotNetCoreTest
 {
     public class Program : TestProvider
     {
+        private const string TaskProviderName = "Polyrific.Catapult.Plugins.DotNetCoreTest";
+
         private ITestRunner _testRunner;
 
-        public Program() : base(new string[0])
+        public Program() : base(new string[0], TaskProviderName)
         {
         }
 
-        public Program(string[] args) : base(args)
+        public Program(string[] args) : base(args, TaskProviderName)
         {
         }
 
-        public override string Name => "Polyrific.Catapult.Plugins.DotNetCoreTest";
+        public override string Name => TaskProviderName;
         
         public override async Task<(string testResultLocation, Dictionary<string, string> outputValues, string errorMessage)> Test()
         {

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/PluginManagerTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/PluginManagerTests.cs
@@ -146,7 +146,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
             await Execute("dotnet", $"new console -n {pluginName} -o \"{outputLocation}\"");
             AddDllReference(projectFile, pluginCoreDll);
             WriteDummyPlugin(Path.Combine(outputLocation, "Program.cs"), pluginName, pluginType);
-
+            
             await Execute("dotnet", $"publish \"{projectFile}\" --output \"{publishLocation}\" --configuration release");
         }
 
@@ -161,15 +161,16 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
             sb.AppendLine("{");
             sb.AppendLine("    public class Program : TaskProvider");
             sb.AppendLine("    {");
-            sb.AppendLine($"        public override string Name => \"{pluginName}\";");
+            sb.AppendLine($"        private const string TaskProviderName = \"{pluginName}\";");
+            sb.AppendLine($"        public override string Name => TaskProviderName;");
             sb.AppendLine("");
             sb.AppendLine($"        public override string Type => \"{pluginType}\";");
             sb.AppendLine("");
-            sb.AppendLine("        public Program() : base(new string[] { })");
+            sb.AppendLine("        public Program() : base(new string[] { }, TaskProviderName)");
             sb.AppendLine("        {");
             sb.AppendLine("        }");
             sb.AppendLine("");
-            sb.AppendLine("        public Program(string[] args) : base(args)");
+            sb.AppendLine("        public Program(string[] args) : base(args, TaskProviderName)");
             sb.AppendLine("        {");
             sb.AppendLine("        }");
             sb.AppendLine("");


### PR DESCRIPTION
## Summary
Plugin provider has had ability to send a message log back to the `PluginManager`. This PR adds exception stack trace to the log message to improve traceability.