### PR TITLE
Fix cors policy to allow multiple origins

### DIFF
--- a/builds/build-web.ps1
+++ b/builds/build-web.ps1
@@ -5,4 +5,4 @@ Set-Location -Path $webLocation
 
 npm install
 
-npm run start
+npm run start -- --ssl --host localhost --port 44300

--- a/src/API/Polyrific.Catapult.Api/Startup.cs
+++ b/src/API/Polyrific.Catapult.Api/Startup.cs
@@ -29,6 +29,7 @@ namespace Polyrific.Catapult.Api
     {
         private readonly ILogger _logger;
         private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly string _allowSpecificOriginsPolicy = "_allowSpecificOriginsPolicy";
 
         public Startup(IConfiguration configuration, ILoggerFactory loggerFactory, IHostingEnvironment hostingEnvironment)
         {
@@ -111,7 +112,15 @@ namespace Polyrific.Catapult.Api
 
             });
 
-            services.AddCors();
+            services.AddCors(options =>
+            {
+                options.AddPolicy(_allowSpecificOriginsPolicy, builder => builder
+                    .WithOrigins(Configuration["AllowedOrigin"].Split(","))
+                    .AllowAnyHeader()
+                    .AllowAnyMethod()
+                    .AllowCredentials()
+                );
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -146,11 +155,7 @@ namespace Polyrific.Catapult.Api
                 c.RoutePrefix = string.Empty;
             });
 
-            app.UseCors(builder => builder
-                .WithOrigins(Configuration["AllowedOrigin"])
-                .AllowAnyHeader()
-                .AllowAnyMethod()
-                .AllowCredentials());
+            app.UseCors(_allowSpecificOriginsPolicy);
 
             app.UseMvc();
 

--- a/src/API/Polyrific.Catapult.Api/appsettings.json
+++ b/src/API/Polyrific.Catapult.Api/appsettings.json
@@ -47,7 +47,7 @@
     }
   },
   "AllowedHosts": "*",
-  "AllowedOrigin": "http://localhost:4200",
+  "AllowedOrigin": "http://localhost:4200,https://localhost:44300",
   "NotificationProviders": "SmtpEmail",
   "SmtpSetting": {
     "Server": "localhost",


### PR DESCRIPTION
## Summary
Fix cors policy to allow multiple origins.

## Coverage
- [x] Set `https://localhost:44300` as the default web URL
- [x] Add the URL to the allowed origins
- [x] Move cors config to the `ConfigureServices`
