### PR TITLE
Add build-web.ps1 script

### DIFF
--- a/builds/build-web.ps1
+++ b/builds/build-web.ps1
@@ -1,0 +1,8 @@
+$rootPath = Split-Path $PSScriptRoot
+$webLocation = Join-Path $rootPath "/src/Web/opencatapultweb"
+
+Set-Location -Path $webLocation
+
+npm install
+
+npm run start


### PR DESCRIPTION
## Summary
Add build script for Web UI. This is just a naive version, which only runs `npm install` and `npm run start`. It doesn't have API URL setting, and it has not been included in the `build-all.ps1` script, which we'll do it later in separate PRs.
