### PR TITLE
Fix build-all.ps1 script for pwsh

### DIFF
--- a/builds/build-all.ps1
+++ b/builds/build-all.ps1
@@ -26,6 +26,19 @@ function Invoke-BuildScript ([string]$script, [string]$scriptArgs)
    Invoke-Expression $fullPathScript
 }
 
+function Start-InNewWindow {
+    param(
+        [string] $command
+    )
+
+    $psVersion = $PSVersionTable.PSVersion.Major
+    if ($psVersion -lt 6) {
+        Start-Process Powershell $command
+    } else {
+        Start-Process pwsh $command
+    }
+}
+
 function Start-InNewWindowMacOS {
   param(
      [Parameter(Mandatory)] [ScriptBlock] $ScriptBlock,
@@ -65,12 +78,7 @@ function Invoke-BuildScriptNewWindow([string]$script, [string]$scriptArgs)
         $command += "`" "
         $command += $scriptArgs
         
-        if ($wait) {
-            Start-Process Powershell $command -Wait
-        }
-        else {
-            Start-Process Powershell $command
-        }
+        Start-InNewWindow $command
     }
     else {
         # Linux or Mac

--- a/builds/build-prerequisites.ps1
+++ b/builds/build-prerequisites.ps1
@@ -1,13 +1,10 @@
 # Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
-function Get-SqlServiceStatus ([string]$server)
+function Get-SqlServiceStatus ()
 {
-   if(Test-Connection $server -Count 2 -Quiet)
-   {
-    Get-WmiObject win32_Service -Computer $server |
-     where {$_.DisplayName -match "SQL Server \("} | 
-     select SystemName, DisplayName, Name, State, Status, StartMode, StartName
-   }
+  Get-CimInstance -ClassName win32_Service |
+    where {$_.DisplayName -match "SQL Server \("} | 
+    select SystemName, DisplayName, Name, State, Status, StartMode, StartName
 }
 
 $dotnetSdkVersion = [System.Version]"2.1.500"
@@ -45,7 +42,7 @@ if ([System.Version]$parsedSdkVersion.Value -lt $dotnetSdkVersion) {
 Write-Host "Checking sql server local instance..."
 if (!($PSVersionTable.Platform) -or $PSVersionTable.Platform -ne "Unix") {
 	# Check SQL Instance in windows
-	$sqlResult = Get-SqlServiceStatus -server localhost
+	$sqlResult = Get-SqlServiceStatus
 	if ($sqlResult) {
 		if ($sqlResult.State -eq "Running") {
 			"SQL Server available in local machine."


### PR DESCRIPTION
## Summary
Fix `build-all.ps1` script so it can be run on `pwsh` (PowerShell 6). Note that `Get-WmiObject` is deprecated, so I change it with `Get-CimInstance`.
