### PR TITLE
Improve the queue cli response

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddCommand.cs
@@ -67,6 +67,8 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
                         "CatapultEngineVersion"
                     });
                     Logger.LogInformation(message);
+
+                    message += "\nThe job will be picked up by a running engine shortly.";
                     return message;
                 }
             }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/GetCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Cli.Extensions;
@@ -50,8 +51,30 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
                     message = queue.ToCliString($"Job Queue {Number}", excludedFields: new string[]
                     {
                         "ProjectId",
-                        "JobDefinitionId"
+                        "JobDefinitionId",
+                        "JobTasksStatus"
                     });
+
+                    if (queue.JobTasksStatus?.Count > 0)
+                    {
+                        var sb = new System.Text.StringBuilder();
+                        sb.AppendLine();
+                        sb.AppendLine("  ------------------------------------------------------------------");
+                        sb.AppendLine("  Job Task Status:");
+
+                        foreach (var taskStatus in queue.JobTasksStatus.OrderBy(t => t.Sequence))
+                        {
+                            sb.AppendLine();
+                            sb.AppendLine($"    {taskStatus.Sequence}. Task Name: {taskStatus.TaskName}");
+                            sb.AppendLine($"       Status: {taskStatus.Status}");
+                            sb.AppendLine($"       Remarks: {taskStatus.Remarks}");
+                        }
+
+                        sb.AppendLine();
+                        sb.AppendLine("  ------------------------------------------------------------------");
+
+                        message += sb.ToString();
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Improve the `queue add` response to add description that the job will be picked up shortly by a running engine
- Improve the `queue get` response to accentuate the part about job task status

## Related issue
- #296 