### PR TITLE
Fix folder path in the build-prerequisites message

### DIFF
--- a/builds/build-prerequisites.ps1
+++ b/builds/build-prerequisites.ps1
@@ -7,7 +7,7 @@ $currentSdkVersion = dotnet --version
 
 if ([System.Version]$currentSdkVersion -lt $dotnetSdkVersion) {
     Write-Output "You need to install dotnet SDK version $dotnetSdkVersion."
-    Write-Host "Please run this command in an elevated shell: .\dotnet-install.ps1 -Channel 2.1 -InstallDir `$env:ProgramFiles\dotnet"
+    Write-Host "Please run this command in an elevated shell: .\builds\dotnet-install.ps1 -Channel 2.1 -InstallDir `$env:ProgramFiles\dotnet"
 
     $allGood = $false
 }


### PR DESCRIPTION
## Summary
Since our docs uses the opencatapult folder as the root when running the build command, I change the message in `build-prerequisites.ps1` to include the `.\builds` folder path, to avoid confusion for the user when following the build instruction in our docs.