### PR TITLE
Include Project Id when retrieving Queue

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
@@ -56,18 +56,20 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <summary>
         /// Get a job queue by id
         /// </summary>
+        /// <param name="projectId">Id of the project</param>
         /// <param name="jobQueueId">Id of the job queue</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>job queue entity</returns>
-        Task<JobQueue> GetJobQueueById(int jobQueueId, CancellationToken cancellationToken = default(CancellationToken));
+        Task<JobQueue> GetJobQueueById(int projectId, int jobQueueId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get a job queue by code
         /// </summary>
+        /// <param name="projectId">Id of the project</param>
         /// <param name="jobQueueCode">Code of the job queue</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>job queue entity</returns>
-        Task<JobQueue> GetJobQueueByCode(string jobQueueCode, CancellationToken cancellationToken = default(CancellationToken));
+        Task<JobQueue> GetJobQueueByCode(int projectId, string jobQueueCode, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get the execution status of a job

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
@@ -81,10 +81,11 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <summary>
         /// Get the execution logs of a job
         /// </summary>
-        /// <param name="id">The job queue id</param>
+        /// <param name="projectId">The id of the project</param>
+        /// <param name="jobQueueId">The job queue id</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>The log text</returns>
-        Task<string> GetJobLogs(int id, CancellationToken cancellationToken = default(CancellationToken));
+        Task<string> GetJobLogs(int projectId, int jobQueueId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get the first unassigned queued job to be run

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -152,27 +152,27 @@ namespace Polyrific.Catapult.Api.Core.Services
 
         public async Task<List<JobQueue>> GetJobQueuesByStatus(string status, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var queueSpec = new JobQueueFilterSpecification(null, status);
+            var queueSpec = new JobQueueFilterSpecification(0, null, status);
             var jobQueues = await _jobQueueRepository.GetBySpec(queueSpec, cancellationToken);
             return jobQueues.ToList();
         }
 
-        public async Task<JobQueue> GetJobQueueById(int id, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<JobQueue> GetJobQueueById(int projectId, int id, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var queueSpec = new JobQueueFilterSpecification(id);
+            var queueSpec = new JobQueueFilterSpecification(projectId, id);
             queueSpec.Includes.Add(q => q.JobDefinition);
             var queue = await _jobQueueRepository.GetSingleBySpec(queueSpec, cancellationToken);
 
             return queue;
         }
 
-        public async Task<JobQueue> GetJobQueueByCode(string jobQueueCode, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<JobQueue> GetJobQueueByCode(int projectId, string jobQueueCode, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var queueSpec = new JobQueueFilterSpecification(jobQueueCode, null);
+            var queueSpec = new JobQueueFilterSpecification(projectId, jobQueueCode, null);
             queueSpec.Includes.Add(q => q.JobDefinition);
             var queue = await _jobQueueRepository.GetSingleBySpec(queueSpec, cancellationToken);
 
@@ -221,7 +221,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             {
                 if (job == null)
                 {
-                    var pendingJobSpec = new JobQueueFilterSpecification(null, JobStatus.Queued, engine);
+                    var pendingJobSpec = new JobQueueFilterSpecification(0, null, JobStatus.Queued, engine);
                     job = await _jobQueueRepository.GetSingleBySpec(pendingJobSpec, cancellationToken);
                 }
 
@@ -245,9 +245,13 @@ namespace Polyrific.Catapult.Api.Core.Services
             return $"{DateTime.UtcNow:yyyyMMdd}.{sequence}";
         }
 
-        public Task<string> GetJobLogs(int projectId, int jobQueueId, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<string> GetJobLogs(int projectId, int jobQueueId, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _textWriter.Read($"{JobQueueLog.FolderNamePrefix}_{projectId}_{jobQueueId}", null);
+            var queue = await GetJobQueueById(projectId, jobQueueId);
+            if (queue != null)
+                return await _textWriter.Read($"{JobQueueLog.FolderNamePrefix}_{projectId}_{jobQueueId}", null);
+            
+            return "";
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -245,9 +245,9 @@ namespace Polyrific.Catapult.Api.Core.Services
             return $"{DateTime.UtcNow:yyyyMMdd}.{sequence}";
         }
 
-        public Task<string> GetJobLogs(int id, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<string> GetJobLogs(int projectId, int jobQueueId, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _textWriter.Read($"{JobQueueLog.FolderNamePrefix}{id}", null);
+            return _textWriter.Read($"{JobQueueLog.FolderNamePrefix}_{projectId}_{jobQueueId}", null);
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
@@ -29,10 +29,12 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         /// <summary>
         /// Filter by the job queue id
         /// </summary>
+        /// <param name="projectId"></param>
         /// <param name="jobQueueId"></param>
-        public JobQueueFilterSpecification(int jobQueueId)
-            : base(m => m.Id == jobQueueId)
+        public JobQueueFilterSpecification(int projectId, int jobQueueId)
+            : base(m => m.ProjectId == projectId && m.Id == jobQueueId)
         {
+            ProjectId = projectId;
             JobQueueId = jobQueueId;
         }
 
@@ -51,12 +53,17 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         /// <summary>
         /// Filter by the queue code or status
         /// </summary>
+        /// <param name="projectId">The Id of the project</param>
         /// <param name="queueCode">Code of the job queue</param>
         /// <param name="status">Status of the job queue</param>
         /// <param name="engineId">Id of the Catapult Engine which executes the queue</param>
-        public JobQueueFilterSpecification(string queueCode, string status, string engineId = null)
-            : base(m => (queueCode == null || m.Code == queueCode) && (status == null || m.Status == status) && (engineId == null || m.CatapultEngineId == engineId), m => m.Created)
+        public JobQueueFilterSpecification(int projectId, string queueCode, string status, string engineId = null)
+            : base(m => (projectId == 0 || m.ProjectId == projectId)
+                && (queueCode == null || m.Code == queueCode) 
+                && (status == null || m.Status == status) 
+                && (engineId == null || m.CatapultEngineId == engineId), m => m.Created)
         {
+            ProjectId = projectId;
             QueueCode = queueCode;
             Status = status;
             EngineId = engineId;

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
@@ -70,7 +70,7 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             _logger.LogInformation("Getting job queue {queueId} in project {projectId}", queueId, projectId);
 
-            var job = await _jobQueueService.GetJobQueueById(queueId);
+            var job = await _jobQueueService.GetJobQueueById(projectId, queueId);
             var result = _mapper.Map<JobDto>(job);
             return Ok(result);
         }
@@ -87,7 +87,7 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             _logger.LogInformation("Getting job queue {queueCode} in project {projectId}", queueCode, projectId);
 
-            var job = await _jobQueueService.GetJobQueueByCode(queueCode);
+            var job = await _jobQueueService.GetJobQueueByCode(projectId, queueCode);
             var result = _mapper.Map<JobDto>(job);
             return Ok(result);
         }
@@ -118,7 +118,7 @@ namespace Polyrific.Catapult.Api.Controllers
                     newJobQueue.JobType,
                     newJobQueue.JobDefinitionId);
 
-                var job = await _jobQueueService.GetJobQueueById(queueId);
+                var job = await _jobQueueService.GetJobQueueById(projectId, queueId);
                 var result = _mapper.Map<JobDto>(job);
 
                 return CreatedAtRoute("GetJobQueueById", new

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
@@ -266,7 +266,7 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             _logger.LogInformation("Getting logs for job queue {queueId}", queueId);
 
-            var logs = await _jobQueueService.GetJobLogs(queueId);
+            var logs = await _jobQueueService.GetJobLogs(projectId, queueId);
 
             return Ok(logs);
         }

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/LogCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/LogCommand.cs
@@ -52,7 +52,7 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
                     switch (queue.Status)
                     {
                         case JobStatus.Processing:
-                            _jobQueueLogListener.Listen(queue.Id, OnLogReceived, OnLogError).Wait();
+                            _jobQueueLogListener.Listen(queue.ProjectId, queue.Id, OnLogReceived, OnLogError).Wait();
                             message = "";
                             return message;
                         case JobStatus.Completed:
@@ -65,7 +65,7 @@ namespace Polyrific.Catapult.Cli.Commands.Queue
                             if (Wait)
                             {
                                 Console.WriteLine("Waiting for log stream...");
-                                _jobQueueLogListener.Listen(queue.Id, OnLogReceived, OnLogError).Wait();
+                                _jobQueueLogListener.Listen(queue.ProjectId, queue.Id, OnLogReceived, OnLogError).Wait();
                                 message = "";
                             }
                             else

--- a/src/CLI/Polyrific.Catapult.Cli/JobQueueLogListener/IJobQueueLogListener.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/JobQueueLogListener/IJobQueueLogListener.cs
@@ -7,6 +7,6 @@ namespace Polyrific.Catapult.Cli
 {
     public interface IJobQueueLogListener
     {
-        Task Listen(int jobQueueId, Action<string> onLogReceived, Action<string> onError);
+        Task Listen(int projectId, int jobQueueId, Action<string> onLogReceived, Action<string> onError);
     }
 }

--- a/src/CLI/Polyrific.Catapult.Cli/JobQueueLogListener/SignalRJobQueueLogListener.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/JobQueueLogListener/SignalRJobQueueLogListener.cs
@@ -19,10 +19,10 @@ namespace Polyrific.Catapult.Cli
             _tokenStore = tokenStore;
         }
 
-        public async Task Listen(int jobQueueId, Action<string> onLogReceived, Action<string> onError)
+        public async Task Listen(int projectId, int jobQueueId, Action<string> onLogReceived, Action<string> onError)
         {
             var jobQueueCompleted = new TaskCompletionSource<bool>();
-            var connection = GetConnection(new Uri(_config.ApiUrl, $"{JobQueueHubEndpoint}?jobQueueId={jobQueueId}").AbsoluteUri);
+            var connection = GetConnection(new Uri(_config.ApiUrl, $"{JobQueueHubEndpoint}?projectId={projectId}&jobQueueId={jobQueueId}").AbsoluteUri);
 
             connection.On<string>("ReceiveInitialMessage", (initialMessage) =>
             {

--- a/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
@@ -47,7 +47,7 @@ namespace Polyrific.Catapult.Engine.Core
 
         public async Task ExecuteJob(JobDto jobQueue)
         {
-            using (_logger.BeginScope(new JobScope(jobQueue.Id)))
+            using (_logger.BeginScope(new JobScope(jobQueue.ProjectId, jobQueue.Id)))
             {
                 try
                 {

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobLogger/IJobLogWriter.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobLogger/IJobLogWriter.cs
@@ -6,7 +6,7 @@ namespace Polyrific.Catapult.Engine.Core.JobLogger
 {
     public interface IJobLogWriter
     {
-        Task WriteLog(int jobQueueId, string taskName, string message);
+        Task WriteLog(int projectId, int jobQueueId, string taskName, string message);
         Task EndJobLog(int jobQueueId);
     }
 }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobLogger/JobLoggerProvider.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobLogger/JobLoggerProvider.cs
@@ -33,22 +33,25 @@ namespace Polyrific.Catapult.Engine.Core.JobLogger
 
         public void WriteLog(string message)
         {
+            int projectId = 0;
             int jobQueueId = 0;
             string taskName = null;
 
             if (CurrentScope.State is JobScope jobScope)
             {
+                projectId = jobScope.ProjectId;
                 jobQueueId = jobScope.JobQueueId;
                 taskName = null;
             }
             else if (CurrentScope.State is TaskScope taskScope && CurrentScope.Parent?.State is JobScope parentJobScope)
             {
+                projectId = parentJobScope.ProjectId;
                 jobQueueId = parentJobScope.JobQueueId;
                 taskName = taskScope.TaskName;
             }
 
             if (jobQueueId != 0)
-                _jobLogWriter.WriteLog(jobQueueId, taskName, message).Wait();
+                _jobLogWriter.WriteLog(projectId, jobQueueId, taskName, message).Wait();
         }
     }
 }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobLogger/JobScope.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobLogger/JobScope.cs
@@ -4,11 +4,14 @@ namespace Polyrific.Catapult.Engine.Core.JobLogger
 {
     public class JobScope
     {
-        public JobScope(int jobQueueId)
+        public JobScope(int projectId, int jobQueueId)
         {
+            ProjectId = projectId;
             JobQueueId = jobQueueId;
         }
 
+        public int ProjectId { get; set; }
+        
         public int JobQueueId { get; set; }
     }
 }

--- a/src/Engine/Polyrific.Catapult.Engine.SignalRLogger/SignalRJobLogWriter.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.SignalRLogger/SignalRJobLogWriter.cs
@@ -35,20 +35,20 @@ namespace Polyrific.Catapult.Engine.SignalRLogger
             }
         }
 
-        public async Task WriteLog(int jobQueueId, string taskName, string message)
+        public async Task WriteLog(int projectId, int jobQueueId, string taskName, string message)
         {
             if (_hubConnection == null)
                 _hubConnection = await GetConnection();
 
             try
             {
-                await _hubConnection.SendAsync("SendMessage", jobQueueId, taskName, message);
+                await _hubConnection.SendAsync("SendMessage", projectId, jobQueueId, taskName, message);
             }
             catch (InvalidOperationException)
             {
                 // handle error occured when _hubConnection is available but the connection is not active
                 await _hubConnection.StartAsync();
-                await _hubConnection.SendAsync("SendMessage", jobQueueId, taskName, message);
+                await _hubConnection.SendAsync("SendMessage", projectId, jobQueueId, taskName, message);
             }
         }
 

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/JobQueueLog.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/JobQueueLog.cs
@@ -4,6 +4,6 @@ namespace Polyrific.Catapult.Shared.Dto.Constants
 {
     public static class JobQueueLog
     {
-        public const string FolderNamePrefix = "JobQueue_";
+        public const string FolderNamePrefix = "JobQueue";
     }
 }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobQueueControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobQueueControllerTests.cs
@@ -62,11 +62,12 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void GetJobQueue_ReturnsJobQueue()
         {
-            _jobQueueService.Setup(s => s.GetJobQueueById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int id, CancellationToken cancellationToken) =>
+            _jobQueueService.Setup(s => s.GetJobQueueById(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int projectId, int id, CancellationToken cancellationToken) =>
                     new JobQueue
                     {
-                        Id = id
+                        Id = id,
+                        ProjectId = projectId
                     });
 
             var controller = new JobQueueController(_jobQueueService.Object, _catapultEngineService.Object, _mapper,
@@ -82,12 +83,13 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void GetJobQueueByCode_ReturnsJobQueue()
         {
-            _jobQueueService.Setup(s => s.GetJobQueueByCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((string code, CancellationToken cancellationToken) =>
+            _jobQueueService.Setup(s => s.GetJobQueueByCode(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int projectId, string code, CancellationToken cancellationToken) =>
                     new JobQueue
                     {
                         Id = 1,
-                        Code = code
+                        Code = code,
+                        ProjectId = projectId
                     });
 
             var controller = new JobQueueController(_jobQueueService.Object, _catapultEngineService.Object, _mapper,
@@ -106,11 +108,12 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
             _jobQueueService
                 .Setup(s => s.AddJobQueue(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(1);
-            _jobQueueService.Setup(s => s.GetJobQueueById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int id, CancellationToken cancellationToken) =>
+            _jobQueueService.Setup(s => s.GetJobQueueById(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int projectId, int id, CancellationToken cancellationToken) =>
                     new JobQueue
                     {
-                        Id = id
+                        Id = id,
+                        ProjectId = projectId
                     });
 
             var controller = new JobQueueController(_jobQueueService.Object, _catapultEngineService.Object, _mapper, _logger.Object);
@@ -341,7 +344,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void GetJobLogs_ReturnsJobQueue()
         {
-            _jobQueueService.Setup(s => s.GetJobLogs(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            _jobQueueService.Setup(s => s.GetJobLogs(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync("logs");
 
             var controller = new JobQueueController(_jobQueueService.Object, _catapultEngineService.Object, _mapper,

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -213,7 +213,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                     _data.FirstOrDefault(spec.Criteria.Compile()));
 
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
-            var entity = await jobQueueService.GetJobQueueById(1);
+            var entity = await jobQueueService.GetJobQueueById(1, 1);
 
             Assert.NotNull(entity);
             Assert.Equal(1, entity.Id);
@@ -228,7 +228,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                     _data.FirstOrDefault(spec.Criteria.Compile()));
 
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
-            var jobQueue = await jobQueueService.GetJobQueueById(2);
+            var jobQueue = await jobQueueService.GetJobQueueById(1, 2);
 
             Assert.Null(jobQueue);
         }
@@ -237,7 +237,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void GetJobQueueByCode_ReturnItem()
         {
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
-            var entity = await jobQueueService.GetJobQueueByCode("20180817.1");
+            var entity = await jobQueueService.GetJobQueueByCode(1, "20180817.1");
 
             Assert.NotNull(entity);
             Assert.Equal(1, entity.Id);
@@ -247,7 +247,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void GetJobQueueByCode_ReturnNull()
         {
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _jobCounterService.Object, _textWriter.Object);
-            var entity = await jobQueueService.GetJobQueueByCode("20180817.2");
+            var entity = await jobQueueService.GetJobQueueByCode(1, "20180817.2");
 
             Assert.Null(entity);
         }

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/QueueCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/QueueCommandTests.cs
@@ -193,7 +193,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
                 ProjectId = 1,
                 Status = JobStatus.Processing
             });
-            _jobQueueLogListener.Setup(s => s.Listen(1, It.IsAny<Action<string>>(), It.IsAny<Action<string>>())).Returns(Task.CompletedTask);
+            _jobQueueLogListener.Setup(s => s.Listen(1, 1, It.IsAny<Action<string>>(), It.IsAny<Action<string>>())).Returns(Task.CompletedTask);
 
             var command = new LogCommand(_console, LoggerMock.GetLogger<LogCommand>().Object, _projectService.Object, _jobQueueService.Object, _jobQueueLogListener.Object)
             {
@@ -203,7 +203,7 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
 
             command.Execute();
 
-            _jobQueueLogListener.Verify(s => s.Listen(1, It.IsAny<Action<string>>(), It.IsAny<Action<string>>()), Times.Once);
+            _jobQueueLogListener.Verify(s => s.Listen(It.IsAny<int>(), 1, It.IsAny<Action<string>>(), It.IsAny<Action<string>>()), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
This PR fixes issue where the logs of queues from different projects got mixed when being queried with the wrong `project name` and `queue id` combination.

## Coverage
- [x] Fix `queue get`
- [x] Fix `queue log`

## References
- Related Issues: https://github.com/Polyrific-Inc/OpenCatapult/issues/322
