### PR TITLE
Move env config to config.json

### DIFF
--- a/src/Web/opencatapultweb/angular.json
+++ b/src/Web/opencatapultweb/angular.json
@@ -20,7 +20,8 @@
             "tsConfig": "src/tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              "src/config.json"
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",

--- a/src/Web/opencatapultweb/src/app/app.module.ts
+++ b/src/Web/opencatapultweb/src/app/app.module.ts
@@ -20,6 +20,8 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { ForgotPasswordComponent } from './forgot-password/forgot-password.component';
 import { ResetPasswordComponent } from './reset-password/reset-password.component';
 
+import { ConfigServiceProvider } from './config/config.service.provider';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -50,6 +52,9 @@ import { ResetPasswordComponent } from './reset-password/reset-password.componen
     ReactiveFormsModule,
     FlexLayoutModule,
     SharedModule.forRoot()
+  ],
+  providers: [
+    ConfigServiceProvider
   ],
   bootstrap: [AppComponent]
 })

--- a/src/Web/opencatapultweb/src/app/config/config.service.provider.ts
+++ b/src/Web/opencatapultweb/src/app/config/config.service.provider.ts
@@ -1,0 +1,15 @@
+import { APP_INITIALIZER } from '@angular/core';
+import { ConfigService } from './config.service';
+
+export const ConfigServiceFactory = (configService: ConfigService) => {
+  return () => {
+    return configService.loadConfig();
+  };
+};
+
+export const ConfigServiceProvider = {
+  provide: APP_INITIALIZER,
+  useFactory: ConfigServiceFactory,
+  multi: true,
+  deps: [ConfigService]
+};

--- a/src/Web/opencatapultweb/src/app/config/config.service.spec.ts
+++ b/src/Web/opencatapultweb/src/app/config/config.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from './config.service';
+
+describe('ConfigService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ConfigService = TestBed.get(ConfigService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/Web/opencatapultweb/src/app/config/config.service.spec.ts
+++ b/src/Web/opencatapultweb/src/app/config/config.service.spec.ts
@@ -1,9 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ConfigService } from './config.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ConfigService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      HttpClientTestingModule
+    ],
+    providers: [
+      ConfigService
+    ]
+  }));
 
   it('should be created', () => {
     const service: ConfigService = TestBed.get(ConfigService);

--- a/src/Web/opencatapultweb/src/app/config/config.service.ts
+++ b/src/Web/opencatapultweb/src/app/config/config.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { config, Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigService {
+
+  private config: Config;
+
+  constructor(private http: HttpClient) { }
+
+  async loadConfig() {
+
+    console.debug("Loading configs...");
+    const data = await this.http.get<Config>('./config.json')
+      .toPromise();
+    this.config = data;
+    console.debug(`Configs has been loaded for environment "${this.config.environmentName}".`);
+
+  }
+
+  getConfig(): Config {
+    return this.config;
+  }
+}
+
+export interface Config {
+  apiUrl: string;
+  environmentName: string;
+}

--- a/src/Web/opencatapultweb/src/app/config/config.service.ts
+++ b/src/Web/opencatapultweb/src/app/config/config.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { config, Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -13,11 +12,11 @@ export class ConfigService {
 
   async loadConfig() {
 
-    console.debug("Loading configs...");
+    // console.debug("Loading configs...");
     const data = await this.http.get<Config>('./config.json')
       .toPromise();
     this.config = data;
-    console.debug(`Configs has been loaded for environment "${this.config.environmentName}".`);
+    // console.debug(`Configs has been loaded for environment "${this.config.environmentName}".`);
 
   }
 

--- a/src/Web/opencatapultweb/src/app/core/auth/auth.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/auth/auth.service.ts
@@ -7,7 +7,7 @@ import * as jwt_decode from 'jwt-decode';
 import { AuthorizePolicy } from './authorize-policy';
 import { Role } from './role';
 import { ProjectMemberRole } from './project-member-role';
-import { Config, ConfigService } from '../../config/config.service'
+import { Config, ConfigService } from '../../config/config.service';
 
 @Injectable()
 export class AuthService {

--- a/src/Web/opencatapultweb/src/app/core/auth/auth.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/auth/auth.service.ts
@@ -3,14 +3,15 @@ import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { map, } from 'rxjs/operators';
 import { User } from './user';
-import { environment } from '@env/environment';
 import * as jwt_decode from 'jwt-decode';
 import { AuthorizePolicy } from './authorize-policy';
 import { Role } from './role';
 import { ProjectMemberRole } from './project-member-role';
+import { Config, ConfigService } from '../../config/config.service'
 
 @Injectable()
 export class AuthService {
+  private config: Config;
   private currentUserSubject: BehaviorSubject<User>;
   public currentUser: Observable<User>;
 
@@ -21,10 +22,11 @@ export class AuthService {
   }
 
   constructor(
-    private http: HttpClient
-  ) {
-    this.currentUserSubject = new BehaviorSubject<User>(JSON.parse(localStorage.getItem('currentUser')));
-    this.currentUser = this.currentUserSubject.asObservable();
+    private configService: ConfigService,
+    private http: HttpClient) {
+      this.config = this.configService.getConfig();
+      this.currentUserSubject = new BehaviorSubject<User>(JSON.parse(localStorage.getItem('currentUser')));
+      this.currentUser = this.currentUserSubject.asObservable();
   }
 
   public get currentUserValue(): User {
@@ -32,7 +34,11 @@ export class AuthService {
   }
 
   login(user: User) {
-    return this.http.post(`${environment.apiUrl}/Token`, { Email: user.email, Password: user.password },
+    if (!this.config) {
+      this.config = this.configService.getConfig();
+    }
+
+    return this.http.post(`${this.config.apiUrl}/Token`, { Email: user.email, Password: user.password },
     {
       responseType: 'text'
     })

--- a/src/Web/opencatapultweb/src/app/core/interceptors/jwt.interceptor.ts
+++ b/src/Web/opencatapultweb/src/app/core/interceptors/jwt.interceptor.ts
@@ -3,16 +3,26 @@ import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/c
 import { Observable } from 'rxjs';
 
 import { AuthService } from '../auth/auth.service';
-import { environment } from '@env/environment';
+import { Config, ConfigService } from '../../config/config.service';
 
 @Injectable()
 export class JwtInterceptor implements HttpInterceptor {
-    constructor(private authenticationService: AuthService) {}
+    private config: Config;
+
+    constructor(
+      private configService: ConfigService,
+      private authenticationService: AuthService) {
+        this.config = this.configService.getConfig();
+      }
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        if (!this.config) {
+          this.config = this.configService.getConfig();
+        }
+
         // add authorization header with jwt token if available
         const currentUser = this.authenticationService.currentUserValue;
-        if (request.url.startsWith(environment.apiUrl) && currentUser && currentUser.token) {
+        if (this.config && request.url.startsWith(this.config.apiUrl) && currentUser && currentUser.token) {
             request = request.clone({
                 setHeaders: {
                     Authorization: `Bearer ${currentUser.token}`

--- a/src/Web/opencatapultweb/src/app/core/services/api.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/services/api.service.ts
@@ -1,16 +1,20 @@
 import { Injectable } from '@angular/core';
-import { environment } from '@env/environment';
 import { HttpClient, HttpParams, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+import { Config, ConfigService } from '../../config/config.service'
 
 @Injectable()
 export class ApiService {
+  config: Config
   constructor(
-    private http: HttpClient
-  ) {}
+    private http: HttpClient,
+    private configService: ConfigService
+  ) {
+    this.config = configService.getConfig();
+  }
 
   private formatErrors(error: HttpErrorResponse) {
     if (error.error) {
@@ -27,25 +31,25 @@ export class ApiService {
   }
 
   get<T>(path: string, params: HttpParams = new HttpParams()): Observable<T> {
-    return this.http.get<T>(`${environment.apiUrl}/${path}`, { params })
+    return this.http.get<T>(`${this.config.apiUrl}/${path}`, { params })
       .pipe(catchError(this.formatErrors));
   }
 
   getString(path: string, params: HttpParams = new HttpParams()): Observable<string> {
-    return this.http.get(`${environment.apiUrl}/${path}`, { responseType: 'text', ...params})
+    return this.http.get(`${this.config.apiUrl}/${path}`, { responseType: 'text', ...params})
       .pipe(catchError(this.formatErrors));
   }
 
   put<T>(path: string, body: Object = {}): Observable<T> {
     return this.http.put<T>(
-      `${environment.apiUrl}/${path}`,
+      `${this.config.apiUrl}/${path}`,
       body
     ).pipe(catchError(this.formatErrors));
   }
 
   putString(path: string, body: Object = {}): Observable<string> {
     return this.http.put(
-      `${environment.apiUrl}/${path}`,
+      `${this.config.apiUrl}/${path}`,
       body,
       { responseType: 'text' }
     ).pipe(catchError(this.formatErrors));
@@ -53,14 +57,14 @@ export class ApiService {
 
   post<T>(path: string, body: Object = {}): Observable<T> {
     return this.http.post<T>(
-      `${environment.apiUrl}/${path}`,
+      `${this.config.apiUrl}/${path}`,
       body
     ).pipe(catchError(this.formatErrors));
   }
 
   postString(path: string, body: Object = {}): Observable<string> {
     return this.http.post(
-      `${environment.apiUrl}/${path}`,
+      `${this.config.apiUrl}/${path}`,
       body,
       {
         responseType: 'text'
@@ -70,7 +74,7 @@ export class ApiService {
 
   delete<T>(path): Observable<T> {
     return this.http.delete<T>(
-      `${environment.apiUrl}/${path}`
+      `${this.config.apiUrl}/${path}`
     ).pipe(catchError(this.formatErrors));
   }
 }

--- a/src/Web/opencatapultweb/src/app/core/services/api.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/services/api.service.ts
@@ -14,6 +14,12 @@ export class ApiService {
     private configService: ConfigService
   ) {
     this.config = configService.getConfig();
+    if (!this.config) {
+      this.config = {
+        apiUrl: "http://localhost",
+        environmentName: "local-dev"
+      }
+    }
   }
 
   private formatErrors(error: HttpErrorResponse) {

--- a/src/Web/opencatapultweb/src/app/core/services/api.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/services/api.service.ts
@@ -4,11 +4,11 @@ import { Observable } from 'rxjs';
 
 import { throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { Config, ConfigService } from '../../config/config.service'
+import { Config, ConfigService } from '../../config/config.service';
 
 @Injectable()
 export class ApiService {
-  config: Config
+  config: Config;
   constructor(
     private http: HttpClient,
     private configService: ConfigService
@@ -16,9 +16,9 @@ export class ApiService {
     this.config = configService.getConfig();
     if (!this.config) {
       this.config = {
-        apiUrl: "http://localhost",
-        environmentName: "local-dev"
-      }
+        apiUrl: 'http://localhost',
+        environmentName: 'local-dev'
+      };
     }
   }
 

--- a/src/Web/opencatapultweb/src/app/core/services/signalr.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/services/signalr.service.ts
@@ -1,21 +1,29 @@
 import { Injectable } from '@angular/core';
-import { environment } from '@env/environment';
 import { HubConnection, HubConnectionBuilder, HttpTransportType } from '@aspnet/signalr';
 import { AuthService } from '../auth/auth.service';
 import { Subject } from 'rxjs';
+import { Config, ConfigService } from '../../config/config.service';
 
 @Injectable()
 export class SignalrService {
   private connection: HubConnection;
+  private config: Config;
 
   constructor(
-    private authenticationService: AuthService) { }
+    private configService: ConfigService,
+    private authenticationService: AuthService) {
+      this.config = this.configService.getConfig();
+    }
 
   connect(path: string, message$: Subject<any>) {
+    if (!this.config) {
+      this.config = this.configService.getConfig();
+    }
+
     const currentUser = this.authenticationService.currentUserValue;
     if (!this.connection) {
       this.connection = new HubConnectionBuilder()
-        .withUrl(`${environment.apiUrl}/${path}`, {
+        .withUrl(`${this.config.apiUrl}/${path}`, {
           accessTokenFactory: () => currentUser.token,
           transport: HttpTransportType.LongPolling,
         })

--- a/src/Web/opencatapultweb/src/app/project/project-clone/project-clone.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-clone/project-clone.component.spec.ts
@@ -9,6 +9,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from '@app/shared/shared.module';
 import { CoreModule } from '@app/core';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 describe('ProjectCloneComponent', () => {
   let component: ProjectCloneComponent;
@@ -27,6 +29,15 @@ describe('ProjectCloneComponent', () => {
         HttpClientTestingModule,
         CoreModule,
         SharedModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute, useValue: {
+            params: of({ id: 1}),
+            data: of({project: { id: 1}}),
+            snapshot: {}
+          }
+        },
       ]
     })
     .compileComponents();

--- a/src/Web/opencatapultweb/src/app/project/project-dashboard/project-dashboard.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/project-dashboard/project-dashboard.component.spec.ts
@@ -5,7 +5,7 @@ import { CoreModule } from '@app/core';
 import { MatCardModule, MatDividerModule } from '@angular/material';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ProjectDashboardComponent', () => {
   let component: ProjectDashboardComponent;
@@ -16,7 +16,7 @@ describe('ProjectDashboardComponent', () => {
       declarations: [ ProjectDashboardComponent ],
       imports: [
         CoreModule,
-        HttpClientModule,
+        HttpClientTestingModule,
         MatCardModule,
         FlexLayoutModule,
         MatDividerModule,

--- a/src/Web/opencatapultweb/src/config.json
+++ b/src/Web/opencatapultweb/src/config.json
@@ -1,0 +1,4 @@
+{
+  "apiUrl": "https://localhost:44305",
+  "environmentName": "local-dev"
+}

--- a/src/Web/opencatapultweb/src/environments/environment.prod.ts
+++ b/src/Web/opencatapultweb/src/environments/environment.prod.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://localhost:44305',
   version: '1.0.0-beta2'
 };

--- a/src/Web/opencatapultweb/src/environments/environment.ts
+++ b/src/Web/opencatapultweb/src/environments/environment.ts
@@ -4,7 +4,6 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'https://localhost:44305',
   version: '1.0.0-beta2'
 };
 


### PR DESCRIPTION
## Summary
In order to separate between app and config, I move out some configs from `environment.ts` to `config.json`. This way, the configs will not be compiled as part of the app and can be modified on the fly when being deployed to different environments.

## Coverage
- [x] Add `config.json`
- [x] Remove some configs from `environment.js`
- [x] Add `ConfigService`
- [x] Replace the usage of `@env/environment` into `config/config.service`

## References
- Related Issues: https://github.com/Polyrific-Inc/OpenCatapult/issues/409
- Other links:
  - https://www.jvandemo.com/how-to-use-environment-variables-to-configure-your-angular-application-without-a-rebuild/
  - https://juristr.com/blog/2018/01/ng-app-runtime-config/
