### PR TITLE
Exclude Properties in service list

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/ListCommand.cs
@@ -28,7 +28,7 @@ namespace Polyrific.Catapult.Cli.Commands.Service
 
             message = services.ToListCliString($"Found {services.Count} external service(s):", excludedFields: new string[]
                 {
-                    "Config",
+                    "Properties",
                     "ExternalServiceTypeId"
                 }, nameDictionary: new Dictionary<string, string>
                 {


### PR DESCRIPTION
## Summary
Fix issue where the Properties is not hidden in service list

## Related issue
- #253 