### PR TITLE
Add cobertura report for code coverage

### DIFF
--- a/src/Web/opencatapultweb/src/karma.conf.js
+++ b/src/Web/opencatapultweb/src/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function (config) {
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '../coverage'),
-      reports: ['html', 'lcovonly', 'text-summary'],
+      reports: ['html', 'lcovonly', 'text-summary', 'cobertura'],
       fixWebpackSourcePaths: true
     },
     reporters: ['progress', 'kjhtml'],


### PR DESCRIPTION
## Summary
Add `cobertura` report for the test coverage. It is required by the CI to display the coverage report in Azure Pipeline.