### PR TITLE
Fix build script arguments

### DIFF
--- a/builds/build-all.ps1
+++ b/builds/build-all.ps1
@@ -124,9 +124,9 @@ Invoke-BuildScript "build-api.ps1" $args
 
 ## Build Engine
 $args = "-configuration " + $configuration
-$args = " -url " + $https
+$args += " -url " + $https
 if ($noConfig) {
-    $args = " -noConfig"
+    $args += " -noConfig"
 }
 Invoke-BuildScriptNewWindow "build-engine.ps1" $args
 


### PR DESCRIPTION
## Summary
Fix build script arguments where the `-configuration` is not passed to the CLI and Engine scripts.