### PR TITLE
Automatically install dotnet in build-prerequisites script

### DIFF
--- a/builds/build-prerequisites.ps1
+++ b/builds/build-prerequisites.ps1
@@ -5,11 +5,28 @@ $allGood = $true
 
 $currentSdkVersion = dotnet --version
 
-if ([System.Version]$currentSdkVersion -lt $dotnetSdkVersion) {
-    Write-Output "You need to install dotnet SDK version $dotnetSdkVersion."
-    Write-Host "Please run this command in an elevated shell: .\builds\dotnet-install.ps1 -Channel 2.1 -InstallDir `$env:ProgramFiles\dotnet"
-
-    $allGood = $false
+if ([System.Version]$currentSdkVersion -lt $dotnetSdkVersion) {	
+	$allGood = $false
+	Write-host "We need to install the dotnet SDK version $dotnetSdkVersion for you. Proceed? (y/n)" -ForegroundColor Yellow 
+	$readInstallDotnet = Read-Host
+	Switch ($readInstallDotnet) { 
+		Y {$installDotnet=$true} 
+		N {$installDotnet=$false} 
+		Default {Write-Host "Invalid input" -ForegroundColor Red; $installDotnet=$false} 
+	} 
+	
+	if ($installDotnet) {
+		if (Test-Path ".\builds\dotnet-install.ps1") { 
+			.\builds\dotnet-install.ps1 -Channel 2.1 -InstallDir $env:ProgramFiles\dotnet
+		}
+		elseif (Test-Path ".\dotnet-install.ps1") { 
+			.\dotnet-install.ps1 -Channel 2.1 -InstallDir $env:ProgramFiles\dotnet
+		}
+		else { 
+			Write-Host "Cannot find dotnet-install.ps1" -ForegroundColor Red
+			Exit 1
+		}
+	}
 }
 
 if ($allGood){

--- a/builds/dotnet-install.ps1
+++ b/builds/dotnet-install.ps1
@@ -1,3 +1,4 @@
+#Requires -RunAsAdministrator
 #
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.


### PR DESCRIPTION
## Summary
In build-prerequisites script, inform user that we need to install dotnet sdk version 2.1. If user confirm, perform the instalation automatically

## Related issue
- #263 