### PR TITLE
Fix access issue for unregistered engines

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
@@ -172,6 +172,9 @@ namespace Polyrific.Catapult.Api.Controllers
         [Authorize(Policy = AuthorizePolicy.UserRoleEngineAccess)]
         public async Task<IActionResult> CheckJob()
         {
+            if (!await CheckEngineStatus())
+                return Unauthorized();
+
             // log as debug so it won't be put to log when min level is Info
             _logger.LogDebug("Checking for job queue");
 
@@ -200,6 +203,9 @@ namespace Polyrific.Catapult.Api.Controllers
         [Authorize(Policy = AuthorizePolicy.UserRoleEngineAccess)]
         public async Task<IActionResult> UpdateJobQueue(int queueId, UpdateJobDto job)
         {
+            if (!await CheckEngineStatus())
+                return Unauthorized();
+                
             _logger.LogInformation("Updating job queue. Request body: {@job}", job);
 
             try
@@ -278,6 +284,13 @@ namespace Polyrific.Catapult.Api.Controllers
             }
 
             return null;
+        }
+
+        private async Task<bool> CheckEngineStatus()
+        {
+            var engine = await _engineService.GetCatapultEngine(User.Identity.Name);
+
+            return engine != null ? engine.IsActive : false;
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Program.cs
+++ b/src/API/Polyrific.Catapult.Api/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace Polyrific.Catapult.Api
@@ -21,7 +22,11 @@ namespace Polyrific.Catapult.Api
             {
                 Log.Information("Starting Catapult API host..");
 
-                CreateWebHostBuilder(args).Build().Run();
+                var webhost = CreateWebHostBuilder(args).Build();
+
+                Console.WriteLine($"Ready for debugger to attach. Process ID: {Process.GetCurrentProcess().Id}.");
+
+                webhost.Run();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
Fix issue where a removed Engine was still able to access API. The focus of this fix is only on the controllers which require Engine role authorization (`[Authorize(Policy = AuthorizePolicy.UserRoleEngineAccess)]`). I don't think we need to apply the same checking for controllers with other user role authorization because it has had preventive mechanism through user login.

## Coverage
- [x] Add logic to check engine status
- [x] Show process ID of the running API to make it possible to debug in Visual Studio

## References
- Related Issues: https://github.com/Polyrific-Inc/OpenCatapult/issues/319
