### PR TITLE
Fix duplicate projects

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
@@ -302,7 +302,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             var projectMembersByUserSpec = new ProjectMemberFilterSpecification(0, getAll ? 0 : userId, isArchived);
             projectMembersByUserSpec.Includes.Add(p => p.ProjectMemberRole);
             var projectMembers = await _projectMemberRepository.GetBySpec(projectMembersByUserSpec, cancellationToken);
-            var projects = projectMembers.Select(m => (m.Project, m.ProjectMemberRole)).ToList();
+            var projects = projectMembers.GroupBy(m => m.ProjectId).Select(g => g.FirstOrDefault()).Select(m => (m.Project, m.ProjectMemberRole)).ToList();
 
             return projects;
         }


### PR DESCRIPTION
## Summary
Fix the GET `project` API where the result returns duplicate project entries when it has several members