### PR TITLE
Fix duplicate console write when invoke plugin

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -158,8 +158,6 @@ namespace Polyrific.Catapult.Engine.Core
             {
                 if (process != null)
                 {
-                    Console.WriteLine($"Invoking Task Provider {Path.GetFileNameWithoutExtension(pluginStartFile)}...");
-
                     if (!string.IsNullOrEmpty(securedPluginArgs))
                     {
                         _logger.LogDebug($"[PluginManager] Command: {fileName} {securedArguments}");

--- a/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
@@ -91,6 +91,8 @@ namespace Polyrific.Catapult.Engine.Core
 
                     // main process
                     _logger.LogInformation("[Queue {Code}] Running {jobTask.Type} task", job.Code, jobTask.Type);
+
+                    System.Console.WriteLine($"Invoking \"{jobTask.Name}\" task.");
                     var result = await taskObj.RunMainTask(outputValues);
                     results[jobTask.Id] = result;
                     if (!result.IsSuccess && result.StopTheProcess)

--- a/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
@@ -92,7 +92,7 @@ namespace Polyrific.Catapult.Engine.Core
                     // main process
                     _logger.LogInformation("[Queue {Code}] Running {jobTask.Type} task", job.Code, jobTask.Type);
 
-                    System.Console.WriteLine($"Invoking \"{jobTask.Name}\" task.");
+                    System.Console.WriteLine($"Invoking \"{jobTask.Type}\" task.");
                     var result = await taskObj.RunMainTask(outputValues);
                     results[jobTask.Id] = result;
                     if (!result.IsSuccess && result.StopTheProcess)


### PR DESCRIPTION
## Summary
Move the console write from the plugin manager, into the task runner, so the console will only be written for the main task.

## Related issue
- #308 