### PR TITLE
Show error when job queue is not found 

### DIFF
--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.spec.ts
@@ -41,12 +41,8 @@ describe('JobQueueDetailComponent', () => {
       providers: [
         {
           provide: ActivatedRoute, useValue: {
-            snapshot: { params: of({ id: 1}) },
-            parent: {
-              parent: {
-                snapshot: { params: of({ id: 1}) }
-              }
-            }
+            data: of({jobQueue: { id: 1, projectId: 1}}),
+            snapshot: {}
           }
         }
       ]

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.ts
@@ -21,30 +21,29 @@ export class JobQueueDetailComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private jobQueueService: JobQueueService,
-    private projectService: ProjectService,
     private snackbar: SnackbarService,
     private dialog: MatDialog
   ) { }
 
   ngOnInit() {
-    this.queueId = this.route.snapshot.params.id;
-    this.projectId = this.projectService.currentProjectId;
     this.getQueue();
   }
 
   getQueue() {
-    this.jobQueueService.getJobQueue(this.projectId, this.queueId)
-      .pipe(tap(results => {
-        if (results.jobTasksStatus) {
-          results.jobTasksStatus.sort((a, b) => (a.sequence > b.sequence) ? 1 : ((b.sequence > a.sequence) ? -1 : 0));
-        }
-      }))
-      .subscribe(data => {
-        this.job = data;
-        this.allowRestart = data.status === JobStatus.Cancelled || data.status === JobStatus.Pending || data.status === JobStatus.Error;
-        this.allowCancel = data.status === JobStatus.Processing || data.status === JobStatus.Pending;
-        this.allowRefresh = data.status !== JobStatus.Completed;
-      });
+    this.route.data.subscribe((data: {jobQueue: JobDto}) => {
+      if (data.jobQueue.jobTasksStatus) {
+        data.jobQueue.jobTasksStatus.sort((a, b) => (a.sequence > b.sequence) ? 1 : ((b.sequence > a.sequence) ? -1 : 0));
+      }
+
+      this.job = data.jobQueue;
+      this.queueId = this.job.id;
+      this.projectId = this.job.projectId;
+
+      this.allowRestart = data.jobQueue.status === JobStatus.Cancelled || data.jobQueue.status === JobStatus.Pending ||
+        data.jobQueue.status === JobStatus.Error;
+      this.allowCancel = data.jobQueue.status === JobStatus.Processing || data.jobQueue.status === JobStatus.Pending;
+      this.allowRefresh = data.jobQueue.status !== JobStatus.Completed;
+    });
   }
 
   onCancelClick() {

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-error/job-queue-error.component.html
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-error/job-queue-error.component.html
@@ -1,0 +1,5 @@
+<p>Failed fetching job queue with Id {{jobQueueId}} in project {{projectId}}.
+  Please make sure the job queue exist and you have access to it.</p>
+  <a mat-button routerLink="/project/{{projectId}}/job-queue">
+    <mat-icon>arrow_back</mat-icon> Back
+  </a>

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-error/job-queue-error.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-error/job-queue-error.component.spec.ts
@@ -1,0 +1,47 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { JobQueueErrorComponent } from './job-queue-error.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+import { MatIconModule, MatButtonModule } from '@angular/material';
+
+describe('JobQueueErrorComponent', () => {
+  let component: JobQueueErrorComponent;
+  let fixture: ComponentFixture<JobQueueErrorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ JobQueueErrorComponent ],
+      imports: [
+        RouterTestingModule,
+        MatIconModule,
+        MatButtonModule
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute, useValue: {
+            snapshot: {
+              params: { id: 1 }
+            },
+            parent: {
+              parent: {
+                snapshot: { params: { projectId: 1 }}
+              }
+            }
+          }
+        }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(JobQueueErrorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-error/job-queue-error.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-error/job-queue-error.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-job-queue-error',
+  templateUrl: './job-queue-error.component.html',
+  styleUrls: ['./job-queue-error.component.css']
+})
+export class JobQueueErrorComponent implements OnInit {
+  projectId: number;
+  jobQueueId: number;
+
+  constructor(private route: ActivatedRoute) { }
+
+  ngOnInit() {
+    this.projectId = +this.route.parent.parent.snapshot.params.projectId;
+    this.jobQueueId = this.route.snapshot.params.id;
+  }
+
+}

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.spec.ts
@@ -42,12 +42,8 @@ describe('JobQueueLogComponent', () => {
       providers: [
         {
           provide: ActivatedRoute, useValue: {
-            snapshot: { params: of({ id: 1}) },
-            parent: {
-              parent: {
-                snapshot: { params: of({ id: 1}) }
-              }
-            }
+            data: of({jobQueue: { id: 1, projectId: 1}}),
+            snapshot: {}
           }
         }
       ]

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.ts
@@ -19,30 +19,27 @@ export class JobQueueLogComponent implements OnInit {queueId: number;
   logReceived: boolean;
   constructor(
     private route: ActivatedRoute,
-    private jobQueueService: JobQueueService,
-    private projectService: ProjectService
+    private jobQueueService: JobQueueService
   ) { }
 
   ngOnInit() {
-    this.queueId = this.route.snapshot.params.id;
-    this.projectId = +this.projectService.currentProjectId;
     this.getQueue();
   }
 
   getQueue() {
-    this.jobQueueService.getJobQueue(this.projectId, this.queueId)
-      .pipe(tap(results => {
-        if (results.jobTasksStatus) {
-          results.jobTasksStatus.sort((a, b) => (a.sequence > b.sequence) ? 1 : ((b.sequence > a.sequence) ? -1 : 0));
-        }
-      }))
-      .subscribe(data => {
-        this.job = data;
+    this.route.data.subscribe((data: {jobQueue: JobDto}) => {
+      if (data.jobQueue.jobTasksStatus) {
+        data.jobQueue.jobTasksStatus.sort((a, b) => (a.sequence > b.sequence) ? 1 : ((b.sequence > a.sequence) ? -1 : 0));
+      }
 
-        if (!this.listened && (data.status === JobStatus.Queued || data.status === JobStatus.Processing)) {
-          this.listenQueueLog();
-        }
-      });
+      this.job = data.jobQueue;
+      this.queueId = this.job.id;
+      this.projectId = this.job.projectId;
+
+      if (!this.listened && (data.jobQueue.status === JobStatus.Queued || data.jobQueue.status === JobStatus.Processing)) {
+        this.listenQueueLog();
+      }
+    });
   }
 
   listenQueueLog() {

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-routing.module.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-routing.module.ts
@@ -3,16 +3,27 @@ import { Routes, RouterModule } from '@angular/router';
 import { JobQueueComponent } from './job-queue/job-queue.component';
 import { JobQueueDetailComponent } from './job-queue-detail/job-queue-detail.component';
 import { JobQueueLogComponent } from './job-queue-log/job-queue-log.component';
+import { JobQueueResolverService } from './services/job-queue-resolver.service';
+import { JobQueueErrorComponent } from './job-queue-error/job-queue-error.component';
 
 const routes: Routes = [
   {
     path: '', component: JobQueueComponent
   },
   {
-    path: ':id', component: JobQueueDetailComponent
+    path: ':id', component: JobQueueDetailComponent,
+    resolve: {
+      jobQueue: JobQueueResolverService
+    }
   },
   {
-    path: ':id/logs', component: JobQueueLogComponent
+    path: ':id/logs', component: JobQueueLogComponent,
+    resolve: {
+      jobQueue: JobQueueResolverService
+    }
+  },
+  {
+    path: ':id/error', component: JobQueueErrorComponent
   }
 ];
 

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue.module.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue.module.ts
@@ -17,6 +17,8 @@ import { JobQueueCancelDialogComponent } from './components/job-queue-cancel-dia
 import { ReactiveFormsModule } from '@angular/forms';
 import { JobQueueTaskStatusComponent } from './components/job-queue-task-status/job-queue-task-status.component';
 import { JobQueueTaskLogComponent } from './job-queue-task-log/job-queue-task-log.component';
+import { JobQueueResolverService } from './services/job-queue-resolver.service';
+import { JobQueueErrorComponent } from './job-queue-error/job-queue-error.component';
 
 @NgModule({
   declarations: [
@@ -27,7 +29,8 @@ import { JobQueueTaskLogComponent } from './job-queue-task-log/job-queue-task-lo
     JobQueueStatusComponent,
     JobQueueCancelDialogComponent,
     JobQueueTaskStatusComponent,
-    JobQueueTaskLogComponent
+    JobQueueTaskLogComponent,
+    JobQueueErrorComponent
   ],
   imports: [
     CommonModule,
@@ -51,6 +54,9 @@ import { JobQueueTaskLogComponent } from './job-queue-task-log/job-queue-task-lo
     MatProgressBarModule,
     MatDialogModule,
     MatExpansionModule
+  ],
+  providers: [
+    JobQueueResolverService
   ],
   entryComponents: [
     JobQueueCancelDialogComponent

--- a/src/Web/opencatapultweb/src/app/project/job-queue/services/job-queue-resolver.service.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/services/job-queue-resolver.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+
+import { JobQueueResolverService } from './job-queue-resolver.service';
+import { CoreModule } from '@app/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('JobQueueResolverService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      CoreModule,
+      HttpClientTestingModule,
+      RouterTestingModule
+    ],
+    providers: [
+      JobQueueResolverService
+    ]
+  }));
+
+  it('should be created', () => {
+    const service: JobQueueResolverService = TestBed.get(JobQueueResolverService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/Web/opencatapultweb/src/app/project/job-queue/services/job-queue-resolver.service.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/services/job-queue-resolver.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { JobQueueService, JobDto } from '@app/core';
+import { Resolve, Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { mergeMap } from 'rxjs/operators';
+import { of, EMPTY, Observable } from 'rxjs';
+
+@Injectable()
+export class JobQueueResolverService implements Resolve<JobDto> {
+
+  constructor(
+    private jobQueueService: JobQueueService,
+    private router: Router
+    ) { }
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): JobDto | Observable<JobDto> | Promise<JobDto> {
+    const projectId = +route.parent.parent.params.projectId;
+    const jobQueueId = +route.params.id;
+
+    return this.jobQueueService.getJobQueue(projectId, jobQueueId)
+      .pipe(mergeMap(job => {
+        if (job) {
+          return of(job);
+        } else {
+          this.router.navigateByUrl(`/project/${projectId}/job-queue/${jobQueueId}/error`);
+          return EMPTY;
+        }
+      }));
+  }
+}


### PR DESCRIPTION
## Summary
Refactor job queue detail and job queue log page to use route resolver, so we can redirect to error page when data is not found, without rendering the page first

## Coverage
- [x] Use route resolver in job queue detail and job queue log
