### PR TITLE
Fix migration script where it does not properly rename the DotNetCore Plugin

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190228050357_RenameDotNetCoreAndTest.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190228050357_RenameDotNetCoreAndTest.cs
@@ -9,6 +9,13 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             migrationBuilder.UpdateData(
                 table: "Plugins",
                 keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "ConcurrencyStamp", "Name" },
+                values: new object[] { "976e0533-360a-4e46-8220-7c1cfdf0e0a3", "Polyrific.Catapult.TaskProviders.DotNetCore" });
+
+            migrationBuilder.UpdateData(
+                table: "Plugins",
+                keyColumn: "Id",
                 keyValue: 4,
                 columns: new[] { "ConcurrencyStamp", "Name" },
                 values: new object[] { "976e0533-360a-4e46-8220-7c1cfdf0e0a4", "Polyrific.Catapult.TaskProviders.DotNetCoreTest" });
@@ -16,6 +23,13 @@ namespace Polyrific.Catapult.Api.Data.Migrations
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.UpdateData(
+                table: "Plugins",
+                keyColumn: "Id",
+                keyValue: 3,
+                columns: new[] { "ConcurrencyStamp", "Name" },
+                values: new object[] { "976e0533-360a-4e46-8220-7c1cfdf0e0a3", "Polyrific.Catapult.Plugins.DotNetCore" });
+
             migrationBuilder.UpdateData(
                 table: "Plugins",
                 keyColumn: "Id",


### PR DESCRIPTION
## Summary
Fix the issue in migration script where it does not have the script to update the `Plugins.DotNetCore` to `TaskProviders.DotNetCore`. 

Note that this only fix the data when the migration is performed from scratch. It won't update the data when it's running the existing database that have previously run the script `20190228050357_RenameDotNetCoreAndTest`. Manual fix would have to be done for this scenario

## Coverage
- [x] Fix migration script