### PR TITLE
Remove plugin trace in engine console

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -160,7 +160,6 @@ namespace Polyrific.Catapult.Engine.Core
                 {
                     if (!string.IsNullOrEmpty(securedPluginArgs))
                     {
-                        Console.WriteLine($"[PluginManager] Command: {fileName} {securedArguments}");
                         _logger.LogDebug($"[PluginManager] Command: {fileName} {securedArguments}");
                     }                        
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -158,6 +158,8 @@ namespace Polyrific.Catapult.Engine.Core
             {
                 if (process != null)
                 {
+                    Console.WriteLine($"Invoking Task Provider {Path.GetFileNameWithoutExtension(pluginStartFile)}...");
+
                     if (!string.IsNullOrEmpty(securedPluginArgs))
                     {
                         _logger.LogDebug($"[PluginManager] Command: {fileName} {securedArguments}");


### PR DESCRIPTION
## Summary
Since we already write the plugin trace command into the log, I think we don't need to show it in the engine console, since the trace can contain a huge json object that is hard to read anyway.

## Related issue
- #295 