### PR TITLE
Update command line utils version

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/ActivateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/ActivateCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "Activate a suspended user")]
+    [Command("activate", Description = "Activate a suspended user")]
     public class ActivateCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "List users")]
+    [Command("list", Description = "List users")]
     public class ListCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account.Password
 {
-    [Command(Description = "Reset user password")]
+    [Command("reset", Description = "Reset user password")]
     public class ResetCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetTokenCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/ResetTokenCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account.Password
 {
-    [Command(Description = "Request reset password token")]
+    [Command("resettoken", Description = "Request reset password token")]
     public class ResetTokenCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/Password/UpdateCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account.Password
 {
-    [Command(Description = "Update current user's password")]
+    [Command("update", Description = "Update current user's password")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/PasswordCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/PasswordCommand.cs
@@ -6,10 +6,10 @@ using Polyrific.Catapult.Cli.Commands.Account.Password;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "Account password related command")]
-    [Subcommand("update", typeof(Password.UpdateCommand))]
-    [Subcommand("resettoken", typeof(ResetTokenCommand))]
-    [Subcommand("reset", typeof(ResetCommand))]
+    [Command("password", Description = "Account password related command")]
+    [Subcommand(typeof(Password.UpdateCommand))]
+    [Subcommand(typeof(ResetTokenCommand))]
+    [Subcommand(typeof(ResetCommand))]
     public class PasswordCommand : BaseCommand
     {
         public PasswordCommand(IConsole console, ILogger<PasswordCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/RegisterCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/RegisterCommand.cs
@@ -9,7 +9,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "Register a new user")]
+    [Command("register", Description = "Register a new user")]
     public class RegisterCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "Remove a user")]
+    [Command("remove", Description = "Remove a user")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/SetRoleCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/SetRoleCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "Set the role of a user")]
+    [Command("setrole", Description = "Set the role of a user")]
     public class SetRoleCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/SuspendCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/SuspendCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "Suspend a user")]
+    [Command("suspend", Description = "Suspend a user")]
     public class SuspendCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Account/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Account/UpdateCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Account
 {
-    [Command(Description = "Update user profile")]
+    [Command("update", Description = "Update user profile")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/AccountCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/AccountCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Account;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("account", Description = "User account related command")]
+    [Command(Description = "User account related command")]
     [Subcommand(typeof(ListCommand))]
     [Subcommand(typeof(ActivateCommand))]
     [Subcommand(typeof(RegisterCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/AccountCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/AccountCommand.cs
@@ -6,15 +6,15 @@ using Polyrific.Catapult.Cli.Commands.Account;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "User account related command")]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("activate", typeof(ActivateCommand))]
-    [Subcommand("register", typeof(RegisterCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("suspend", typeof(SuspendCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
-    [Subcommand("password", typeof(PasswordCommand))]
-    [Subcommand("setrole", typeof(SetRoleCommand))]
+    [Command("account", Description = "User account related command")]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(ActivateCommand))]
+    [Subcommand(typeof(RegisterCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(SuspendCommand))]
+    [Subcommand(typeof(UpdateCommand))]
+    [Subcommand(typeof(PasswordCommand))]
+    [Subcommand(typeof(SetRoleCommand))]
     public class AccountCommand : BaseCommand
     {
         public AccountCommand(IConsole console, ILogger<AccountCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Config/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Config/GetCommand.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Polyrific.Catapult.Cli.Commands.Config
 {
-    [Command(Description = "Get config value")]
+    [Command("get", Description = "Get config value")]
     public class GetCommand : BaseCommand
     {
         private readonly ICliConfig _cliConfig;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Config/ImportCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Config/ImportCommand.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Polyrific.Catapult.Cli.Commands.Config
 {
-    [Command(Description = "Import configuration from a config file")]
+    [Command("import", Description = "Import configuration from a config file")]
     public class ImportCommand : BaseCommand
     {
         private readonly ICliConfig _cliConfig;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Config/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Config/RemoveCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Cli.Extensions;
 
 namespace Polyrific.Catapult.Cli.Commands.Config
 {
-    [Command(Description = "Remove configurations")]
+    [Command("remove", Description = "Remove configurations")]
     public class RemoveCommand : BaseCommand
     {
         private readonly ICliConfig _cliConfig;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Config/SetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Config/SetCommand.cs
@@ -11,7 +11,7 @@ using Polyrific.Catapult.Cli.Extensions;
 
 namespace Polyrific.Catapult.Cli.Commands.Config
 {
-    [Command(Description = "Set config value")]
+    [Command("set", Description = "Set config value")]
     public class SetCommand : BaseCommand
     {
         private readonly ICliConfig _cliConfig;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ConfigCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ConfigCommand.cs
@@ -6,11 +6,11 @@ using Polyrific.Catapult.Cli.Commands.Config;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Configure the CLI")]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("set", typeof(SetCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("import", typeof(ImportCommand))]
+    [Command("config", Description = "Configure the CLI")]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(SetCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(ImportCommand))]
     public class ConfigCommand : BaseCommand
     {
         public ConfigCommand(IConsole console, ILogger<ConfigCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ConfigCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ConfigCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Config;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("config", Description = "Configure the CLI")]
+    [Command(Description = "Configure the CLI")]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(SetCommand))]
     [Subcommand(typeof(RemoveCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/CurrentUserCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/CurrentUserCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("currentuser", Description = "Get current user")]
+    [Command(Description = "Get current user")]
     public class CurrentUserCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/CurrentUserCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/CurrentUserCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Get current user")]
+    [Command("currentuser", Description = "Get current user")]
     public class CurrentUserCommand : BaseCommand
     {
         private readonly IAccountService _accountService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/ActivateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/ActivateCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Engine
 {
-    [Command(Description = "Activate a suspended engine")]
+    [Command("activate", Description = "Activate a suspended engine")]
     public class ActivateCommand : BaseCommand
     {
         private readonly ICatapultEngineService _engineService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/GetCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Engine
 {
-    [Command(Description = "Get a single engine record")]
+    [Command("get", Description = "Get a single engine record")]
     public class GetCommand : BaseCommand
     {
         private readonly ICatapultEngineService _engineService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Engine
 {
-    [Command(Description = "List registered engines")]
+    [Command("list", Description = "List registered engines")]
     public class ListCommand : BaseCommand
     {
         private readonly ICatapultEngineService _engineService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/RegisterCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/RegisterCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Engine
 {
-    [Command(Description = "Register a new engine")]
+    [Command("register", Description = "Register a new engine")]
     public class RegisterCommand : BaseCommand
     {
         private readonly ICatapultEngineService _engineService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Engine
 {
-    [Command(Description = "Remove an engine")]
+    [Command("remove", Description = "Remove an engine")]
     public class RemoveCommand : BaseCommand
     {
         private readonly ICatapultEngineService _engineService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/SuspendCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/SuspendCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Engine
 {
-    [Command(Description = "Suspend an engine")]
+    [Command("suspend", Description = "Suspend an engine")]
     public class SuspendCommand : BaseCommand
     {
         private readonly ICatapultEngineService _engineService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/TokenCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Engine/TokenCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 namespace Polyrific.Catapult.Cli.Commands.Engine
 {
 
-    [Command(Description = "Generate a token for the engine")]
+    [Command("token", Description = "Generate a token for the engine")]
     public class TokenCommand : BaseCommand
     {
         private readonly ITokenService _tokenService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/EngineCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/EngineCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Engine;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("engine", Description = "Catapult Engine registration commands")]
+    [Command(Description = "Catapult Engine registration commands")]
     [Subcommand(typeof(ListCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(RegisterCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/EngineCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/EngineCommand.cs
@@ -6,14 +6,14 @@ using Polyrific.Catapult.Cli.Commands.Engine;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Catapult Engine registration commands")]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("register", typeof(RegisterCommand))]
-    [Subcommand("token", typeof(TokenCommand))]
-    [Subcommand("suspend", typeof(SuspendCommand))]
-    [Subcommand("activate", typeof(ActivateCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
+    [Command("engine", Description = "Catapult Engine registration commands")]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(RegisterCommand))]
+    [Subcommand(typeof(TokenCommand))]
+    [Subcommand(typeof(SuspendCommand))]
+    [Subcommand(typeof(ActivateCommand))]
+    [Subcommand(typeof(RemoveCommand))]
     public class EngineCommand : BaseCommand
     {
         public EngineCommand(IConsole console, ILogger<EngineCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/AddCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Job
 {
-    [Command(Description = "Add a new job definition")]
+    [Command("add", Description = "Add a new job definition")]
     public class AddCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/GetCommand.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Job
 {
-    [Command(Description = "Get a single job definition record")]
+    [Command("get", Description = "Get a single job definition record")]
     public class GetCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Job
 {
-    [Command(Description = "List project definitions")]
+    [Command("list", Description = "List project definitions")]
     public class ListCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Job
 {
-    [Command(Description = "Remove a job definition")]
+    [Command("remove", Description = "Remove a job definition")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/UpdateCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Job
 {
-    [Command(Description = "Update a job definition")]
+    [Command("update", Description = "Update a job definition")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Job;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("job", Description = "Job definition related command")]
+    [Command(Description = "Job definition related command")]
     [Subcommand(typeof(AddCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(ListCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
@@ -6,12 +6,12 @@ using Polyrific.Catapult.Cli.Commands.Job;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Job definition related command")]
-    [Subcommand("add", typeof(AddCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
+    [Command("job", Description = "Job definition related command")]
+    [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(UpdateCommand))]
     public class JobCommand : BaseCommand
     {
         public JobCommand(IConsole console, ILogger<JobCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/LoginCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/LoginCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Login as a user")]
+    [Command("login", Description = "Login as a user")]
     public class LoginCommand : BaseCommand
     {
         private readonly ITokenService _tokenService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/LoginCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/LoginCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("login", Description = "Login as a user")]
+    [Command(Description = "Login as a user")]
     public class LoginCommand : BaseCommand
     {
         private readonly ITokenService _tokenService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/LogoutCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/LogoutCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Logout from the application")]
+    [Command("logout", Description = "Logout from the application")]
     public class LogoutCommand : BaseCommand
     {
         private readonly ITokenStore _tokenStore;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/LogoutCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/LogoutCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("logout", Description = "Logout from the application")]
+    [Command(Description = "Logout from the application")]
     public class LogoutCommand : BaseCommand
     {
         private readonly ITokenStore _tokenStore;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Member/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Member/AddCommand.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Member
 {
-    [Command(Description = "Add user as a project member")]
+    [Command("add", Description = "Add user as a project member")]
     public class AddCommand : BaseCommand
     {
         private readonly IProjectMemberService _projectMemberService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Member/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Member/ListCommand.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Member
 {
-    [Command(Description = "List members of a project")]
+    [Command("list", Description = "List members of a project")]
     public class ListCommand : BaseCommand
     {
         private readonly IProjectMemberService _projectMemberService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Member/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Member/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Member
 {
-    [Command(Description = "Remove a project member")]
+    [Command("remove", Description = "Remove a project member")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IProjectMemberService _projectMemberService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Member/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Member/UpdateCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Member
 {
-    [Command(Description = "Update the role of a project member")]
+    [Command("update", Description = "Update the role of a project member")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IProjectMemberService _projectMemberService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/MemberCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/MemberCommand.cs
@@ -6,11 +6,11 @@ using Polyrific.Catapult.Cli.Commands.Member;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Project member related command")]
-    [Subcommand("add", typeof(AddCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
+    [Command("member", Description = "Project member related command")]
+    [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(UpdateCommand))]
     public class MemberCommand : BaseCommand
     {
         public MemberCommand(IConsole console, ILogger<MemberCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/MemberCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/MemberCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Member;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("member", Description = "Project member related command")]
+    [Command(Description = "Project member related command")]
     [Subcommand(typeof(AddCommand))]
     [Subcommand(typeof(ListCommand))]
     [Subcommand(typeof(RemoveCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/AddCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Model
 {
-    [Command(Description = "Add a project data model")]
+    [Command("add", Description = "Add a project data model")]
     public class AddCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/GetCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Model
 {
-    [Command(Description = "Get a single project data model record")]
+    [Command("get", Description = "Get a single project data model record")]
     public class GetCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Model
 {
-    [Command(Description = "List data models in a project")]
+    [Command("list", Description = "List data models in a project")]
     public class ListCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Model
 {
-    [Command(Description = "Remove a project data model")]
+    [Command("remove", Description = "Remove a project data model")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Model/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Model/UpdateCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Model
 {
-    [Command(Description = "Update project data model")]
+    [Command("update", Description = "Update project data model")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ModelCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ModelCommand.cs
@@ -6,12 +6,12 @@ using Polyrific.Catapult.Cli.Commands.Model;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Project data model related command")]
-    [Subcommand("add", typeof(AddCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
+    [Command("model", Description = "Project data model related command")]
+    [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(UpdateCommand))]
     public class ModelCommand : BaseCommand
     {
         public ModelCommand(IConsole console, ILogger<ModelCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ModelCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ModelCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Model;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("model", Description = "Project data model related command")]
+    [Command(Description = "Project data model related command")]
     [Subcommand(typeof(AddCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(ListCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ArchiveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ArchiveCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Archive a project")]
+    [Command("archive", Description = "Archive a project")]
     public class ArchiveCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CloneCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CloneCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Create project by copying from existing")]
+    [Command("clone", Description = "Create project by copying from existing")]
     public class CloneCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
@@ -19,7 +19,7 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Create a project")]
+    [Command("create", Description = "Create a project")]
     public class CreateCommand : BaseCommand
     {
         private readonly IConsoleReader _consoleReader;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ExportCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ExportCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Export project into a yaml file")]
+    [Command("export", Description = "Export project into a yaml file")]
     public class ExportCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/GetCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Get a single project record")]
+    [Command("get", Description = "Get a single project record")]
     public class GetCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "List projects which the user has access to")]
+    [Command("list", Description = "List projects which the user has access to")]
     public class ListCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Remove a project")]
+    [Command("remove", Description = "Remove a project")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/RestoreCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/RestoreCommand.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Restore an archived project")]
+    [Command("restore", Description = "Restore an archived project")]
     public class RestoreCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/UpdateCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
-    [Command(Description = "Update a project")]
+    [Command("update", Description = "Update a project")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ProjectCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ProjectCommand.cs
@@ -6,16 +6,16 @@ using Polyrific.Catapult.Cli.Commands.Project;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Project related command")]
-    [Subcommand("archive", typeof(ArchiveCommand))]
-    [Subcommand("create", typeof(CreateCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("restore", typeof(RestoreCommand))]
-    [Subcommand("clone", typeof(CloneCommand))]
-    [Subcommand("export", typeof(ExportCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
+    [Command("project", Description = "Project related command")]
+    [Subcommand(typeof(ArchiveCommand))]
+    [Subcommand(typeof(CreateCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(RestoreCommand))]
+    [Subcommand(typeof(CloneCommand))]
+    [Subcommand(typeof(ExportCommand))]
+    [Subcommand(typeof(UpdateCommand))]
     public class ProjectCommand : BaseCommand
     {
         public ProjectCommand(IConsole console, ILogger<ProjectCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ProjectCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ProjectCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Project;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("project", Description = "Project related command")]
+    [Command(Description = "Project related command")]
     [Subcommand(typeof(ArchiveCommand))]
     [Subcommand(typeof(CreateCommand))]
     [Subcommand(typeof(GetCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Property/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Property/AddCommand.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Property
 {
-    [Command(Description = "Add a project data model property")]
+    [Command("add", Description = "Add a project data model property")]
     public class AddCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Property/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Property/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Property
 {
-    [Command(Description = "List properties of a data model")]
+    [Command("list", Description = "List properties of a data model")]
     public class ListCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Property/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Property/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Property
 {
-    [Command(Description = "Remove a project data model property")]
+    [Command("remove", Description = "Remove a project data model property")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Property/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Property/UpdateCommand.cs
@@ -9,7 +9,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Polyrific.Catapult.Cli.Commands.Property
 {
-    [Command(Description = "Update a project data model property")]
+    [Command("update", Description = "Update a project data model property")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/PropertyCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/PropertyCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Property;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("property", Description = "Project data model property related command")]
+    [Command(Description = "Project data model property related command")]
     [Subcommand(typeof(AddCommand))]
     [Subcommand(typeof(ListCommand))]
     [Subcommand(typeof(RemoveCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/PropertyCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/PropertyCommand.cs
@@ -6,11 +6,11 @@ using Polyrific.Catapult.Cli.Commands.Property;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Project data model property related command")]
-    [Subcommand("add", typeof(AddCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
+    [Command("property", Description = "Project data model property related command")]
+    [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(UpdateCommand))]
     public class PropertyCommand : BaseCommand
     {
         public PropertyCommand(IConsole console, ILogger<PropertyCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/GetCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Provider
 {
-    [Command(Description = "Get a single task provider details")]
+    [Command("get", Description = "Get a single task provider details")]
     public class GetCommand : BaseCommand
     {
         private readonly IProviderService _providerService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Provider
 {
-    [Command(Description = "List registered task providers")]
+    [Command("list", Description = "List registered task providers")]
     public class ListCommand : BaseCommand
     {
         private readonly IProviderService _providerService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/RegisterCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/RegisterCommand.cs
@@ -10,7 +10,7 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace Polyrific.Catapult.Cli.Commands.Provider
 {
-    [Command(Description = "Register a new task provider")]
+    [Command("register", Description = "Register a new task provider")]
     public class RegisterCommand : BaseCommand
     {
         private readonly IProviderService _providerService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Provider/RemoveCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Provider
 {
-    [Command(Description = "Remove a task provider registration")]
+    [Command("remove", Description = "Remove a task provider registration")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IProviderService _providerService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ProviderCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ProviderCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Provider;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("provider", Description = "Task provider registration commands")]
+    [Command(Description = "Task provider registration commands")]
     [Subcommand(typeof(ListCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(RegisterCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ProviderCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ProviderCommand.cs
@@ -6,11 +6,11 @@ using Polyrific.Catapult.Cli.Commands.Provider;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Task provider registration commands")]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("register", typeof(RegisterCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
+    [Command("provider", Description = "Task provider registration commands")]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(RegisterCommand))]
+    [Subcommand(typeof(RemoveCommand))]
     public class ProviderCommand : BaseCommand
     {
         public ProviderCommand(IConsole console, ILogger<ProviderCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddCommand.cs
@@ -12,7 +12,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Queue
 {
-    [Command(Description = "Add job to queue")]
+    [Command("add", Description = "Add job to queue")]
     public class AddCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/CancelCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/CancelCommand.cs
@@ -11,7 +11,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Queue
 {
-    [Command(Description = "Cancelling a processing job")]
+    [Command("cancel", Description = "Cancelling a processing job")]
     public class CancelCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/GetCommand.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Queue
 {
-    [Command(Description = "Get a job queue")]
+    [Command("get", Description = "Get a job queue")]
     public class GetCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/ListCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Queue
 {
-    [Command(Description = "List queued jobs")]
+    [Command("list", Description = "List queued jobs")]
     public class ListCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/LogCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/LogCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Queue
 {
-    [Command(Description = "Get complete logs of a queued job")]
+    [Command("log", Description = "Get complete logs of a queued job")]
     public class LogCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/RestartCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/RestartCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Queue
 {
-    [Command(Description = "Restart a pending queued job")]
+    [Command("restart", Description = "Restart a pending queued job")]
     public class RestartCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
@@ -6,13 +6,13 @@ using Polyrific.Catapult.Cli.Commands.Queue;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Job queue related command")]
-    [Subcommand("add", typeof(AddCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("log", typeof(LogCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("restart", typeof(RestartCommand))]
-    [Subcommand("cancel", typeof(CancelCommand))]
+    [Command("queue", Description = "Job queue related command")]
+    [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(LogCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(RestartCommand))]
+    [Subcommand(typeof(CancelCommand))]
     public class QueueCommand : BaseCommand
     {
         public QueueCommand(IConsole console, ILogger<QueueCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Queue;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("queue", Description = "Job queue related command")]
+    [Command(Description = "Job queue related command")]
     [Subcommand(typeof(AddCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(LogCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
@@ -13,7 +13,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Service
 {
-    [Command(Description = "Add new external service")]
+    [Command("add", Description = "Add new external service")]
     public class AddCommand : BaseCommand
     {
         private readonly IConsoleReader _consoleReader;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/GetCommand.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Service
 {
-    [Command(Description = "Display a single external service")]
+    [Command("get", Description = "Display a single external service")]
     public class GetCommand : BaseCommand
     {
         private readonly IExternalServiceService _externalServiceService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/ListCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Service
 {
-    [Command(Description = "List external service names the user has access to")]
+    [Command("list", Description = "List external service names the user has access to")]
     public class ListCommand : BaseCommand
     {
         private readonly IExternalServiceService _externalServiceService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Service
 {
-    [Command(Description = "Remove an external service")]
+    [Command("remove", Description = "Remove an external service")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IExternalServiceService _externalServiceService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/UpdateCommand.cs
@@ -12,7 +12,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Service
 {
-    [Command(Description = "Update an external service")]
+    [Command("update", Description = "Update an external service")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IConsoleReader _consoleReader;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ServiceCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ServiceCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("service", Description = "External service related commands")]
+    [Command(Description = "External service related commands")]
     [Subcommand(typeof(AddCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(ListCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/ServiceCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/ServiceCommand.cs
@@ -6,12 +6,12 @@ using Polyrific.Catapult.Cli.Commands.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "External service related commands")]
-    [Subcommand("add", typeof(AddCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
+    [Command("service", Description = "External service related commands")]
+    [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(UpdateCommand))]
     public class ServiceCommand : BaseCommand
     {
         public ServiceCommand(IConsole console, ILogger<ServiceCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/AddCommand.cs
@@ -13,7 +13,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Task
 {
-    [Command(Description = "Add task to a job definition")]
+    [Command("add", Description = "Add task to a job definition")]
     public class AddCommand : BaseCommand
     {
         private readonly IConsoleReader _consoleReader;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/GetCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/GetCommand.cs
@@ -9,7 +9,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Task
 {
-    [Command(Description = "Get a single job task definition")]
+    [Command("get", Description = "Get a single job task definition")]
     public class GetCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/ListCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/ListCommand.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Task
 {
-    [Command(Description = "List job task definitions")]
+    [Command("list", Description = "List job task definitions")]
     public class ListCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/RemoveCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/RemoveCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Task
 {
-    [Command(Description = "Remove a job task definition")]
+    [Command("remove", Description = "Remove a job task definition")]
     public class RemoveCommand : BaseCommand
     {
         private readonly IProjectService _projectService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
@@ -14,7 +14,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands.Task
 {
-    [Command(Description = "Update a job task definition")]
+    [Command("update", Description = "Update a job task definition")]
     public class UpdateCommand : BaseCommand
     {
         private readonly IConsoleReader _consoleReader;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/TaskCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/TaskCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Cli.Commands.Task;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("task", Description = "Job task definition related command")]
+    [Command(Description = "Job task definition related command")]
     [Subcommand(typeof(AddCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(ListCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/TaskCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/TaskCommand.cs
@@ -6,12 +6,12 @@ using Polyrific.Catapult.Cli.Commands.Task;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Job task definition related command")]
-    [Subcommand("add", typeof(AddCommand))]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("list", typeof(ListCommand))]
-    [Subcommand("update", typeof(UpdateCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
+    [Command("task", Description = "Job task definition related command")]
+    [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(ListCommand))]
+    [Subcommand(typeof(UpdateCommand))]
+    [Subcommand(typeof(RemoveCommand))]
     public class TaskCommand : BaseCommand
     {
         public TaskCommand(IConsole console, ILogger<TaskCommand> logger) : base(console, logger)

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/VersionCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/VersionCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command(Description = "Check version of the components")]
+    [Command("version", Description = "Check version of the components")]
     public class VersionCommand : BaseCommand
     {
         private readonly IVersionService _versionService;

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/VersionCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/VersionCommand.cs
@@ -8,7 +8,7 @@ using Polyrific.Catapult.Shared.Service;
 
 namespace Polyrific.Catapult.Cli.Commands
 {
-    [Command("version", Description = "Check version of the components")]
+    [Command(Description = "Check version of the components")]
     public class VersionCommand : BaseCommand
     {
         private readonly IVersionService _versionService;

--- a/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj
+++ b/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
     <PackageReference Include="microsoft.aspnetcore.signalr.client" Version="1.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/CheckCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/CheckCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Engine.Extensions;
 
 namespace Polyrific.Catapult.Engine.Commands
 {
-    [Command("check", Description = "Check for any available job in queue")]
+    [Command(Description = "Check for any available job in queue")]
     public class CheckCommand : BaseCommand
     {
         private readonly ICatapultEngine _engine;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/CheckCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/CheckCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Engine.Extensions;
 
 namespace Polyrific.Catapult.Engine.Commands
 {
-    [Command(Description = "Check for any available job in queue")]
+    [Command("check", Description = "Check for any available job in queue")]
     public class CheckCommand : BaseCommand
     {
         private readonly ICatapultEngine _engine;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/Config/GetCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/Config/GetCommand.cs
@@ -7,7 +7,7 @@ using Polyrific.Catapult.Engine.Core;
 
 namespace Polyrific.Catapult.Engine.Commands.Config
 {
-    [Command(Description = "Get config value")]
+    [Command("get", Description = "Get config value")]
     public class GetCommand : BaseCommand
     {
         private readonly ICatapultEngineConfig _engineConfig;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/Config/ImportCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/Config/ImportCommand.cs
@@ -14,7 +14,7 @@ using Polyrific.Catapult.Engine.Core;
 
 namespace Polyrific.Catapult.Engine.Commands.Config
 {
-    [Command(Description = "Import configuration from a config file")]
+    [Command("import", Description = "Import configuration from a config file")]
     public class ImportCommand : BaseCommand
     {
         private readonly ICatapultEngineConfig _engineConfig;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/Config/RemoveCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/Config/RemoveCommand.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Polyrific.Catapult.Engine.Commands.Config
 {
-    [Command(Description = "Remove configurations")]
+    [Command("remove", Description = "Remove configurations")]
     public class RemoveCommand : BaseCommand
     {
         private readonly ICatapultEngineConfig _engineConfig;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/Config/SetCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/Config/SetCommand.cs
@@ -12,7 +12,7 @@ using Polyrific.Catapult.Engine.Extensions;
 
 namespace Polyrific.Catapult.Engine.Commands.Config
 {
-    [Command(Description = "Set config value")]
+    [Command("set", Description = "Set config value")]
     public class SetCommand : BaseCommand
     {
         private readonly ICatapultEngineConfig _engineConfig;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/ConfigCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/ConfigCommand.cs
@@ -6,11 +6,11 @@ using Polyrific.Catapult.Engine.Commands.Config;
 
 namespace Polyrific.Catapult.Engine.Commands
 {
-    [Command(Description = "Configure the engine")]
-    [Subcommand("get", typeof(GetCommand))]
-    [Subcommand("set", typeof(SetCommand))]
-    [Subcommand("remove", typeof(RemoveCommand))]
-    [Subcommand("import", typeof(ImportCommand))]
+    [Command("config", Description = "Configure the engine")]
+    [Subcommand(typeof(GetCommand))]
+    [Subcommand(typeof(SetCommand))]
+    [Subcommand(typeof(RemoveCommand))]
+    [Subcommand(typeof(ImportCommand))]
     public class ConfigCommand : BaseCommand
     {
         public ConfigCommand(IConsole console, ILogger<ConfigCommand> logger) : base(console, logger)

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/ConfigCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/ConfigCommand.cs
@@ -6,7 +6,7 @@ using Polyrific.Catapult.Engine.Commands.Config;
 
 namespace Polyrific.Catapult.Engine.Commands
 {
-    [Command("config", Description = "Configure the engine")]
+    [Command(Description = "Configure the engine")]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(SetCommand))]
     [Subcommand(typeof(RemoveCommand))]

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
@@ -9,7 +9,7 @@ using System.Timers;
 
 namespace Polyrific.Catapult.Engine.Commands
 {
-    [Command(Description = "Start the engine")]
+    [Command("start", Description = "Start the engine")]
     public class StartCommand : BaseCommand
     {
         private readonly ICatapultEngine _engine;

--- a/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Commands/StartCommand.cs
@@ -9,7 +9,7 @@ using System.Timers;
 
 namespace Polyrific.Catapult.Engine.Commands
 {
-    [Command("start", Description = "Start the engine")]
+    [Command(Description = "Start the engine")]
     public class StartCommand : BaseCommand
     {
         private readonly ICatapultEngine _engine;

--- a/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj
+++ b/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />


### PR DESCRIPTION
## Summary
Update `McMaster.Extensions.CommandLineUtils` to version `2.3.2` and fix obsolete methods.

## Coverage
- [x] Update package version
- [x] Fix obsolete methods

## References
- Other links: https://github.com/natemcmaster/CommandLineUtils/issues/139
