### PR TITLE
Log setting connection string failed

### DIFF
--- a/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/AzureUtils.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/AzureUtils.cs
@@ -93,7 +93,7 @@ namespace Polyrific.Catapult.Plugins.AzureAppService
             else
                 web = null;
 
-            var connStrings = web?.GetConnectionStrings();
+            var connStrings = ExecuteWithRetry(() => web?.GetConnectionStrings());
             if (connStrings == null || !connStrings.ContainsKey(connectionStringName))
             {
                 throw new Exception("Failed setting connection string. Please check for the user permission");

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/AzureUtils.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/AzureUtils.cs
@@ -84,12 +84,22 @@ namespace Polyrific.Catapult.Plugins.AzureAppService
 
         public IWebAppBase SetConnectionString(IWebAppBase deployTarget, string connectionStringName, string connectionString)
         {
+            _logger.LogInformation("Setting connection string...");
+            IWebAppBase web;
             if (deployTarget is IWebApp webApp)
-                return ExecuteWithRetry(() => webApp.Update().WithConnectionString(connectionStringName, connectionString, Microsoft.Azure.Management.AppService.Fluent.Models.ConnectionStringType.Custom).Apply());
+                web = ExecuteWithRetry(() => webApp.Update().WithConnectionString(connectionStringName, connectionString, Microsoft.Azure.Management.AppService.Fluent.Models.ConnectionStringType.Custom).Apply());
             else if (deployTarget is IDeploymentSlot slot)
-                return ExecuteWithRetry(() => slot.Update().WithConnectionString(connectionStringName, connectionString, Microsoft.Azure.Management.AppService.Fluent.Models.ConnectionStringType.Custom).Apply());
+                web = ExecuteWithRetry(() => slot.Update().WithConnectionString(connectionStringName, connectionString, Microsoft.Azure.Management.AppService.Fluent.Models.ConnectionStringType.Custom).Apply());
             else
-                return null;
+                web = null;
+
+            var connStrings = web?.GetConnectionStrings();
+            if (connStrings == null || !connStrings.ContainsKey(connectionStringName))
+            {
+                throw new Exception("Failed setting connection string. Please check for the user permission");
+            }
+
+            return web;
         }
 
         #region Private Methods


### PR DESCRIPTION
## Summary
There's an issue occured where the connection string in azure app service is not set, but the deploy task does not log any error. I made it so it'd throw exception if the app service is not having the set connection string.