### PR TITLE
Set console window titles

### DIFF
--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -10,6 +10,8 @@ param(
     [string]$environment = "Development"
 )
 
+$host.UI.RawUI.WindowTitle = "OpenCatapult API";
+
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = $true
 $env:ASPNETCORE_ENVIRONMENT = $environment
 

--- a/builds/build-cli.ps1
+++ b/builds/build-cli.ps1
@@ -6,6 +6,8 @@ param(
     [switch]$noConfig = $false
 )
 
+$host.UI.RawUI.WindowTitle = "OpenCatapult CLI";
+
 $rootPath = Split-Path $PSScriptRoot
 $cliCsprojPath = Join-Path $rootPath "/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj"
 $cliPublishPath = Join-Path $rootPath "/publish/cli"

--- a/builds/build-engine.ps1
+++ b/builds/build-engine.ps1
@@ -6,6 +6,8 @@ param(
     [switch]$noConfig = $false
 )
 
+$host.UI.RawUI.WindowTitle = "OpenCatapult Engine";
+
 $rootPath = Split-Path $PSScriptRoot
 $engineCsprojPath = Join-Path $rootPath "/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj"
 $enginePublishPath = Join-Path $rootPath "/publish/engine"

--- a/src/API/Polyrific.Catapult.Api/Program.cs
+++ b/src/API/Polyrific.Catapult.Api/Program.cs
@@ -14,6 +14,8 @@ namespace Polyrific.Catapult.Api
     {
         public static void Main(string[] args)
         {
+            Console.Title = "OpenCatapult API";
+
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(Configuration)
                 .CreateLogger();

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/BaseCommand.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Cli.Extensions;
 using Polyrific.Catapult.Shared.Common;
 
 namespace Polyrific.Catapult.Cli.Commands
@@ -41,6 +42,8 @@ namespace Polyrific.Catapult.Cli.Commands
 
         protected virtual int OnExecute(CommandLineApplication app)
         {
+            Console.SetWindowTitle("OpenCatapult CLI");
+
             Console.WriteLine("----------------------------");
             Console.WriteLine("|     OpenCatapult CLI     |");
             Console.WriteLine("----------------------------");

--- a/src/CLI/Polyrific.Catapult.Cli/Extensions/ConsoleExtension.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Extensions/ConsoleExtension.cs
@@ -136,6 +136,16 @@ namespace Polyrific.Catapult.Cli.Extensions
             while (true);
         }
 
+        /// <summary>
+        /// Set title of the opened console window.
+        /// </summary>
+        /// <param name="console">The console</param>
+        /// <param name="title">The title</param>
+        public static void SetWindowTitle(this IConsole console, string title)
+        {
+            Console.Title = title;
+        }
+
         private static void Write(string value, ConsoleColor? foreground, ConsoleColor? background)
         {
             if (foreground.HasValue)

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/BaseCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/BaseCommand.cs
@@ -2,6 +2,7 @@
 
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Engine.Extensions;
 using System;
 using System.Diagnostics;
 
@@ -35,6 +36,8 @@ namespace Polyrific.Catapult.Engine.Commands
 
         protected virtual int OnExecute(CommandLineApplication app)
         {
+            Console.SetWindowTitle("OpenCatapult Engine");
+
             Console.WriteLine("-------------------------------");
             Console.WriteLine("|     OpenCatapult Engine     |");
             Console.WriteLine("-------------------------------");

--- a/src/Engine/Polyrific.Catapult.Engine/Extensions/ConsoleExtension.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Extensions/ConsoleExtension.cs
@@ -173,6 +173,16 @@ namespace Polyrific.Catapult.Engine.Extensions
         }
 
         /// <summary>
+        /// Set title of the opened console window.
+        /// </summary>
+        /// <param name="console">The console</param>
+        /// <param name="title">The title</param>
+        public static void SetWindowTitle(this IConsole console, string title)
+        {
+            Console.Title = title;
+        }
+
+        /// <summary>
         /// Base implementation of GetPassword and GetPasswordAsString. Prompts the user for
         /// a password and yields each key as the user inputs. Password is masked as input. Pressing Escape will reset the password
         /// by flushing the stream with backspace keys.


### PR DESCRIPTION
## Summary
Set title of the console window (PowerShell) when running OpenCatapult components. Apparently this fixes will only set the title when the app is running, not permanently. However I think this behavior is appropriate because when the app stops, the process is detached from the console (hence it won't make sense to keep the title for detached processes).

## Coverage
- [x] Set title from the build scripts
- [x] Set title from the running binary

## References
- Related Issues: https://github.com/Polyrific-Inc/OpenCatapult/issues/321