### PR TITLE
Refactor plugin core constructor

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -101,7 +101,7 @@ namespace Polyrific.Catapult.Engine.Core
                             var type = info.EntryPoint.DeclaringType?.FullName;
                             if (type != null)
                             {
-                                var instance = (TaskProvider)info.CreateInstance(type, false, BindingFlags.ExactBinding, null, new object[] { }, null, null);
+                                var instance = (TaskProvider)info.CreateInstance(type, false, BindingFlags.ExactBinding, null, new object[] { new string[0] }, null, null);
                                 if (instance != null)
                                 {
                                     if (!_plugins.ContainsKey(instance.Type))

--- a/src/Plugins/BuildProvider/Polyrific.Catapult.Plugins.DotNetCore/src/Program.cs
+++ b/src/Plugins/BuildProvider/Polyrific.Catapult.Plugins.DotNetCore/src/Program.cs
@@ -14,12 +14,8 @@ namespace Polyrific.Catapult.Plugins.DotNetCore
         private IBuilder _builder;
 
         public override string Name => TaskProviderName;
-
-        public Program() : base(new string[0], TaskProviderName)
-        {
-        }
-
-        public Program(string[] args) : base(args, TaskProviderName)
+        
+        public Program(string[] args) : base(args)
         {
         }
         

--- a/src/Plugins/DatabaseProvider/Polyrific.Catapult.Plugins.EntityFrameworkCore/src/Program.cs
+++ b/src/Plugins/DatabaseProvider/Polyrific.Catapult.Plugins.EntityFrameworkCore/src/Program.cs
@@ -13,11 +13,7 @@ namespace Polyrific.Catapult.Plugins.EntityFrameworkCore
 
         private IDatabaseCommand _databaseCommand;
 
-        public Program() : base(new string[0], TaskProviderName)
-        {
-        }
-
-        public Program(string[] args) : base(args, TaskProviderName)
+        public Program(string[] args) : base(args)
         {
         }
 

--- a/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Program.cs
+++ b/src/Plugins/GeneratorProvider/Polyrific.Catapult.Plugins.AspNetCoreMvc/src/Program.cs
@@ -12,11 +12,7 @@ namespace Polyrific.Catapult.Plugins.AspNetCoreMvc
 
         public override string Name => TaskProviderName;
 
-        public Program() : base(new string[0], TaskProviderName)
-        {
-        }
-
-        public Program(string[] args) : base(args, TaskProviderName)
+        public Program(string[] args) : base(args)
         {
         }
         

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/Program.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.Plugins.AzureAppService/src/Program.cs
@@ -13,11 +13,7 @@ namespace Polyrific.Catapult.Plugins.AzureAppService
         private readonly IAzureUtils _azureUtils;
         private readonly IDeployUtils _deployUtils;
 
-        public Program() : base(new string[0], TaskProviderName)
-        {
-        }
-
-        public Program(string[] args) : base(args, TaskProviderName)
+        public Program(string[] args) : base(args)
         {
         }
 

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/BuildProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/BuildProvider.cs
@@ -10,8 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class BuildProvider : TaskProvider
     {
-        protected BuildProvider(string[] args, string taskProviderName) 
-            : base(args, taskProviderName)
+        protected BuildProvider(string[] args) 
+            : base(args)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/CodeGeneratorProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/CodeGeneratorProvider.cs
@@ -11,8 +11,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class CodeGeneratorProvider : TaskProvider
     {
-        protected CodeGeneratorProvider(string[] args, string taskProviderName) 
-            : base(args, taskProviderName)
+        protected CodeGeneratorProvider(string[] args) 
+            : base(args)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/DatabaseProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/DatabaseProvider.cs
@@ -10,8 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class DatabaseProvider : TaskProvider
     {
-        protected DatabaseProvider(string[] args, string taskProviderName) 
-            : base(args, taskProviderName)
+        protected DatabaseProvider(string[] args) 
+            : base(args)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/HostingProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/HostingProvider.cs
@@ -10,8 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class HostingProvider : TaskProvider
     {
-        protected HostingProvider(string[] args, string taskProviderName) 
-            : base(args, taskProviderName)
+        protected HostingProvider(string[] args) 
+            : base(args)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/RepositoryProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/RepositoryProvider.cs
@@ -10,8 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class RepositoryProvider : TaskProvider
     {
-        protected RepositoryProvider(string[] args, string taskProviderName) 
-            : base(args, taskProviderName)
+        protected RepositoryProvider(string[] args) 
+            : base(args)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/StorageProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/StorageProvider.cs
@@ -10,8 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class StorageProvider : TaskProvider
     {
-        protected StorageProvider(string[] args, string taskProviderName) 
-            : base(args, taskProviderName)
+        protected StorageProvider(string[] args) 
+            : base(args)
         {
             ParseArguments();
         }

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/TaskProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/TaskProvider.cs
@@ -17,7 +17,7 @@ namespace Polyrific.Catapult.Plugins.Core
         protected Dictionary<string, object> ParsedArguments;
         protected ILogger Logger;
 
-        protected TaskProvider(string[] args, string taskProviderName)
+        protected TaskProvider(string[] args)
         {
             if (args.Contains("--attach") && Debugger.IsAttached == false)
                 Debugger.Launch();
@@ -49,7 +49,7 @@ namespace Polyrific.Catapult.Plugins.Core
                 ParsedArguments = args.Length > 0 ? JsonConvert.DeserializeObject<Dictionary<string, object>>(args[0]) : new Dictionary<string, object>();
             }            
             
-            Logger = new TaskLogger(taskProviderName);
+            Logger = new TaskLogger(Name);
         }
 
         /// <summary>

--- a/src/Plugins/Polyrific.Catapult.Plugins.Core/TestProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.Plugins.Core/TestProvider.cs
@@ -10,8 +10,8 @@ namespace Polyrific.Catapult.Plugins.Core
 {
     public abstract class TestProvider : TaskProvider
     {
-        protected TestProvider(string[] args, string taskProviderName) 
-            : base(args, taskProviderName)
+        protected TestProvider(string[] args) 
+            : base(args)
         {
             ParseArguments();
         }

--- a/src/Plugins/RepositoryProvider/Polyrific.Catapult.Plugins.GitHub/src/Program.cs
+++ b/src/Plugins/RepositoryProvider/Polyrific.Catapult.Plugins.GitHub/src/Program.cs
@@ -24,11 +24,7 @@ namespace Polyrific.Catapult.Plugins.GitHub
 
         public override string[] RequiredServices => new[] { "GitHub" };
 
-        public Program() : base(new string[0], TaskProviderName)
-        {
-        }
-
-        public Program(string[] args) : base(args, TaskProviderName)
+        public Program(string[] args) : base(args)
         {
         }
 

--- a/src/Plugins/TestProvider/Polyrific.Catapult.Plugins.DotNetCoreTest/src/Program.cs
+++ b/src/Plugins/TestProvider/Polyrific.Catapult.Plugins.DotNetCoreTest/src/Program.cs
@@ -13,11 +13,7 @@ namespace Polyrific.Catapult.Plugins.DotNetCoreTest
 
         private ITestRunner _testRunner;
 
-        public Program() : base(new string[0], TaskProviderName)
-        {
-        }
-
-        public Program(string[] args) : base(args, TaskProviderName)
+        public Program(string[] args) : base(args)
         {
         }
 


### PR DESCRIPTION
## Summary
- Currently each plugin should provide a default constructor with no arguments, so plugin manager does not throw error when loading them. This error could only be identified in runtime, and is undetectable during plugin development. To handle this, I change the plugin manager to use the constructor with the `string[] args` argument when loading the plugin.
- Simplify the base constructor. We don't need to provide the TaskProviderName in the constructor, because it is actually available in the `Name` property. This should simplify the plugin development because the developer just need to create a standard constructor: `public Program(string[] args) : base(args)`.

