### PR TITLE
Fix timezone issue for Created and Updated date

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/BaseEntityConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/BaseEntityConfig.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Polyrific.Catapult.Api.Core.Entities;
@@ -11,6 +12,8 @@ namespace Polyrific.Catapult.Api.Data.EntityConfigs
         public virtual void Configure(EntityTypeBuilder<TEntity> builder)
         {
             builder.Property(e => e.ConcurrencyStamp).IsConcurrencyToken();
+            builder.Property(e => e.Created).HasConversion(v => v, v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+            builder.Property(e => e.Updated).HasConversion(v => v, v => v != null ? (DateTime?)DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : null);
         }
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
@@ -47,7 +47,7 @@ namespace Polyrific.Catapult.Cli.Extensions
                 {
                     sb.AppendLine(enumProp.ToListCliString($"{indentationString}{GetDisplayName(item.Name, nameDictionary)}:", obfuscatedFields, indentation, excludedFields));
                 }
-                else if (prop is DateTime)
+                else if (prop is DateTime || prop is DateTime?)
                 {
                     sb.AppendLine($"{indentationString}{GetDisplayName(item.Name, nameDictionary)}: {GetDisplayValue(item.Name, TimeZoneInfo.ConvertTimeFromUtc((DateTime)prop, TimeZoneInfo.Local).ToString(), obfuscatedFields)}");
                 }

--- a/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Extensions/CatapultCliExtensions.cs
@@ -47,6 +47,10 @@ namespace Polyrific.Catapult.Cli.Extensions
                 {
                     sb.AppendLine(enumProp.ToListCliString($"{indentationString}{GetDisplayName(item.Name, nameDictionary)}:", obfuscatedFields, indentation, excludedFields));
                 }
+                else if (prop is DateTime)
+                {
+                    sb.AppendLine($"{indentationString}{GetDisplayName(item.Name, nameDictionary)}: {GetDisplayValue(item.Name, TimeZoneInfo.ConvertTimeFromUtc((DateTime)prop, TimeZoneInfo.Local).ToString(), obfuscatedFields)}");
+                }
                 else
                 {
                     sb.AppendLine($"{indentationString}{GetDisplayName(item.Name, nameDictionary)}: {GetDisplayValue(item.Name, prop.ToString(), obfuscatedFields)}");


### PR DESCRIPTION
## Summary
Currently the date time for created and updated dates are displayed in UTC. It should be displayed in the local time instead. Setting the datetime kind to utc would allow the web ui to automatically display the local time as well.

## Coverage
- [x] Add conversion in repository
- [x] Update `ToCliString` helper to convert the timezone when displaying the date
