### PR TITLE
Log the plugin command arguments for traceability

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -161,7 +161,7 @@ namespace Polyrific.Catapult.Engine.Core
                     if (!string.IsNullOrEmpty(securedPluginArgs))
                     {
                         Console.WriteLine($"[Master] Command: {fileName} {securedArguments}");
-                        _logger.LogDebug("[Master] Command: {fileName} {securedArguments}", fileName, securedArguments);
+                        _logger.LogDebug($"[Master] Command: {fileName} {securedArguments}");
                     }                        
 
                     var reader = _pluginProcess.GetStandardOutput(process);

--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -159,7 +159,10 @@ namespace Polyrific.Catapult.Engine.Core
                 if (process != null)
                 {
                     if (!string.IsNullOrEmpty(securedPluginArgs))
+                    {
                         Console.WriteLine($"[Master] Command: {fileName} {securedArguments}");
+                        _logger.LogDebug("[Master] Command: {fileName} {securedArguments}", fileName, securedArguments);
+                    }                        
 
                     var reader = _pluginProcess.GetStandardOutput(process);
                     while (!reader.EndOfStream)

--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -160,8 +160,8 @@ namespace Polyrific.Catapult.Engine.Core
                 {
                     if (!string.IsNullOrEmpty(securedPluginArgs))
                     {
-                        Console.WriteLine($"[Master] Command: {fileName} {securedArguments}");
-                        _logger.LogDebug($"[Master] Command: {fileName} {securedArguments}");
+                        Console.WriteLine($"[PluginManager] Command: {fileName} {securedArguments}");
+                        _logger.LogDebug($"[PluginManager] Command: {fileName} {securedArguments}");
                     }                        
 
                     var reader = _pluginProcess.GetStandardOutput(process);


### PR DESCRIPTION
## Summary
In addition to showing it in the engine console, we should also log the plugin's command arguments for traceability, so we can still see it after the engine shell window is closed.