### PR TITLE
Fix issue when parsing the installed dotnet SDK version

### DIFF
--- a/builds/build-prerequisites.ps1
+++ b/builds/build-prerequisites.ps1
@@ -14,9 +14,10 @@ $dotnetSdkVersion = [System.Version]"2.1.500"
 $allGood = $true
 
 $currentSdkVersion = dotnet --version
+$versionPattern = [Regex]::new("(\d+\.)(\d+\.)(\d+)")
+$parsedSdkVersion = $versionPattern.Matches($currentSdkVersion)
 
-
-if ([System.Version]$currentSdkVersion -lt $dotnetSdkVersion) {	
+if ([System.Version]$parsedSdkVersion.Value -lt $dotnetSdkVersion) {	
 	$allGood = $false
 	# Ask user if she want to automatically install the dotnet SDK
 	Write-host "We need to install the dotnet SDK version $dotnetSdkVersion for you. Proceed? (y/n)" -ForegroundColor Yellow 


### PR DESCRIPTION
## Summary
There was issue in the `build-prerequisites.ps1` script where the checking of SDK version was failed when the version contained some string values, e.g. `2.1.600-preview-009497`. In this PR I fix the issue by parsing the simple format only (e.g. `2.1.600`) to be compared with the required minimum SDK version.