### PR TITLE
Enable CORS for angular website

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Startup.cs
+++ b/src/API/Polyrific.Catapult.Api/Startup.cs
@@ -110,6 +110,8 @@ namespace Polyrific.Catapult.Api
                 c.IncludeXmlComments(xmlPath);
 
             });
+
+            services.AddCors();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -143,6 +145,11 @@ namespace Polyrific.Catapult.Api
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "OpenCatapult API V1");
                 c.RoutePrefix = string.Empty;
             });
+
+            app.UseCors(builder => builder
+                .WithOrigins(Configuration["AllowedOrigin"])
+                .AllowAnyHeader()
+                .AllowAnyMethod());
 
             app.UseMvc();
 

--- a/src/API/Polyrific.Catapult.Api/appsettings.json
+++ b/src/API/Polyrific.Catapult.Api/appsettings.json
@@ -47,6 +47,7 @@
     }
   },
   "AllowedHosts": "*",
+  "AllowedOrigin": "http://localhost:4200",
   "NotificationProviders": "SmtpEmail",
   "SmtpSetting": {
     "Server": "localhost",


### PR DESCRIPTION
## Summary
Enable CORS in the API so the angular website can invoke it

## Related issue
- #320 