### PR TITLE
Docs: Rename Plugins to TaskProviders

### DIFF
--- a/docs/home/intro.md
+++ b/docs/home/intro.md
@@ -45,6 +45,6 @@ Engine runs as a stand-alone console application which waits for any queued jobs
 OpenCatapult's Engine is a platform-agnostic system. It means that Engine actually knows nothing about the concrete work that the job tasks do.
 Task Provider is an `OpenCatapult` extension which provides specific implementation of a job task.
 
-For example, Engine actually knows nothing about GitHub repository. All Engine knows is just it wants to push some code to a remote repository via `Push` task. So we need to provide a Task Provider, e.g. `Polyrific.Catapult.Plugins.GitHub`, which will handle the source code delivery in a specific way to GitHub. If you want to submit the code into another repository service, you can just plug in a new Task Provider, and reconfigure the `Push` task to use it.
+For example, Engine actually knows nothing about GitHub repository. All Engine knows is just it wants to push some code to a remote repository via `Push` task. So we need to provide a Task Provider, e.g. `Polyrific.Catapult.TaskProviders.GitHub`, which will handle the source code delivery in a specific way to GitHub. If you want to submit the code into another repository service, you can just plug in a new Task Provider, and reconfigure the `Push` task to use it.
 
 `OpenCatapult` is packed with some built-in Task Providers. Please check them in the [Task Provider References](../task-providers/task-provider.md).

--- a/docs/home/start.md
+++ b/docs/home/start.md
@@ -113,12 +113,12 @@ dotnet .\publish\engine\ocengine.dll config set -n ApiUrl -v https://localhost:4
 While configuring the Engine environment, let's publish the built-in Task Providers as well. They will be required later when executing job tasks.
 
 ```sh
-dotnet publish .\src\Plugins\GeneratorProvider\Polyrific.Catapult.Plugins.AspNetCoreMvc\src\Polyrific.Catapult.Plugins.AspNetCoreMvc.csproj -c Release -o ..\..\..\..\publish\engine\plugins\GeneratorProvider\Polyrific.Catapult.Plugins.AspNetCoreMvc
-dotnet publish .\src\Plugins\HostingProvider\Polyrific.Catapult.Plugins.AzureAppService\src\Polyrific.Catapult.Plugins.AzureAppService.csproj -c Release -o ..\..\..\..\publish\engine\plugins\HostingProvider\Polyrific.Catapult.Plugins.AzureAppService
-dotnet publish .\src\Plugins\BuildProvider\Polyrific.Catapult.Plugins.DotNetCore\src\Polyrific.Catapult.Plugins.DotNetCore.csproj -c Release -o ..\..\..\..\publish\engine\plugins\BuildProvider\Polyrific.Catapult.Plugins.DotNetCore
-dotnet publish .\src\Plugins\TestProvider\Polyrific.Catapult.Plugins.DotNetCoreTest\src\Polyrific.Catapult.Plugins.DotNetCoreTest.csproj -c Release -o ..\..\..\..\publish\engine\plugins\TestProvider\Polyrific.Catapult.Plugins.DotNetCoreTest
-dotnet publish .\src\Plugins\DatabaseProvider\Polyrific.Catapult.Plugins.EntityFrameworkCore\src\Polyrific.Catapult.Plugins.EntityFrameworkCore.csproj -c Release -o ..\..\..\..\publish\engine\plugins\DatabaseProvider\Polyrific.Catapult.Plugins.EntityFrameworkCore
-dotnet publish .\src\Plugins\RepositoryProvider\Polyrific.Catapult.Plugins.GitHub\src\Polyrific.Catapult.Plugins.GitHub.csproj -c Release -o ..\..\..\..\publish\engine\plugins\RepositoryProvider\Polyrific.Catapult.Plugins.GitHub
+dotnet publish .\src\Plugins\GeneratorProvider\Polyrific.Catapult.TaskProviders.AspNetCoreMvc\src\Polyrific.Catapult.TaskProviders.AspNetCoreMvc.csproj -c Release -o ..\..\..\..\publish\engine\plugins\GeneratorProvider\Polyrific.Catapult.TaskProviders.AspNetCoreMvc
+dotnet publish .\src\Plugins\HostingProvider\Polyrific.Catapult.TaskProviders.AzureAppService\src\Polyrific.Catapult.TaskProviders.AzureAppService.csproj -c Release -o ..\..\..\..\publish\engine\plugins\HostingProvider\Polyrific.Catapult.TaskProviders.AzureAppService
+dotnet publish .\src\Plugins\BuildProvider\Polyrific.Catapult.TaskProviders.DotNetCore\src\Polyrific.Catapult.TaskProviders.DotNetCore.csproj -c Release -o ..\..\..\..\publish\engine\plugins\BuildProvider\Polyrific.Catapult.TaskProviders.DotNetCore
+dotnet publish .\src\Plugins\TestProvider\Polyrific.Catapult.TaskProviders.DotNetCoreTest\src\Polyrific.Catapult.TaskProviders.DotNetCoreTest.csproj -c Release -o ..\..\..\..\publish\engine\plugins\TestProvider\Polyrific.Catapult.TaskProviders.DotNetCoreTest
+dotnet publish .\src\Plugins\DatabaseProvider\Polyrific.Catapult.TaskProviders.EntityFrameworkCore\src\Polyrific.Catapult.TaskProviders.EntityFrameworkCore.csproj -c Release -o ..\..\..\..\publish\engine\plugins\DatabaseProvider\Polyrific.Catapult.TaskProviders.EntityFrameworkCore
+dotnet publish .\src\Plugins\RepositoryProvider\Polyrific.Catapult.TaskProviders.GitHub\src\Polyrific.Catapult.TaskProviders.GitHub.csproj -c Release -o ..\..\..\..\publish\engine\plugins\RepositoryProvider\Polyrific.Catapult.TaskProviders.GitHub
 ```
 
 > Note: There is one more steps required to start the Engine, which is to enter the authorization token. But we will do it later after registering the Engine via CLI.
@@ -211,7 +211,7 @@ You can find more details about these procedure at [Manage engine registration](
 
 ### Create sample project
 
-And now, you're good to go to create a project. We will use `sample` template, which will give you some pre-defined models, and a job definition with a single `Generate` task. The task uses a built-in generator provider called `Polyrific.Catapult.Plugins.AspNetCoreMvc`, which will generate a starter ASP.NET Core MVC application.
+And now, you're good to go to create a project. We will use `sample` template, which will give you some pre-defined models, and a job definition with a single `Generate` task. The task uses a built-in generator provider called `Polyrific.Catapult.TaskProviders.AspNetCoreMvc`, which will generate a starter ASP.NET Core MVC application.
 
 Activate the CLI shell, and enter this command:
 

--- a/docs/task-providers/build-provider.md
+++ b/docs/task-providers/build-provider.md
@@ -2,20 +2,20 @@
 
 Build providers can be used in [Build task](../user-guides/job-definitions.md#build). The main role of this provider is to provide specific way to build the generated code, and produce a deliverable artifact. The artifact can then be used as input for [Hosting provider](hosting-provider.md) or [Database provider](database-provider.md).
 
-## Polyrific.Catapult.Plugins.DotNetCore
+## Polyrific.Catapult.TaskProviders.DotNetCore
 
-`OpenCatapult` provides `Polyrific.Catapult.Plugins.DotNetCore` as the built-in provider for Build Provider. This provider can be used to build and create deployable artifact for dotnet core applications. It uses the `dotnet publish` command that comes with the dotnet core sdk.
+`OpenCatapult` provides `Polyrific.Catapult.TaskProviders.DotNetCore` as the built-in provider for Build Provider. This provider can be used to build and create deployable artifact for dotnet core applications. It uses the `dotnet publish` command that comes with the dotnet core sdk.
 
 ### Usage
 
-This provider can only be used in Build task. You can use the name `Polyrific.Catapult.Plugins.DotNetCore` when adding or updating a Build task:
+This provider can only be used in Build task. You can use the name `Polyrific.Catapult.TaskProviders.DotNetCore` when adding or updating a Build task:
 
 ```sh
-dotnet occli.dll task add -p SampleProject -j Default -n Build -t Build -prov Polyrific.Catapult.Plugins.DotNetCore
+dotnet occli.dll task add -p SampleProject -j Default -n Build -t Build -prov Polyrific.Catapult.TaskProviders.DotNetCore
 ```
 
 ```sh
-dotnet occli.dll task update -p SampleProject -j Default -n Build -prov Polyrific.Catapult.Plugins.DotNetCore
+dotnet occli.dll task update -p SampleProject -j Default -n Build -prov Polyrific.Catapult.TaskProviders.DotNetCore
 ```
 
 ### Additional configs

--- a/docs/task-providers/database-provider.md
+++ b/docs/task-providers/database-provider.md
@@ -2,20 +2,20 @@
 
 Database providers can be used in [Deploy Db task](../user-guides/job-definitions.md#deploydb). The main role of this provider is to provide specific way to update database in the deployment environment.
 
-## Polyrific.Catapult.Plugins.EntityFrameworkCore
+## Polyrific.Catapult.TaskProviders.EntityFrameworkCore
 
-`OpenCatapult` provides `Polyrific.Catapult.Plugins.EntityFrameworkCore` as the built-in provider for Database Provider. This provider can be used to update a specified database to the latest migration script available in the source code. It uses the `dotnet ef database update` command that comes with the dotnet core entity framework sdk.
+`OpenCatapult` provides `Polyrific.Catapult.TaskProviders.EntityFrameworkCore` as the built-in provider for Database Provider. This provider can be used to update a specified database to the latest migration script available in the source code. It uses the `dotnet ef database update` command that comes with the dotnet core entity framework sdk.
 
 ### Usage
 
-This provider can only be used in DeployDb task. You can use the name `Polyrific.Catapult.Plugins.EntityFrameworkCore` when adding or updating a DeployDb task:
+This provider can only be used in DeployDb task. You can use the name `Polyrific.Catapult.TaskProviders.EntityFrameworkCore` when adding or updating a DeployDb task:
 
 ```sh
-dotnet occli.dll task add -p SampleProject -j Default -n DeployDb -t DeployDb -prov Polyrific.Catapult.Plugins.EntityFrameworkCore
+dotnet occli.dll task add -p SampleProject -j Default -n DeployDb -t DeployDb -prov Polyrific.Catapult.TaskProviders.EntityFrameworkCore
 ```
 
 ```sh
-dotnet occli.dll task update -p SampleProject -j Default -n DeployDb -prov Polyrific.Catapult.Plugins.EntityFrameworkCore
+dotnet occli.dll task update -p SampleProject -j Default -n DeployDb -prov Polyrific.Catapult.TaskProviders.EntityFrameworkCore
 ```
 
 ### Additional configs

--- a/docs/task-providers/generator-provider.md
+++ b/docs/task-providers/generator-provider.md
@@ -2,20 +2,20 @@
 
 Generator providers can be used in [Generate task](../user-guides/job-definitions.md#generate). The main role of this provider is to provide a specific implementation of source code generation based on the project configuration and the defined data models.
 
-## Polyrific.Catapult.Plugins.AspNetCoreMvc
+## Polyrific.Catapult.TaskProviders.AspNetCoreMvc
 
-`OpenCatapult` provides `Polyrific.Catapult.Plugins.AspNetCoreMvc` as the built-in provider for Generator Provider. This provider will create an AspNet Core Mvc application. The generated code further explained in the last section.
+`OpenCatapult` provides `Polyrific.Catapult.TaskProviders.AspNetCoreMvc` as the built-in provider for Generator Provider. This provider will create an AspNet Core Mvc application. The generated code further explained in the last section.
 
 ### Usage
 
-This provider can only be used in Generate task. You can use the name `Polyrific.Catapult.Plugins.AspNetCoreMvc` when adding or updating a Generate task:
+This provider can only be used in Generate task. You can use the name `Polyrific.Catapult.TaskProviders.AspNetCoreMvc` when adding or updating a Generate task:
 
 ```sh
-dotnet occli.dll task add -p SampleProject -j Default -n Generate -t Generate -prov Polyrific.Catapult.Plugins.AspNetCoreMvc
+dotnet occli.dll task add -p SampleProject -j Default -n Generate -t Generate -prov Polyrific.Catapult.TaskProviders.AspNetCoreMvc
 ```
 
 ```sh
-dotnet occli.dll task update -p SampleProject -j Default -n Generate -prov Polyrific.Catapult.Plugins.AspNetCoreMvc
+dotnet occli.dll task update -p SampleProject -j Default -n Generate -prov Polyrific.Catapult.TaskProviders.AspNetCoreMvc
 ```
 
 ### Additional configs

--- a/docs/task-providers/hosting-provider.md
+++ b/docs/task-providers/hosting-provider.md
@@ -2,20 +2,20 @@
 
 Hosting providers can be used in [Deploy task](../user-guides/job-definitions.md#deploy). The main role of this provider is to provide a specific way to deploy build artifact into a hosting environment.
 
-## Polyrific.Catapult.Plugins.AzureAppService
+## Polyrific.Catapult.TaskProviders.AzureAppService
 
-`OpenCatapult` provides `Polyrific.Catapult.Plugins.AzureAppService` as the built-in provider for Hosting Provider. This provider can be used to deploy a web application into Azure App Service instance. It uses kudu deploy `zipdeploy` api to upload the package and update the application.
+`OpenCatapult` provides `Polyrific.Catapult.TaskProviders.AzureAppService` as the built-in provider for Hosting Provider. This provider can be used to deploy a web application into Azure App Service instance. It uses kudu deploy `zipdeploy` api to upload the package and update the application.
 
 ### Usage
 
-This provider can only be used in Deploy task. You can use the name `Polyrific.Catapult.Plugins.AzureAppService` when adding or updating a Deploy task:
+This provider can only be used in Deploy task. You can use the name `Polyrific.Catapult.TaskProviders.AzureAppService` when adding or updating a Deploy task:
 
 ```sh
-dotnet occli.dll task add -p SampleProject -j Default -n Deploy -t Deploy -prov Polyrific.Catapult.Plugins.AzureAppService
+dotnet occli.dll task add -p SampleProject -j Default -n Deploy -t Deploy -prov Polyrific.Catapult.TaskProviders.AzureAppService
 ```
 
 ```sh
-dotnet occli.dll task update -p SampleProject -j Default -n Deploy -prov Polyrific.Catapult.Plugins.AzureAppService
+dotnet occli.dll task update -p SampleProject -j Default -n Deploy -prov Polyrific.Catapult.TaskProviders.AzureAppService
 ```
 
 ### Required services

--- a/docs/task-providers/repository-provider.md
+++ b/docs/task-providers/repository-provider.md
@@ -2,20 +2,20 @@
 
 Repository providers can be used by [Clone task](../user-guides/job-definitions.md#clone), [Push task](../user-guides/job-definitions.md#push), and [Merge task](../user-guides/job-definitions.md#merge). The main role of this provider is to provide a specific implementation to work with remote code repository service.
 
-## Polyrific.Catapult.Plugins.GitHub
+## Polyrific.Catapult.TaskProviders.GitHub
 
-`OpenCatapult` provides `Polyrific.Catapult.Plugins.GitHub` as the built-in provider for Repository Provider. This provider can be used to clone, push, create and merge pull request in a GitHub repository.
+`OpenCatapult` provides `Polyrific.Catapult.TaskProviders.GitHub` as the built-in provider for Repository Provider. This provider can be used to clone, push, create and merge pull request in a GitHub repository.
 
 ### Usage
 
-This provider can be used in Clone, Push, and Merge task. You can use the name `Polyrific.Catapult.Plugins.GitHub` when adding or updating the tasks:
+This provider can be used in Clone, Push, and Merge task. You can use the name `Polyrific.Catapult.TaskProviders.GitHub` when adding or updating the tasks:
 
 ```sh
-dotnet occli.dll task add -p SampleProject -j Default -n Clone -t Clone -prov Polyrific.Catapult.Plugins.GitHub
+dotnet occli.dll task add -p SampleProject -j Default -n Clone -t Clone -prov Polyrific.Catapult.TaskProviders.GitHub
 ```
 
 ```sh
-dotnet occli.dll task update -p SampleProject -j Default -n Clone -prov Polyrific.Catapult.Plugins.GitHub
+dotnet occli.dll task update -p SampleProject -j Default -n Clone -prov Polyrific.Catapult.TaskProviders.GitHub
 ```
 
 ### Required services

--- a/docs/task-providers/task-provider.md
+++ b/docs/task-providers/task-provider.md
@@ -14,26 +14,26 @@ There are 7 types of Task Provider. `OpenCatapult` provides built-in Task Provid
 
   A "Generator Provider" defines **what** you are asking `OpenCatapult` to create. For example, you may consume or create a provider that builds a .NET MVC based intranet, or a PHP based eCommerce site. A task provider can even be created for an Amazon Alexa voice app; `OpenCatapult` doesn't care what is music is on the cassette tape, it just knows how to play whatever you have selected. 
   
-  The default generator provider is `Polyrific.Catapult.Plugins.AspNetCoreMvc`
+  The default generator provider is `Polyrific.Catapult.TaskProviders.AspNetCoreMvc`
 
 - [Build Provider](build-provider.md)
 
   Build Providers answer the question of **how** your code will be built and deployed. `OpenCatapult` allows you to define a CI/CD pipeline that works your way by creating a build provider that defines every actionable step in your build & release flow.
 
-  The default build provider is `Polyrific.Catapult.Plugins.DotNetCore`
+  The default build provider is `Polyrific.Catapult.TaskProviders.DotNetCore`
 
 - [Repository Provider](repository-provider.md)
 
   The Repository Provider dictates **where** your source code will live. You can create or consume task providers for almost any kind of version control service so that your code is checked in to a location of your choosing. 
 
-  The default repository provider is `Polyrific.Catapult.Plugins.GitHub`
+  The default repository provider is `Polyrific.Catapult.TaskProviders.GitHub`
 
 - [Hosting Provider](hosting-provider.md)
 
   The Hosting Provider lets you declare **where** your app should be deployed. You can create or consume a hosting provider that will deploy your apps to Azure, AWS, Rackspace, on-premise, or any other place of your choosing.
 
-  The default hosting provider is `Polyrific.Catapult.Plugins.AzureAppService`.
+  The default hosting provider is `Polyrific.Catapult.TaskProviders.AzureAppService`.
 
-- [Database Provider](database-provider.md), with `Polyrific.Catapult.Plugins.EntityFrameworkCore` as the default provider
-- [Test Provider](test-provider.md), with `Polyrific.Catapult.Plugins.DotNetCoreTest` as the default provider
+- [Database Provider](database-provider.md), with `Polyrific.Catapult.TaskProviders.EntityFrameworkCore` as the default provider
+- [Test Provider](test-provider.md), with `Polyrific.Catapult.TaskProviders.DotNetCoreTest` as the default provider
 - [Storage Provider](storage-provider.md)

--- a/docs/task-providers/test-provider.md
+++ b/docs/task-providers/test-provider.md
@@ -2,18 +2,18 @@
 
 Test Providers can be used in [Test task](../user-guides/job-definitions.md#test). The main role of this provider is to provide a specific way to run a test based on the selected test runner.
 
-## Polyrific.Catapult.Plugins.DotNetCoreTest
+## Polyrific.Catapult.TaskProviders.DotNetCoreTest
 
-`OpenCatapult` provides `Polyrific.Catapult.Plugins.DotNetCoreTest` as the built-in provider for Test Provider. This provider can be used to run test for the generated dotnet core application. It uses the `dotnet test` command that comes with the dotnet core sdk.
+`OpenCatapult` provides `Polyrific.Catapult.TaskProviders.DotNetCoreTest` as the built-in provider for Test Provider. This provider can be used to run test for the generated dotnet core application. It uses the `dotnet test` command that comes with the dotnet core sdk.
 
 ### Usage
 
-This provider can only be used in Test task. You can use the name `Polyrific.Catapult.Plugins.DotNetCoreTest` when adding or updating a Test task:
+This provider can only be used in Test task. You can use the name `Polyrific.Catapult.TaskProviders.DotNetCoreTest` when adding or updating a Test task:
 
 ```sh
-dotnet occli.dll task add -p SampleProject -j Default -n Test -t Test -prov Polyrific.Catapult.Plugins.DotNetCoreTest
+dotnet occli.dll task add -p SampleProject -j Default -n Test -t Test -prov Polyrific.Catapult.TaskProviders.DotNetCoreTest
 ```
 
 ```sh
-dotnet occli.dll task update -p SampleProject -j Default -n Test -prov Polyrific.Catapult.Plugins.DotNetCoreTest
+dotnet occli.dll task update -p SampleProject -j Default -n Test -prov Polyrific.Catapult.TaskProviders.DotNetCoreTest
 ```

--- a/docs/user-guides/job-definitions.md
+++ b/docs/user-guides/job-definitions.md
@@ -143,9 +143,9 @@ For all of the Task types mentioned, you can also specify the following generic 
 
 ## Built-in Providers
 Following are the built-in providers. You can add other providers later using the [task provider](task-providers.md) command.
-- `Polyrific.Catapult.Plugins.AspNetCoreMvc`: Generate an asp net core mvc application
-- `Polyrific.Catapult.Plugins.GitHub`: Used to clone or push code to GitHub
-- `Polyrific.Catapult.Plugins.DotNetCore`: Build a dotnet core application
-- `Polyrific.Catapult.Plugins.DotNetCoreTest`: Run tests available on the project
-- `Polyrific.Catapult.Plugins.EntityFrameworkCore`: A database provider for deploying the model changes
-- `Polyrific.Catapult.Plugins.AzureAppService`: Deploys the application into Azure App Service instance
+- `Polyrific.Catapult.TaskProviders.AspNetCoreMvc`: Generate an asp net core mvc application
+- `Polyrific.Catapult.TaskProviders.GitHub`: Used to clone or push code to GitHub
+- `Polyrific.Catapult.TaskProviders.DotNetCore`: Build a dotnet core application
+- `Polyrific.Catapult.TaskProviders.DotNetCoreTest`: Run tests available on the project
+- `Polyrific.Catapult.TaskProviders.EntityFrameworkCore`: A database provider for deploying the model changes
+- `Polyrific.Catapult.TaskProviders.AzureAppService`: Deploys the application into Azure App Service instance


### PR DESCRIPTION
## Summary
Rename the remaining docs and guide that still use `Plugins.` namespace and rename it to `TaskProviders.`
