### PR TITLE
Improve build script response

### DIFF
--- a/builds/build-all.ps1
+++ b/builds/build-all.ps1
@@ -139,6 +139,11 @@ if (!$noRun) {
     $apiPublishPath = Join-Path $rootPath "/publish/api"
     $apiDll = Join-Path $apiPublishPath "/ocapi.dll"
     Write-Output "Running API..."
+    Write-Host "--------------------------------------------------------------" -ForegroundColor Yellow 
+    Write-Host "|This terminal window should remain open for catapult to work|" -ForegroundColor Yellow 
+    Write-Host "--------------------------------------------------------------" -ForegroundColor Yellow 
+    Write-Host "The engine and CLI are in the new terminal windows. Please go ahead and try to run the commands available there." -ForegroundColor Green 
+    Write-Host "To learn more about catapult components, please follow this link: https://docs.opencatapult.net/home/intro#the-components" -ForegroundColor Green 
     Write-Output "dotnet $apiDll --urls `"$http;$https`""
     Set-Location $apiPublishPath
     dotnet $apiDll --urls "$http;$https"

--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -88,10 +88,13 @@ if ($LASTEXITCODE -ne 0) {
 
 # run the API
 if ($noRun) {
-    Set-Location $apiPublishPath
     Write-Output "API is ready. Please run: dotnet $apiDll --urls `"$http;$https`""
 } else {
     Write-Output "Running API..."
+    Write-Host "--------------------------------------------------------------" -ForegroundColor Yellow 
+    Write-Host "|This terminal window should remain open for catapult to work|" -ForegroundColor Yellow 
+    Write-Host "--------------------------------------------------------------" -ForegroundColor Yellow 
+    Write-Host "To learn more about catapult components, please follow this link: https://docs.opencatapult.net/home/intro#the-components" -ForegroundColor Green 
     Write-Output "dotnet $apiDll --urls `"$http;$https`""
     Set-Location $apiPublishPath
     dotnet $apiDll --urls "$http;$https"


### PR DESCRIPTION
## Summary
Add message when running build script API, so user is aware that the terminal window should remain open for catapult to work. Also add link to learn more about catapult components

## Related issue
- #294 