### PR TITLE
Add `build-prod` script to package.json

### DIFF
--- a/src/Web/opencatapultweb/package.json
+++ b/src/Web/opencatapultweb/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "build-prod": "ng build --prod --build-optimizer"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
Add `build-prod` script to Web's package.json. It is required by the CI setup.