### PR TITLE
Implement API for deletion job definition

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/JobDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/JobDefinition.cs
@@ -22,6 +22,11 @@ namespace Polyrific.Catapult.Api.Core.Entities
         public string Name { get; set; }
 
         /// <summary>
+        /// Is the job definition for resource deletion?
+        /// </summary>
+        public bool IsDeletion { get; set; }
+
+        /// <summary>
         /// Tasks of the job definition
         /// </summary>
         public virtual ICollection<JobTaskDefinition> Tasks { get; set; }

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/JobQueueInProgressException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/JobQueueInProgressException.cs
@@ -6,12 +6,12 @@ namespace Polyrific.Catapult.Api.Core.Exceptions
 {
     public class JobQueueInProgressException : Exception
     {
-        public int JobDefinitionId { get; set; }
+        public int ProjectId { get; set; }
 
         public JobQueueInProgressException(int projectId)
             : base($"There is already a running job in project \"{projectId}\". Please wait for it to complete before queueing a new job.")
         {
-            JobDefinitionId = projectId;
+            ProjectId = projectId;
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/JobTaskDefinitionTypeException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/JobTaskDefinitionTypeException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class JobTaskDefinitionTypeException : Exception
+    {
+        public bool IsJobDeletion { get; set; }
+        public string TaskDefinitionType { get; set; }
+
+        public JobTaskDefinitionTypeException(bool isJobDeletion, string taskDefinitionType)
+            : base($"Task with type \"{taskDefinitionType}\" cannot be added to {(isJobDeletion ? "deletion" : "normal")} job definition")
+        {
+            IsJobDeletion = isJobDeletion;
+            TaskDefinitionType = taskDefinitionType;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/MultipleDeletionJobException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/MultipleDeletionJobException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class MultipleDeletionJobException : Exception
+    {
+        public MultipleDeletionJobException()
+            : base("A deletion job definition is already exist. A project should only contain one deletion job definition.")
+        {
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -14,9 +14,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// </summary>
         /// <param name="projectId">Id of the project</param>
         /// <param name="name">Name of the job definition</param>
+        /// <param name="isDeletion">Is the job definition for resource deletion?</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>Id of the new added job definition</returns>
-        Task<int> AddJobDefinition(int projectId, string name, CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> AddJobDefinition(int projectId, string name, bool isDeletion, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Rename a job definition
@@ -139,9 +140,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <summary>
         /// Validate the task property and config whether it has satisfy required values
         /// </summary>
+        /// <param name="jobDefinition">The job definition object</param>
         /// <param name="jobTaskDefinition">The job task definition object</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns></returns>
-        Task ValidateJobTaskDefinition(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
+        Task ValidateJobTaskDefinition(JobDefinition jobDefinition, JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
@@ -220,7 +220,7 @@ namespace Polyrific.Catapult.Api.Core.Services
                         foreach (var task in job.Tasks)
                         {
                             task.Created = DateTime.UtcNow;
-                            await _jobDefinitionService.ValidateJobTaskDefinition(task);
+                            await _jobDefinitionService.ValidateJobTaskDefinition(job, task);
                         }
                     }
                 }

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobDefinitionFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobDefinitionFilterSpecification.cs
@@ -11,15 +11,17 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         public string Name { get; set; }
         public int ExcludedJobDefinitionId { get; set; }
         public int[] JobDefinitionIds { get; set; }
+        public bool? IsDeletion { get; set; }
 
         /// <summary>
         /// Filter the job definition by project
         /// </summary>
         /// <param name="projectId">The project id</param>
-        public JobDefinitionFilterSpecification(int projectId)
-            : base(m => m.ProjectId == projectId)
+        public JobDefinitionFilterSpecification(int projectId, bool? isDeletion = null)
+            : base(m => m.ProjectId == projectId && (isDeletion == null || m.IsDeletion == isDeletion))
         {
             ProjectId = projectId;
+            IsDeletion = isDeletion;
         }
 
         /// <summary>

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobTaskDefinitionFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobTaskDefinitionFilterSpecification.cs
@@ -14,8 +14,8 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         /// Filter job task definition by job definition id
         /// </summary>
         /// <param name="jobDefinitionId">The job definition id</param>
-        public JobTaskDefinitionFilterSpecification(int jobDefinitionId)
-            : base(m => m.JobDefinitionId == jobDefinitionId, m => m.Sequence)
+        public JobTaskDefinitionFilterSpecification(int jobDefinitionId, int jobTaskDefinitionId = 0)
+            : base(m => m.JobDefinitionId == jobDefinitionId && (jobTaskDefinitionId == 0 || m.Id == jobTaskDefinitionId), m => m.Sequence)
         {
             JobDefinitionId = jobDefinitionId;
         }

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190319073105_JobDefinitionDeletion.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190319073105_JobDefinitionDeletion.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190319073105_JobDefinitionDeletion")]
+    partial class JobDefinitionDeletion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190319073105_JobDefinitionDeletion.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190319073105_JobDefinitionDeletion.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class JobDefinitionDeletion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeletion",
+                table: "JobDefinitions",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeletion",
+                table: "JobDefinitions");
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -63,7 +63,8 @@ namespace Polyrific.Catapult.Api.Controllers
                 var newJobDefinitionResponse = _mapper.Map<JobDefinitionDto>(newJobDefinition);
                 newJobDefinitionResponse.ProjectId = projectId;
                 newJobDefinitionResponse.Id = await _jobDefinitionService.AddJobDefinition(projectId,
-                    newJobDefinition.Name);
+                    newJobDefinition.Name,
+                    newJobDefinition.IsDeletion);
 
                 return CreatedAtRoute("GetJobDefinitionById", new
                 {
@@ -80,6 +81,11 @@ namespace Polyrific.Catapult.Api.Controllers
             {
                 _logger.LogWarning(projEx, "Project not found");
                 return BadRequest(projEx.Message);
+            }
+            catch (MultipleDeletionJobException jobEx)
+            {
+                _logger.LogWarning(jobEx, "A deletion job definition is already exist. A project should only contain one deletion job definition.");
+                return BadRequest(jobEx.Message);
             }
         }
 
@@ -270,6 +276,11 @@ namespace Polyrific.Catapult.Api.Controllers
             {
                 _logger.LogWarning(iestEx, "Incorrect external service type");
                 return BadRequest(iestEx.Message);
+            }
+            catch (JobTaskDefinitionTypeException taskEx)
+            {
+                _logger.LogWarning(taskEx, "Incorrect task definition type");
+                return BadRequest(taskEx.Message);
             }
         }
 

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/JobTaskDefinitionType.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/JobTaskDefinitionType.cs
@@ -13,5 +13,7 @@ namespace Polyrific.Catapult.Shared.Dto.Constants
         public const string Push = "Push";
         public const string PublishArtifact = "PublishArtifact";
         public const string Test = "Test";
+        public const string DeleteRepository = "DeleteRepository";
+        public const string DeleteHosting = "DeleteHosting";
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobDefinitionDto.cs
@@ -7,9 +7,14 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
     public class CreateJobDefinitionDto
     {
         /// <summary>
-        /// Name of the data model
+        /// Name of the job definition
         /// </summary>
         [Required]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Is the job definition for resource deletion?
+        /// </summary>
+        public bool IsDeletion { get; set; }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobDefinitionDto.cs
@@ -22,6 +22,11 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         public string Name { get; set; }
 
         /// <summary>
+        /// Is the job definition for resource deletion?
+        /// </summary>
+        public bool IsDeletion { get; set; }
+
+        /// <summary>
         /// Name of the data model
         /// </summary>
         public List<JobTaskDefinitionDto> Tasks { get; set; }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
@@ -58,7 +58,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         public async void CreateJobDefinition_ReturnsCreatedJobDefinition()
         {
             _jobDefinitionService
-                .Setup(s => s.AddJobDefinition(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Setup(s => s.AddJobDefinition(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(1);
 
             var controller = new JobDefinitionController(_jobDefinitionService.Object, _mapper, _logger.Object);


### PR DESCRIPTION
## Summary
Implement the changes in API to support job definition for resource deletion. Changes in UI (CLI/Web) will be done in separate PR

## Coverage
- [x] Add `IsDeletion` flag in job definition
- [x] Add validation for job definition and job task definition

## References
- Related Issues: #310 
