### PR TITLE
Add manual build guide to summary

### DIFF
--- a/docs/summary.md
+++ b/docs/summary.md
@@ -23,6 +23,7 @@
   * [Create your first project using Web UI](user-guides/create-first-project-web.md)
 * [Developer Guide](dev-guides/dev-guides.md)
   * [Build Scripts](dev-guides/build-scripts.md)
+  * [Manual Build](dev-guides/manual-build.md)
   * [Project template](dev-guides/project-template.md)
   * [Coding Style](dev-guides/coding-style.md)
   * [Code of conduct](dev-guides/contribute.md)


### PR DESCRIPTION
## Summary
Previously I moved the manual build guide out from the quick start into its own section. This PR adds the new section into the summary file so it's shown up in the left nav panel.