### PR TITLE
Show error when project is not found

### DIFF
--- a/src/Web/opencatapultweb/src/app/core/services/project-history.service.spec.ts
+++ b/src/Web/opencatapultweb/src/app/core/services/project-history.service.spec.ts
@@ -1,11 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ProjectHistoryService } from './project-history.service';
+import { AuthService } from '../auth/auth.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ProjectHistoryService', () => {
   beforeEach(() => TestBed.configureTestingModule({
     providers: [
-      ProjectHistoryService
+      ProjectHistoryService,
+      AuthService
+    ],
+    imports: [
+      HttpClientTestingModule
     ]
   }));
 

--- a/src/Web/opencatapultweb/src/app/core/services/project-history.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/services/project-history.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ProjectDto } from '../models/project/project-dto';
+import { AuthService } from '../auth/auth.service';
+import { User } from '../auth/user';
 
 const localStorageKey = 'projectHistory';
 
@@ -7,19 +9,33 @@ const localStorageKey = 'projectHistory';
 export class ProjectHistoryService {
   history: {id: number, name: string}[];
 
-  constructor() {
-    const historyString = localStorage.getItem(localStorageKey);
+  constructor(private authService: AuthService) {
+    this.authService.currentUser.subscribe(user => {
+      const historyString = this.getHistoryLocalStorage(user);
 
-    if (historyString) {
-      this.history = JSON.parse(historyString);
-    } else {
-      this.history = [];
-    }
+      if (historyString) {
+        this.history = JSON.parse(historyString);
+      } else {
+        this.history = [];
+      }
+    });
   }
 
   addProjectHistory(dto: ProjectDto) {
     this.history = this.history.filter(p => p.id !== dto.id);
     this.history.splice(0, 0, {id: dto.id, name: dto.name});
-    localStorage.setItem(localStorageKey, JSON.stringify(this.history));
+    this.saveHistoryLocalStorage();
+  }
+
+  private getHistoryLocalStorage(user: User) {
+    if (user) {
+      return localStorage.getItem(`${localStorageKey}_${user.email}`);
+    }
+  }
+
+  private saveHistoryLocalStorage() {
+    if (this.authService.currentUserValue) {
+      return localStorage.setItem(`${localStorageKey}_${this.authService.currentUserValue.email}`, JSON.stringify(this.history));
+    }
   }
 }

--- a/src/Web/opencatapultweb/src/app/project/components/project-info-form/project-info-form.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/components/project-info-form/project-info-form.component.ts
@@ -23,9 +23,9 @@ export class ProjectInfoFormComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.projectInfoForm = this.fb.group({
-      name: [{value: null, disabled: this.disableForm}, Validators.required],
-      displayName: [{value: null, disabled: this.disableForm}],
-      client: {value: null, disabled: this.disableForm}
+      name: [{value: this.project ? this.project.name : null, disabled: this.disableForm}, Validators.required],
+      displayName: [{value: this.project ? this.project.displayName : null, disabled: this.disableForm}],
+      client: {value: this.project ? this.project.client : null, disabled: this.disableForm}
     });
 
     this.normalizeProjectName();

--- a/src/Web/opencatapultweb/src/app/project/project-archive-detail/project-archive-detail.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-archive-detail/project-archive-detail.component.spec.ts
@@ -34,7 +34,7 @@ describe('ProjectArchiveDetailComponent', () => {
       providers: [
         {
           provide: ActivatedRoute, useValue: {
-            params: of({ id: 1})
+            data: of({project: { id: 1}})
           }
         },
         {

--- a/src/Web/opencatapultweb/src/app/project/project-archive-detail/project-archive-detail.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-archive-detail/project-archive-detail.component.ts
@@ -35,13 +35,9 @@ export class ProjectArchiveDetailComponent implements OnInit {
   }
 
   getProject(): void {
-    this.route.params.subscribe(params => {
-      const id = +params.projectId;
-      this.projectService.getProject(id)
-        .subscribe(project => {
-          this.project = project;
-          this.projectInfoForm.patchValue(this.project);
-        });
+    this.route.data.subscribe((data: {project: ProjectDto}) => {
+      this.project = data.project;
+      this.projectInfoForm.patchValue(this.project);
     });
   }
 

--- a/src/Web/opencatapultweb/src/app/project/project-clone/project-clone.component.html
+++ b/src/Web/opencatapultweb/src/app/project/project-clone/project-clone.component.html
@@ -1,14 +1,14 @@
 <h3>Clone Project</h3>
-<div fxLayout="row" fxLayout.xs="column" class="form-container">  
+<div fxLayout="row" fxLayout.xs="column" class="form-container">
   <form fxFlex="50" fxFlex.md="70" [formGroup]="cloneProjectForm" (ngSubmit)="onSubmit()">
-      <mat-progress-bar mode='indeterminate' *ngIf='loading'></mat-progress-bar>      
+      <mat-progress-bar mode='indeterminate' *ngIf='loading'></mat-progress-bar>
       <app-project-info-form (formReady)="formInitialized($event)" [disableForm]="false" [formSubmitAttempt]="formSubmitAttempt"></app-project-info-form>
-      
-      <mat-checkbox [checked]="true" disabled>Clone Data Models?</mat-checkbox>      
+
+      <mat-checkbox [checked]="true" disabled>Clone Data Models?</mat-checkbox>
       <mat-checkbox formControlName="includeJobDefinitions">Clone Job Definitions?</mat-checkbox>
       <mat-checkbox formControlName="includeMembers">Clone Members?</mat-checkbox>
       <div class="margin10"></div>
       <button mat-raised-button color="primary" [disabled]="loading">Clone</button>
-      <button mat-raised-button [disabled]="loading" (click)="onCancelClick()">Cancel</button>
+      <button mat-raised-button type="button" [disabled]="loading" (click)="onCancelClick()">Cancel</button>
     </form>
 </div>

--- a/src/Web/opencatapultweb/src/app/project/project-clone/project-clone.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-clone/project-clone.component.ts
@@ -38,14 +38,12 @@ export class ProjectCloneComponent implements OnInit {
   }
 
   getProject(): void {
-    const id = +this.route.snapshot.paramMap.get('projectId');
-    this.projectService.getProject(id)
-      .subscribe(project => {
-        this.sourceProject = project;
-        this.projectInfoForm.patchValue({
-          client: this.sourceProject.client
-        });
+    this.route.data.subscribe((data: {project: ProjectDto}) => {
+      this.sourceProject = data.project;
+      this.projectInfoForm.patchValue({
+        client: this.sourceProject.client
       });
+    });
   }
 
   onSubmit() {

--- a/src/Web/opencatapultweb/src/app/project/project-dashboard/project-dashboard.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-dashboard/project-dashboard.component.spec.ts
@@ -5,6 +5,7 @@ import { CoreModule } from '@app/core';
 import { MatCardModule, MatDividerModule } from '@angular/material';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('ProjectDashboardComponent', () => {
   let component: ProjectDashboardComponent;
@@ -15,6 +16,7 @@ describe('ProjectDashboardComponent', () => {
       declarations: [ ProjectDashboardComponent ],
       imports: [
         CoreModule,
+        HttpClientModule,
         MatCardModule,
         FlexLayoutModule,
         MatDividerModule,

--- a/src/Web/opencatapultweb/src/app/project/project-detail/project-detail.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-detail/project-detail.component.spec.ts
@@ -29,6 +29,7 @@ describe('ProjectDetailComponent', () => {
         {
           provide: ActivatedRoute, useValue: {
             params: of({ id: 1}),
+            data: of({project: { id: 1}}),
             snapshot: {},
             firstChild: {
               snapshot: {
@@ -41,6 +42,7 @@ describe('ProjectDetailComponent', () => {
         },
         {
           provide: AuthService, useValue: {
+            currentUser: of({}),
             currentUserValue: {
               role: 'Administrator'
             },

--- a/src/Web/opencatapultweb/src/app/project/project-detail/project-detail.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-detail/project-detail.component.ts
@@ -29,15 +29,11 @@ export class ProjectDetailComponent implements OnInit {
   }
 
   getProject(): void {
-    this.route.params.subscribe(params => {
+    this.route.data.subscribe((data: {project: ProjectDto}) => {
       this.activeLink = 'info';
 
-      const id = +params.projectId;
-      this.projectService.getProject(id)
-        .subscribe(project => {
-          this.project = project;
-          this.projectHistoryService.addProjectHistory(project);
-        });
+      this.project = data.project;
+      this.projectHistoryService.addProjectHistory(this.project);
     });
   }
 

--- a/src/Web/opencatapultweb/src/app/project/project-error/project-error.component.html
+++ b/src/Web/opencatapultweb/src/app/project/project-error/project-error.component.html
@@ -1,0 +1,1 @@
+<p>Failed fetching project with Id {{projectId}}. Please make sure the project exist and you have access to it.</p>

--- a/src/Web/opencatapultweb/src/app/project/project-error/project-error.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-error/project-error.component.spec.ts
@@ -1,0 +1,39 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectErrorComponent } from './project-error.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+
+describe('ProjectErrorComponent', () => {
+  let component: ProjectErrorComponent;
+  let fixture: ComponentFixture<ProjectErrorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ProjectErrorComponent ],
+      imports: [
+        RouterTestingModule
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute, useValue: {
+            snapshot: {
+              params: { projectId: 1 }
+            }
+          }
+        }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProjectErrorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Web/opencatapultweb/src/app/project/project-error/project-error.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-error/project-error.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-project-error',
+  templateUrl: './project-error.component.html',
+  styleUrls: ['./project-error.component.css']
+})
+export class ProjectErrorComponent implements OnInit {
+  projectId: number;
+
+  constructor(private route: ActivatedRoute) { }
+
+  ngOnInit() {
+    this.projectId = +this.route.snapshot.params.projectId;
+  }
+
+}

--- a/src/Web/opencatapultweb/src/app/project/project-info/project-info.component.html
+++ b/src/Web/opencatapultweb/src/app/project/project-info/project-info.component.html
@@ -1,5 +1,5 @@
 <div fxLayout="row" fxLayout.xs="column" class="form-container">
-    <form fxFlex="50" fxFlex.md="70" [formGroup]="projectInfoForm" (ngSubmit)="onSubmit()">
+    <form fxFlex="50" fxFlex.md="70" [formGroup]="projectForm" (ngSubmit)="onSubmit()">
         <mat-progress-bar mode='indeterminate' *ngIf='loading'></mat-progress-bar>
         <mat-form-field class="full-width-input">
             <mat-label>Project ID</mat-label>

--- a/src/Web/opencatapultweb/src/app/project/project-info/project-info.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-info/project-info.component.spec.ts
@@ -35,7 +35,7 @@ describe('ProjectInfoComponent', () => {
         {
           provide: ActivatedRoute, useValue: {
             parent: {
-              params: of({ id: 1})
+              data: of({project: { id: 1}})
             }
           }
         },

--- a/src/Web/opencatapultweb/src/app/project/project-info/project-info.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-info/project-info.component.ts
@@ -11,6 +11,7 @@ import { SnackbarService } from '@app/shared';
   styleUrls: ['./project-info.component.css']
 })
 export class ProjectInfoComponent implements OnInit {
+  projectForm: FormGroup;
   projectInfoForm: FormGroup;
   project: ProjectDto;
   editing: boolean;
@@ -26,7 +27,7 @@ export class ProjectInfoComponent implements OnInit {
     ) { }
 
   ngOnInit() {
-    this.projectInfoForm = this.fb.group({
+    this.projectForm = this.fb.group({
       id: new FormControl({value: null, disabled: true}),
       createdDate: new FormControl({value: null, disabled: true})
     });
@@ -37,20 +38,16 @@ export class ProjectInfoComponent implements OnInit {
   }
 
   getProject(): void {
-    this.route.parent.params.subscribe(params => {
-      const id = +params.projectId;
-      this.projectService.getProject(id)
-        .subscribe(project => {
-          this.project = project;
-          this.populateForm();
-        });
+    this.route.parent.data.subscribe((data: {project: ProjectDto}) => {
+      this.project = data.project;
+      this.populateForm();
     });
   }
 
   populateForm() {
     const datePipe = new DatePipe('en-US');
-    this.projectInfoForm.patchValue({
-      ...this.project,
+    this.projectForm.patchValue({
+      id: this.project.id,
       createdDate: datePipe.transform(this.project.created, 'MMMM d, yyyy')
     });
   }
@@ -59,10 +56,7 @@ export class ProjectInfoComponent implements OnInit {
    * After a form is initialized, we link it to our main form
    */
   formInitialized(form: FormGroup) {
-    this.projectInfoForm = this.fb.group({
-      ...this.projectInfoForm.controls,
-      ...form.controls
-    });
+    this.projectInfoForm = form;
   }
 
   onSubmit() {

--- a/src/Web/opencatapultweb/src/app/project/project-routing.module.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-routing.module.ts
@@ -9,6 +9,8 @@ import { ProjectArchiveDetailComponent } from './project-archive-detail/project-
 import { AuthorizePolicy } from '@app/core';
 import { AuthGuard } from '@app/core/auth/auth.guard';
 import { ProjectDashboardComponent } from './project-dashboard/project-dashboard.component';
+import { ProjectErrorComponent } from './project-error/project-error.component';
+import { ProjectResolverService } from './services/project-resolver.service';
 
 const routes: Routes = [
   {
@@ -29,17 +31,30 @@ const routes: Routes = [
       {
         path: ':projectId/clone',
         component: ProjectCloneComponent,
-        data: { authPolicy: AuthorizePolicy.ProjectOwnerAccess }
+        data: { authPolicy: AuthorizePolicy.ProjectOwnerAccess },
+        resolve: {
+          project: ProjectResolverService
+        }
+      },
+      {
+        path: ':projectId/error',
+        component: ProjectErrorComponent
       },
       {
         path: 'archive/:projectId',
         component: ProjectArchiveDetailComponent,
-        data: { authPolicy: AuthorizePolicy.ProjectOwnerAccess }
+        data: { authPolicy: AuthorizePolicy.ProjectOwnerAccess },
+        resolve: {
+          project: ProjectResolverService
+        }
       },
       {
         path: ':projectId',
         component: ProjectDetailComponent,
         canActivateChild: [AuthGuard],
+        resolve: {
+          project: ProjectResolverService
+        },
         children: [
           {path: '', redirectTo: 'info', pathMatch: 'full'},
           {

--- a/src/Web/opencatapultweb/src/app/project/project.module.ts
+++ b/src/Web/opencatapultweb/src/app/project/project.module.ts
@@ -16,6 +16,8 @@ import { SharedModule } from '@app/shared/shared.module';
 import { ProjectCloneComponent } from './project-clone/project-clone.component';
 import { ProjectArchiveDetailComponent } from './project-archive-detail/project-archive-detail.component';
 import { ProjectDashboardComponent } from './project-dashboard/project-dashboard.component';
+import { ProjectErrorComponent } from './project-error/project-error.component';
+import { ProjectResolverService } from './services/project-resolver.service';
 
 @NgModule({
   declarations: [ProjectComponent,
@@ -25,7 +27,8 @@ import { ProjectDashboardComponent } from './project-dashboard/project-dashboard
     ProjectNewComponent,
     ProjectCloneComponent,
     ProjectArchiveDetailComponent,
-    ProjectDashboardComponent
+    ProjectDashboardComponent,
+    ProjectErrorComponent
   ],
   imports: [
     CommonModule,
@@ -48,6 +51,9 @@ import { ProjectDashboardComponent } from './project-dashboard/project-dashboard
     MatDialogModule,
     MatCheckboxModule,
     MatCardModule
+  ],
+  providers: [
+    ProjectResolverService
   ]
 })
 export class ProjectModule { }

--- a/src/Web/opencatapultweb/src/app/project/services/project-resolver.service.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/services/project-resolver.service.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProjectResolverService } from './project-resolver.service';
+import { ProjectService } from '@app/core';
+import { ApiService } from '@app/core/services/api.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('ProjectResolverService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      HttpClientTestingModule,
+      RouterTestingModule
+    ],
+    providers: [
+      ProjectService,
+      ApiService,
+      ProjectResolverService
+    ]
+  }));
+
+  it('should be created', () => {
+    const service: ProjectResolverService = TestBed.get(ProjectResolverService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/Web/opencatapultweb/src/app/project/services/project-resolver.service.ts
+++ b/src/Web/opencatapultweb/src/app/project/services/project-resolver.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { ProjectDto, ProjectService } from '@app/core';
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { Observable, of, EMPTY } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+
+@Injectable()
+export class ProjectResolverService implements Resolve<ProjectDto> {
+
+  constructor(
+    private projectService: ProjectService,
+    private router: Router
+    ) { }
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): ProjectDto | Observable<ProjectDto> | Promise<ProjectDto> {
+    const projectId = +route.params.projectId;
+
+    return this.projectService.getProject(projectId)
+      .pipe(mergeMap(project => {
+        if (project) {
+          return of(project);
+        } else {
+          this.router.navigateByUrl(`/project/${projectId}/error`);
+          return EMPTY;
+        }
+      }));
+  }
+}


### PR DESCRIPTION
## Summary
- Show error page when trying to open project that does not exist
- Bugfix in project dashboard

## Coverage
- [x] Use route resolver to get project data, and reroute to error if not found
- [x] Refactor other component to get the data from route instead of fetching it to backend
- [x] bugfix on project history to handle multiple user