### PR TITLE
Engine: Execute delete resource job definition

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/Project.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/Project.cs
@@ -22,9 +22,9 @@ namespace Polyrific.Catapult.Api.Core.Entities
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Is project archived?
+        /// Status of the project
         /// </summary>
-        public bool IsArchived { get; set; }
+        public string Status { get; set; }
         
         /// <summary>
         /// Project data models of the project

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -38,7 +38,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             cancellationToken.ThrowIfCancellationRequested();
 
             var project = await _projectRepository.GetById(projectId, cancellationToken);
-            if (project == null || project.IsArchived)
+            if (project == null || project.Status != ProjectStatusFilterType.Active)
             {
                 throw new ProjectNotFoundException(projectId);
             }
@@ -82,7 +82,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             jobQueueSpec.Includes.Add(j => j.Project);
             var jobQueue = await _jobQueueRepository.GetSingleBySpec(jobQueueSpec, cancellationToken);
 
-            if (jobQueue != null && !jobQueue.Project.IsArchived)
+            if (jobQueue != null && jobQueue.Project.Status == ProjectStatusFilterType.Active)
             {
                 if (updatedJobQueue.ProjectId == 0 && !string.IsNullOrEmpty(jobQueue.CatapultEngineId) && jobQueue.CatapultEngineId != updatedJobQueue.CatapultEngineId)
                 {
@@ -109,7 +109,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             jobQueueSpec.Includes.Add(q => q.Project);
             var jobQueue = await _jobQueueRepository.GetSingleBySpec(jobQueueSpec, cancellationToken);
 
-            if (jobQueue != null && !jobQueue.Project.IsArchived)
+            if (jobQueue != null && jobQueue.Project.Status == ProjectStatusFilterType.Active)
             {
                 if (!_inProgressJobStatus.Contains(jobQueue.Status))
                 {
@@ -220,6 +220,7 @@ namespace Polyrific.Catapult.Api.Core.Services
 
             var queuedJobSpec = new JobQueueFilterSpecification();
             queuedJobSpec.Includes.Add(q => q.JobDefinition);
+            queuedJobSpec.Includes.Add(q => q.Project);
             var jobQueue = await _jobQueueRepository.GetSingleBySpec(queuedJobSpec, cancellationToken);
 
             if (!string.IsNullOrEmpty(engine))

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -82,7 +82,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             jobQueueSpec.Includes.Add(j => j.Project);
             var jobQueue = await _jobQueueRepository.GetSingleBySpec(jobQueueSpec, cancellationToken);
 
-            if (jobQueue != null && jobQueue.Project.Status == ProjectStatusFilterType.Active)
+            if (jobQueue != null && jobQueue.Project.Status != ProjectStatusFilterType.Archived)
             {
                 if (updatedJobQueue.ProjectId == 0 && !string.IsNullOrEmpty(jobQueue.CatapultEngineId) && jobQueue.CatapultEngineId != updatedJobQueue.CatapultEngineId)
                 {
@@ -109,7 +109,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             jobQueueSpec.Includes.Add(q => q.Project);
             var jobQueue = await _jobQueueRepository.GetSingleBySpec(jobQueueSpec, cancellationToken);
 
-            if (jobQueue != null && jobQueue.Project.Status == ProjectStatusFilterType.Active)
+            if (jobQueue != null)
             {
                 if (!_inProgressJobStatus.Contains(jobQueue.Status))
                 {

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobQueueFilterSpecification.cs
@@ -20,7 +20,7 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         /// Filter to get unassigned queued job only
         /// </summary>
         public JobQueueFilterSpecification()
-            : base(m => m.Status == JobStatus.Queued && m.CatapultEngineId == null && !m.Project.IsArchived, m => m.Created)
+            : base(m => m.Status == JobStatus.Queued && m.CatapultEngineId == null && m.Project.Status == ProjectStatusFilterType.Active, m => m.Created)
         {
             Status = JobStatus.Queued;
             UnassignedOnly = true;

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/ProjectMemberFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/ProjectMemberFilterSpecification.cs
@@ -8,19 +8,19 @@ namespace Polyrific.Catapult.Api.Core.Specifications
     {
         public int ProjectId { get; set; }
         public int UserId { get; set; }
-        public bool? IsArchived { get; set; }
+        public string Status { get; set; }
         public int RoleId { get; set; }
         public int MemberId { get; set; }
 
-        public ProjectMemberFilterSpecification(int projectId, int userId, bool? isArchived = null, int roleId = 0) 
+        public ProjectMemberFilterSpecification(int projectId, int userId, string status = null, int roleId = 0) 
             : base(m => (projectId == 0 || m.ProjectId == projectId) 
                         && (userId == 0 || m.UserId == userId) 
-                        && (isArchived == null || m.Project.IsArchived == isArchived)
+                        && (status == null || m.Project.Status == status)
                         && (roleId == 0 || m.ProjectMemberRoleId == roleId))
         {
             ProjectId = projectId;
             UserId = userId;
-            IsArchived = isArchived;
+            Status = status;
             RoleId = roleId;
 
             if (projectId == 0)

--- a/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/ProjectConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/ProjectConfig.cs
@@ -1,11 +1,19 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Polyrific.Catapult.Api.Core.Entities;
+using Polyrific.Catapult.Shared.Dto.Constants;
 
 namespace Polyrific.Catapult.Api.Data.EntityConfigs
 {
     public class ProjectConfig : BaseEntityConfig<Project>
     {
-        
+        public override void Configure(EntityTypeBuilder<Project> builder)
+        {
+            base.Configure(builder);
+
+            builder.Property(p => p.Status).IsRequired().HasDefaultValue(ProjectStatusFilterType.Active);
+        }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321033216_ProjectStatus.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321033216_ProjectStatus.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190321033216_ProjectStatus")]
+    partial class ProjectStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321033216_ProjectStatus.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321033216_ProjectStatus.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class ProjectStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsArchived",
+                table: "Projects");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Projects",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Projects");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsArchived",
+                table: "Projects",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321065855_ProjectStatus.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321065855_ProjectStatus.Designer.cs
@@ -10,7 +10,7 @@ using Polyrific.Catapult.Api.Data;
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    [Migration("20190321033216_ProjectStatus")]
+    [Migration("20190321065855_ProjectStatus")]
     partial class ProjectStatus
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -363,7 +363,10 @@ namespace Polyrific.Catapult.Api.Data.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("Status");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue("active");
 
                     b.Property<DateTime?>("Updated");
 

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321065855_ProjectStatus.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190321065855_ProjectStatus.cs
@@ -13,7 +13,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             migrationBuilder.AddColumn<string>(
                 name: "Status",
                 table: "Projects",
-                nullable: true);
+                nullable: false,
+                defaultValue: "active");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultDbContextModelSnapshot.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultDbContextModelSnapshot.cs
@@ -361,7 +361,10 @@ namespace Polyrific.Catapult.Api.Data.Migrations
 
                     b.Property<string>("Name");
 
-                    b.Property<string>("Status");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue("active");
 
                     b.Property<DateTime?>("Updated");
 

--- a/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
@@ -16,7 +16,8 @@ namespace Polyrific.Catapult.Api.AutoMapperProfiles
                 .ForMember(dest => dest.JobTasksStatus, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<List<JobTaskStatusDto>>(src.JobTasksStatus)))
                 .ForMember(dest => dest.OutputValues, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<Dictionary<string, string>>(src.OutputValues)))
                 .ForMember(dest => dest.JobDefinitionName, opt => opt.MapFrom(src => src.JobDefinition.Name))
-                .ForMember(dest => dest.IsDeletion, opt => opt.MapFrom(src => src.JobDefinition.IsDeletion));
+                .ForMember(dest => dest.IsDeletion, opt => opt.MapFrom(src => src.JobDefinition.IsDeletion))
+                .ForMember(dest => dest.ProjectStatus, opt => opt.MapFrom(src => src.Project.Status));
 
             CreateMap<NewJobDto, JobDto>();
 

--- a/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/ProjectAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/ProjectAutoMapperProfile.cs
@@ -11,8 +11,7 @@ namespace Polyrific.Catapult.Api.AutoMapperProfiles
     {
         public ProjectAutoMapperProfile()
         {
-            CreateMap<Project, ProjectDto>()
-                .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.IsArchived ? ProjectStatusFilterType.Archived: ProjectStatusFilterType.Active));
+            CreateMap<Project, ProjectDto>();
 
             CreateMap<UpdateProjectDto, Project>();
         }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
@@ -64,6 +64,11 @@ namespace Polyrific.Catapult.Engine.Core
                         jobQueue.Status = JobStatus.Error;
                     else
                         jobQueue.Status = JobStatus.Completed;
+
+                    if (jobQueue.IsDeletion)
+                    {
+                        // Call the API to perform hard delete
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
@@ -19,6 +19,7 @@ namespace Polyrific.Catapult.Engine.Core
         private readonly IHealthService _healthService;
         private readonly IJobQueueService _jobQueueService;
         private readonly IJobDefinitionService _jobDefinitionService;
+        private readonly IProjectService _projectService;
         private readonly IJobLogWriter _jobLogWriter;
         private readonly ILogger<CatapultEngine> _logger;
 
@@ -27,6 +28,7 @@ namespace Polyrific.Catapult.Engine.Core
             IHealthService healthService,
             IJobQueueService jobQueueService, 
             IJobDefinitionService jobDefinitionService,
+            IProjectService projectService,
             IJobLogWriter jobLogWriter,
             ILogger<CatapultEngine> logger)
         {
@@ -35,6 +37,7 @@ namespace Polyrific.Catapult.Engine.Core
             _healthService = healthService;
             _jobQueueService = jobQueueService;
             _jobDefinitionService = jobDefinitionService;
+            _projectService = projectService;
             _jobLogWriter = jobLogWriter;
             _logger = logger;
         }
@@ -65,9 +68,12 @@ namespace Polyrific.Catapult.Engine.Core
                     else
                         jobQueue.Status = JobStatus.Completed;
 
-                    if (jobQueue.IsDeletion)
+                    if (jobQueue.Status == JobStatus.Completed && 
+                        jobQueue.IsDeletion && 
+                        jobQueue.ProjectStatus == ProjectStatusFilterType.Deleting)
                     {
-                        // Call the API to perform hard delete
+                        _logger.LogInformation($"Deleting project {jobQueue.ProjectId}");
+                        await _projectService.DeleteProject(jobQueue.ProjectId);
                     }
                 }
                 catch (Exception ex)

--- a/src/Engine/Polyrific.Catapult.Engine.Core/EngineCoreInjection.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/EngineCoreInjection.cs
@@ -22,6 +22,8 @@ namespace Polyrific.Catapult.Engine.Core
             services.AddTransient<IPublishArtifactTask, PublishArtifactTask>();
             services.AddTransient<IPushTask, PushTask>();
             services.AddTransient<ITestTask, TestTask>();
+            services.AddTransient<IDeleteRepositoryTask, DeleteRepositoryTask>();
+            services.AddTransient<IDeleteHostingTask, DeleteHostingTask>();
             services.AddTransient<JobTaskService, JobTaskService>();
         }
     }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTaskService.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTaskService.cs
@@ -17,7 +17,9 @@ namespace Polyrific.Catapult.Engine.Core
             IMergeTask mergeTask,
             IPublishArtifactTask publishArtifactTask,
             IPushTask pushTask,
-            ITestTask testTask)
+            ITestTask testTask,
+            IDeleteRepositoryTask deleteRepositoryTask,
+            IDeleteHostingTask deleteHostingTask)
         {
             BuildTask = buildTask;
             CloneTask = cloneTask;
@@ -28,6 +30,8 @@ namespace Polyrific.Catapult.Engine.Core
             PublishArtifactTask = publishArtifactTask;
             PushTask = pushTask;
             TestTask = testTask;
+            DeleteRepositoryTask = deleteRepositoryTask;
+            DeleteHostingTask = deleteHostingTask;
         }
 
         /// <summary>
@@ -74,5 +78,15 @@ namespace Polyrific.Catapult.Engine.Core
         /// Instance of <see cref="ITestTask"/>
         /// </summary>
         public ITestTask TestTask { get; }
+
+        /// <summary>
+        /// Instance of <see cref="IDeleteRepositoryTask"/>
+        /// </summary>
+        public IDeleteRepositoryTask DeleteRepositoryTask { get; }
+
+        /// <summary>
+        /// Instance of <see cref="IDeleteHostingTask"/>
+        /// </summary>
+        public IDeleteHostingTask DeleteHostingTask { get; }
     }
 }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteHostingTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteHostingTask.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Polyrific.Catapult.Shared.Dto.Constants;
+using Polyrific.Catapult.Shared.Service;
+using Polyrific.Catapult.TaskProviders.Core.Configs;
+
+namespace Polyrific.Catapult.Engine.Core.JobTasks
+{
+    public class DeleteHostingTask : BaseJobTask<BaseJobTaskConfig>, IDeleteHostingTask
+    {
+        /// <inheritdoc />
+        public DeleteHostingTask(
+            IProjectService projectService, IExternalServiceService externalServiceService, 
+            IExternalServiceTypeService externalServiceTypeService, IProviderService providerService, 
+            IPluginManager pluginManager, ILogger<DeleteHostingTask> logger)
+            : base(projectService, externalServiceService, externalServiceTypeService, providerService, pluginManager, logger)
+        {
+        }
+
+        public override string Type => JobTaskDefinitionType.DeleteHosting;
+
+        public List<PluginItem> HostingProviders => PluginManager.GetPlugins(PluginType.HostingProvider);
+
+        public override async Task<TaskRunnerResult> RunMainTask(Dictionary<string, string> previousTasksOutputValues)
+        {
+            var provider = HostingProviders?.FirstOrDefault(p => p.Name == Provider);
+            if (provider == null)
+                return new TaskRunnerResult($"Deploy provider \"{Provider}\" could not be found.");
+
+            await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
+
+            var arg = GetArgString();
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
+            if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
+                return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
+
+            var hostLocation = "";
+            var taskRemarks = "";
+            if (result.ContainsKey("hostLocation"))
+            {
+                hostLocation = result["hostLocation"].ToString();
+                taskRemarks = $"The hosting url {hostLocation} has been deleted";
+            }
+
+            var outputValues = new Dictionary<string, string>();
+            if (result.ContainsKey("outputValues") && !string.IsNullOrEmpty(result["outputValues"]?.ToString()))
+                outputValues = JsonConvert.DeserializeObject<Dictionary<string, string>>(result["outputValues"].ToString());
+
+            return new TaskRunnerResult(true, "", outputValues)
+            {
+                TaskRemarks = taskRemarks
+            };
+        }
+
+        private (string argString, string securedArgString) GetArgString()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                {"process", "delete"},
+                {"project", Project.Name},
+                {"config", TaskConfig},
+                {"additional", AdditionalConfigs}
+            };
+
+            var argString = JsonConvert.SerializeObject(dict);
+
+            dict["additional"] = SecuredAdditionalConfigs;
+            var securedArgString = JsonConvert.SerializeObject(dict);
+
+            return (argString, securedArgString);
+        }
+    }
+}

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteHostingTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteHostingTask.cs
@@ -39,9 +39,9 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
 
             var hostLocation = "";
             var taskRemarks = "";
-            if (result.ContainsKey("hostLocation"))
+            if (result.ContainsKey("deletedHostLocation"))
             {
-                hostLocation = result["hostLocation"].ToString();
+                hostLocation = result["deletedHostLocation"].ToString();
                 taskRemarks = $"The hosting url {hostLocation} has been deleted";
             }
 
@@ -49,7 +49,7 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             if (result.ContainsKey("outputValues") && !string.IsNullOrEmpty(result["outputValues"]?.ToString()))
                 outputValues = JsonConvert.DeserializeObject<Dictionary<string, string>>(result["outputValues"].ToString());
 
-            return new TaskRunnerResult(true, "", outputValues)
+            return new TaskRunnerResult(true, hostLocation, outputValues)
             {
                 TaskRemarks = taskRemarks
             };

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteRepositoryTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteRepositoryTask.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Polyrific.Catapult.Shared.Dto.Constants;
+using Polyrific.Catapult.Shared.Service;
+using Polyrific.Catapult.TaskProviders.Core.Configs;
+
+namespace Polyrific.Catapult.Engine.Core.JobTasks
+{
+    public class DeleteRepositoryTask : BaseJobTask<DeleteRepositoryTaskConfig>, IDeleteRepositoryTask
+    {
+        /// <inheritdoc />
+        public DeleteRepositoryTask(
+            IProjectService projectService, IExternalServiceService externalServiceService, 
+            IExternalServiceTypeService externalServiceTypeService, IProviderService providerService, 
+            IPluginManager pluginManager, ILogger<DeleteRepositoryTask> logger)
+            : base(projectService, externalServiceService, externalServiceTypeService, providerService, pluginManager, logger)
+        {
+        }
+
+        public override string Type => JobTaskDefinitionType.DeleteRepository;
+
+        public List<PluginItem> CodeRepositoryProviders => PluginManager.GetPlugins(PluginType.RepositoryProvider);
+        
+        public override async Task<TaskRunnerResult> RunMainTask(Dictionary<string, string> previousTasksOutputValues)
+        {
+            var provider = CodeRepositoryProviders?.FirstOrDefault(p => p.Name == Provider);
+            if (provider == null)
+                return new TaskRunnerResult($"Code repository provider \"{Provider}\" could not be found.");
+
+            await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
+
+            var arg = GetArgString();
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
+            if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
+                return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
+
+            var taskRemarks = "";
+            if (result.ContainsKey("cloneLocation"))
+            {
+                taskRemarks = $"The remote repository \"{TaskConfig.Repository}\" has been deleted";
+            }
+
+            var outputValues = new Dictionary<string, string>();
+            if (result.ContainsKey("outputValues") && !string.IsNullOrEmpty(result["outputValues"]?.ToString()))
+                outputValues = JsonConvert.DeserializeObject<Dictionary<string, string>>(result["outputValues"].ToString());
+
+            return new TaskRunnerResult(true, "", outputValues)
+            {
+                TaskRemarks = taskRemarks
+            };
+        }
+
+        private (string argString, string securedArgString) GetArgString()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                {"process", "delete"},
+                {"project", Project.Name},
+                {"cloneconfig", TaskConfig},
+                {"additional", AdditionalConfigs}
+            };
+
+            var argString = JsonConvert.SerializeObject(dict);
+
+            dict["additional"] = SecuredAdditionalConfigs;
+            var securedArgString = JsonConvert.SerializeObject(dict);
+
+            return (argString, securedArgString);
+        }
+    }
+}

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteRepositoryTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteRepositoryTask.cs
@@ -37,19 +37,13 @@ namespace Polyrific.Catapult.Engine.Core.JobTasks
             if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
                 return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
 
-            var taskRemarks = "";
-            if (result.ContainsKey("cloneLocation"))
-            {
-                taskRemarks = $"The remote repository \"{TaskConfig.Repository}\" has been deleted";
-            }
-
             var outputValues = new Dictionary<string, string>();
             if (result.ContainsKey("outputValues") && !string.IsNullOrEmpty(result["outputValues"]?.ToString()))
                 outputValues = JsonConvert.DeserializeObject<Dictionary<string, string>>(result["outputValues"].ToString());
 
             return new TaskRunnerResult(true, "", outputValues)
             {
-                TaskRemarks = taskRemarks
+                TaskRemarks = $"The remote repository \"{TaskConfig.Repository}\" has been deleted"
             };
         }
 

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteHostingTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteHostingTask.cs
@@ -1,0 +1,6 @@
+﻿namespace Polyrific.Catapult.Engine.Core.JobTasks
+{
+    public interface IDeleteHostingTask : IJobTask
+    {
+    }
+}

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteRepositoryTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteRepositoryTask.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Polyrific.Catapult.Engine.Core.JobTasks
+{
+    public interface IDeleteRepositoryTask : IJobTask
+    {
+    }
+}

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/AzureAutomation.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/AzureAutomation.cs
@@ -82,35 +82,36 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService
             }
         }
 
-        public Task<string> DeleteWebsite(string subscriptionId, string resourceGroupName, string appServiceName, string deploymentSlot)
+        public Task<(string deletedHostLocation, string errorMessage)> DeleteWebsite(string subscriptionId, string resourceGroupName, string appServiceName, string deploymentSlot)
         {
             try
             {
                 var website = _azureUtils.GetWebsite(subscriptionId, resourceGroupName, appServiceName);
 
                 if (website == null)
-                    return Task.FromResult("");
+                    return Task.FromResult<(string, string)>((null, ""));
 
                 if (!string.IsNullOrEmpty(deploymentSlot))
                 {
                     var slot = _azureUtils.GetSlot(website, deploymentSlot);
 
                     if (slot == null)
-                        return Task.FromResult("");
+                        return Task.FromResult<(string, string)>((null, ""));
 
                     _azureUtils.DeleteSlot(website, slot.Id);
+                    return Task.FromResult<(string, string)>((slot.DefaultHostName, ""));
                 }
                 else
                 {
                     _azureUtils.DeleteWebsite(subscriptionId, website.Id);
-                }
 
-                return Task.FromResult("");
+                    return Task.FromResult<(string, string)>((website.DefaultHostName, ""));
+                }
             }
             catch (System.Exception ex)
             {
                 _logger.LogError(ex, ex.Message);
-                return Task.FromResult(ex.Message);
+                return Task.FromResult<(string, string)>((null, ex.Message));
             }
         }
     }

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/IAzureAutomation.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/IAzureAutomation.cs
@@ -29,6 +29,6 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService
         /// <param name="appServiceName">Name of the App Service</param>
         /// <param name="deploymentSlot">Name of the deployment slot</param>
         /// <returns>Error message if any</returns>
-        Task<string> DeleteWebsite(string subscriptionId, string resourceGroupName, string appServiceName, string deploymentSlot);
+        Task<(string deletedHostLocation, string errorMessage)> DeleteWebsite(string subscriptionId, string resourceGroupName, string appServiceName, string deploymentSlot);
     }
 }

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Program.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Program.cs
@@ -83,6 +83,34 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService
             return (hostLocation, null, "");
         }
 
+        public async override Task<string> DeleteHostingResources()
+        {
+            if (_azure == null)
+                _azure = new AzureAutomation(GetAzureAppServiceConfig(AdditionalConfigs), _azureUtils, _deployUtils, Logger);
+
+            var subscriptionId = "";
+            if (AdditionalConfigs.ContainsKey("SubscriptionId") && !string.IsNullOrEmpty(AdditionalConfigs["SubscriptionId"]))
+                subscriptionId = AdditionalConfigs["SubscriptionId"];
+            else
+                return "Subscription Id is not provided";
+
+            var resourceGroupName = "";
+            if (AdditionalConfigs.ContainsKey("ResourceGroupName") && !string.IsNullOrEmpty(AdditionalConfigs["ResourceGroupName"]))
+                resourceGroupName = AdditionalConfigs["ResourceGroupName"];
+            else
+                return "Resource group name is not provided";
+
+            var appServiceName = ProjectName;
+            if (AdditionalConfigs.ContainsKey("AppServiceName") && !string.IsNullOrEmpty(AdditionalConfigs["AppServiceName"]))
+                appServiceName = AdditionalConfigs["AppServiceName"];
+
+            var deploymentSlot = "";
+            if (AdditionalConfigs.ContainsKey("DeploymentSlot") && !string.IsNullOrEmpty(AdditionalConfigs["DeploymentSlot"]))
+                deploymentSlot = AdditionalConfigs["DeploymentSlot"];
+
+            return await _azure.DeleteWebsite(subscriptionId, resourceGroupName, appServiceName, deploymentSlot);
+        }
+
         private static async Task Main(string[] args)
         {
             var app = new Program(args);
@@ -105,36 +133,6 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService
                 Config.TenantId = AdditionalConfigs["TenantId"];
 
             return Config;
-        }
-
-        public async override Task<string> DeleteHostingResources()
-        {
-            if (_azure == null)
-                _azure = new AzureAutomation(GetAzureAppServiceConfig(AdditionalConfigs), _azureUtils, _deployUtils, Logger);
-
-            var subscriptionId = "";
-            if (AdditionalConfigs.ContainsKey("SubscriptionId") && !string.IsNullOrEmpty(AdditionalConfigs["SubscriptionId"]))
-                subscriptionId = AdditionalConfigs["SubscriptionId"];
-            else
-                return "Subscription Id is not provided";
-
-            var resourceGroupName = "";
-            if (AdditionalConfigs.ContainsKey("ResourceGroupName") && !string.IsNullOrEmpty(AdditionalConfigs["ResourceGroupName"]))
-                resourceGroupName = AdditionalConfigs["ResourceGroupName"];
-            else
-                return "Resource group name is not provided";
-
-            var appServiceName = AdditionalConfigs["AppServiceName"];
-            if (AdditionalConfigs.ContainsKey("AppServiceName") && !string.IsNullOrEmpty(AdditionalConfigs["AppServiceName"]))
-                appServiceName = AdditionalConfigs["AppServiceName"];
-            else
-                return "App service name is not provided";
-
-            var deploymentSlot = "";
-            if (AdditionalConfigs.ContainsKey("DeploymentSlot") && !string.IsNullOrEmpty(AdditionalConfigs["DeploymentSlot"]))
-                deploymentSlot = AdditionalConfigs["DeploymentSlot"];
-
-            return await _azure.DeleteWebsite(subscriptionId, resourceGroupName, appServiceName, deploymentSlot);
         }
     }
 }

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Program.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Program.cs
@@ -83,7 +83,7 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService
             return (hostLocation, null, "");
         }
 
-        public async override Task<string> DeleteHostingResources()
+        public async override Task<(string deletedHostLocation, string errorMessage)> DeleteHostingResources()
         {
             if (_azure == null)
                 _azure = new AzureAutomation(GetAzureAppServiceConfig(AdditionalConfigs), _azureUtils, _deployUtils, Logger);
@@ -92,13 +92,13 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService
             if (AdditionalConfigs.ContainsKey("SubscriptionId") && !string.IsNullOrEmpty(AdditionalConfigs["SubscriptionId"]))
                 subscriptionId = AdditionalConfigs["SubscriptionId"];
             else
-                return "Subscription Id is not provided";
+                return (null, "Subscription Id is not provided");
 
             var resourceGroupName = "";
             if (AdditionalConfigs.ContainsKey("ResourceGroupName") && !string.IsNullOrEmpty(AdditionalConfigs["ResourceGroupName"]))
                 resourceGroupName = AdditionalConfigs["ResourceGroupName"];
             else
-                return "Resource group name is not provided";
+                return (null, "Resource group name is not provided");
 
             var appServiceName = ProjectName;
             if (AdditionalConfigs.ContainsKey("AppServiceName") && !string.IsNullOrEmpty(AdditionalConfigs["AppServiceName"]))

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/tests/HostingProviderTests.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/tests/HostingProviderTests.cs
@@ -98,7 +98,7 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService.UnitTests
 
             var provider = new Program(new string[] { GetArgString("delete", "TestProject", taskConfig, additionalConfigs) }, _azureUtils.Object, _deployUtils.Object);
 
-            var errorMessage = await provider.DeleteHostingResources();
+            (string deletedHostLocation, string errorMessage) = await provider.DeleteHostingResources();
 
             if (string.IsNullOrEmpty(slotName))
                 _azureUtils.Verify(s => s.DeleteWebsite("subsid", "webid"), Times.Once);
@@ -106,6 +106,7 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService.UnitTests
                 _azureUtils.Verify(s => s.DeleteSlot(It.IsAny<IWebApp>(), "slotid"), Times.Once);
 
             Assert.Equal("", errorMessage);
+            Assert.Equal("https://test.azurewebsites.net", deletedHostLocation);
         }
 
         private string GetArgString(string process, string projectName, DeployTaskConfig taskConfig, Dictionary<string, string> additionalConfigs)

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/Configs/DeleteRepositoryTaskConfig.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/Configs/DeleteRepositoryTaskConfig.cs
@@ -1,0 +1,10 @@
+﻿namespace Polyrific.Catapult.TaskProviders.Core.Configs
+{
+    public class DeleteRepositoryTaskConfig : BaseJobTaskConfig
+    {
+        /// <summary>
+        /// Remote repository
+        /// </summary>
+        public string Repository { get; set; }
+    }
+}

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/HostingProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/HostingProvider.cs
@@ -62,9 +62,9 @@ namespace Polyrific.Catapult.TaskProviders.Core
                         result.Add("errorMessage", error);
                     break;
                 case "delete":
-                    error = await DeleteHostingResources();
-                    if (!string.IsNullOrEmpty(error))
-                        result.Add("errorMessage", error);
+                    (string deletedHostLocation, string deleteErrorMessage) = await DeleteHostingResources();
+                    result.Add("deletedHostLocation", deletedHostLocation);
+                    result.Add("errorMessage", deleteErrorMessage);
                     break;
                 default:
                     await BeforeDeploy();
@@ -114,7 +114,7 @@ namespace Polyrific.Catapult.TaskProviders.Core
         /// Delete the hostring resources
         /// </summary>
         /// <returns></returns>
-        public abstract Task<string> DeleteHostingResources();
+        public abstract Task<(string deletedHostLocation, string errorMessage)> DeleteHostingResources();
 
         /// <summary>
         /// Process to run after executing deployment

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/ProjectStatusFilterType.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/ProjectStatusFilterType.cs
@@ -7,5 +7,6 @@ namespace Polyrific.Catapult.Shared.Dto.Constants
         public const string All = "all";
         public const string Active = "active";
         public const string Archived = "archived";
+        public const string Deleting = "deleting";
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/JobDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobQueue/JobDto.cs
@@ -18,6 +18,11 @@ namespace Polyrific.Catapult.Shared.Dto.JobQueue
         public int ProjectId { get; set; }
 
         /// <summary>
+        /// Status of the project
+        /// </summary>
+        public string ProjectStatus { get; set; }
+
+        /// <summary>
         /// Status of the job
         /// </summary>
         public string Status { get; set; }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -38,7 +38,8 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                     Status = JobStatus.Completed,
                     Project = new Project
                     {
-                        Id = 1
+                        Id = 1,
+                        Status = ProjectStatusFilterType.Active
                     }
                 }
             };
@@ -85,7 +86,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             _projectRepository = new Mock<IProjectRepository>();
             _projectRepository.Setup(r => r.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((int id, CancellationToken cancellationToken) =>
-                    id == 1 ? new Project() {Id = id} : null);
+                    id == 1 ? new Project() {Id = id, Status = ProjectStatusFilterType.Active} : null);
 
             _jobCounterService = new Mock<IJobCounterService>();
             _jobCounterService.Setup(r => r.GetNextSequence(It.IsAny<CancellationToken>())).ReturnsAsync(1);
@@ -386,7 +387,8 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 Created = DateTime.UtcNow.AddHours(1),
                 Project = new Project
                 {
-                    Id = 1
+                    Id = 1,
+                    Status = ProjectStatusFilterType.Active
                 }
             });
 
@@ -399,7 +401,8 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 Created = DateTime.UtcNow,
                 Project = new Project
                 {
-                    Id = 2
+                    Id = 2,
+                    Status = ProjectStatusFilterType.Active
                 }
             });
 

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectServiceTests.cs
@@ -12,6 +12,7 @@ using Polyrific.Catapult.Api.Core.Repositories;
 using Polyrific.Catapult.Api.Core.Services;
 using Polyrific.Catapult.Api.Core.Specifications;
 using Polyrific.Catapult.Api.UnitTests.Utilities;
+using Polyrific.Catapult.Shared.Dto.Constants;
 using Xunit;
 
 namespace Polyrific.Catapult.Api.UnitTests.Core.Services
@@ -34,7 +35,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 {
                     Id = 1,
                     Name = "Project-A",
-                    IsArchived = false
+                    Status = ProjectStatusFilterType.Active
                 }
             };
 
@@ -110,7 +111,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             var projectService = new ProjectService(_projectRepository.Object, _projectMemberRepository.Object, _projectDataModelPropertyRepository.Object, _mapper, _jobDefinitionService.Object);
             await projectService.ArchiveProject(1);
             
-            Assert.True(_data.First(p => p.Id == 1).IsArchived);
+            Assert.Equal(ProjectStatusFilterType.Archived, _data.First(p => p.Id == 1).Status);
         }
 
         [Fact]
@@ -128,7 +129,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             var projectService = new ProjectService(_projectRepository.Object, _projectMemberRepository.Object, _projectDataModelPropertyRepository.Object, _mapper, _jobDefinitionService.Object);
             await projectService.RestoreProject(1);
 
-            Assert.False(_data.First(p => p.Id == 1).IsArchived);
+            Assert.Equal(ProjectStatusFilterType.Active, _data.First(p => p.Id == 1).Status);
         }
 
         [Fact]

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/DeleteHostingTaskTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/DeleteHostingTaskTests.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Polyrific.Catapult.Engine.Core;
+using Polyrific.Catapult.Engine.Core.JobTasks;
+using Polyrific.Catapult.Shared.Dto.ExternalService;
+using Polyrific.Catapult.Shared.Dto.ExternalServiceType;
+using Polyrific.Catapult.Shared.Dto.Provider;
+using Polyrific.Catapult.Shared.Dto.Project;
+using Polyrific.Catapult.Shared.Service;
+using Xunit;
+
+namespace Polyrific.Catapult.Engine.UnitTests.Core.JobTasks
+{
+    public class DeleteHostingTaskTests
+    {
+        private readonly Mock<ILogger<DeleteHostingTask>> _logger;
+        private readonly Mock<IProjectService> _projectService;
+        private readonly Mock<IExternalServiceService> _externalServiceService;
+        private readonly Mock<IExternalServiceTypeService> _externalServiceTypeService;
+        private readonly Mock<IProviderService> _providerService;
+        private readonly Mock<IPluginManager> _pluginManager;
+
+        public DeleteHostingTaskTests()
+        {
+            _logger = new Mock<ILogger<DeleteHostingTask>>();
+
+            _projectService = new Mock<IProjectService>();
+            _externalServiceService = new Mock<IExternalServiceService>();
+            _projectService.Setup(s => s.GetProject(It.IsAny<int>()))
+                .ReturnsAsync((int id) => new ProjectDto { Id = id, Name = $"Project {id}" });
+
+            _pluginManager = new Mock<IPluginManager>();
+            _pluginManager.Setup(p => p.GetPlugins(It.IsAny<string>())).Returns(new List<PluginItem>
+            {
+                new PluginItem("FakeHostingProvider", "path/to/FakeHostingProvider.dll", new string[] { })
+            });
+
+            _externalServiceTypeService = new Mock<IExternalServiceTypeService>();
+            _externalServiceTypeService.Setup(s => s.GetExternalServiceTypes(It.IsAny<bool>()))
+                .ReturnsAsync(new List<ExternalServiceTypeDto>
+                {
+                    new ExternalServiceTypeDto
+                    {
+                        Name = "GitHub",
+                        ExternalServiceProperties = new List<ExternalServicePropertyDto>
+                        {
+                            new ExternalServicePropertyDto
+                            {
+                                Name = "AuthToken",
+                                IsSecret = true
+                            }
+                        }
+                    }
+                });
+            _providerService = new Mock<IProviderService>();
+            _providerService.Setup(s => s.GetProviderAdditionalConfigByProviderName(It.IsAny<string>()))
+                .ReturnsAsync(new List<ProviderAdditionalConfigDto>
+                {
+                    new ProviderAdditionalConfigDto
+                    {
+                        Name = "ConnectionString",
+                        IsSecret = true
+                    }
+                });
+        }
+
+        [Fact]
+        public async void RunMainTask_Success()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretProviderArgs) => new Dictionary<string, object>
+                {
+                    {"deletedHostLocation", "https://test.azurewebsites.net"}
+                });
+
+            var config = new Dictionary<string, string>();
+
+            var task = new DeleteHostingTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeHostingProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("https://test.azurewebsites.net", result.ReturnValue);
+            Assert.Equal("The hosting url https://test.azurewebsites.net has been deleted", result.TaskRemarks);
+        }
+
+        [Fact]
+        public async void RunMainTask_Failed()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretProviderArgs) => new Dictionary<string, object>
+                {
+                    {"errorMessage", "error-message"}
+                });
+
+            var config = new Dictionary<string, string>();
+
+            var task = new DeleteHostingTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeHostingProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("error-message", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async void RunMainTask_NoProvider()
+        {
+            var config = new Dictionary<string, string>();
+
+            var task = new DeleteHostingTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "NotExistHostingProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("Deploy provider \"NotExistHostingProvider\" could not be found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async void RunMainTask_AdditionalConfigSecured()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretProviderArgs) => new Dictionary<string, object>
+                {
+                    {"deletedHostLocation", "https://test.azurewebsites.net"}
+                });
+            _pluginManager.Setup(p => p.GetPlugins(It.IsAny<string>())).Returns(new List<PluginItem>
+            {
+                new PluginItem("FakeHostingProvider", "path/to/FakeHostingProvider.dll", new string[] { "GitHub" })
+            });
+            _externalServiceService.Setup(p => p.GetExternalServiceByName(It.IsAny<string>())).ReturnsAsync((string name) => new ExternalServiceDto
+            {
+                Name = name,
+                Config = new Dictionary<string, string>
+                {
+                    { "AuthToken", "123" }
+                }
+            });
+
+            var config = new Dictionary<string, string>
+            {
+                { "GitHubExternalService", "github-test" }
+            };
+
+            var task = new DeleteHostingTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeHostingProvider";
+            task.AdditionalConfigs = new Dictionary<string, string>
+            {
+                { "ConnectionString", "Server=localhost;Database=TestProject;User ID=sa;Password=samprod;" }
+            };
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("https://test.azurewebsites.net", result.ReturnValue);
+            Assert.Equal("The hosting url https://test.azurewebsites.net has been deleted", result.TaskRemarks);
+
+            Assert.Equal(2, task.AdditionalConfigs.Count);
+            Assert.Equal(2, task.SecuredAdditionalConfigs.Count);
+            Assert.Equal("***", task.SecuredAdditionalConfigs["AuthToken"]);
+            Assert.Equal("***", task.SecuredAdditionalConfigs["ConnectionString"]);
+            Assert.Equal("123", task.AdditionalConfigs["AuthToken"]);
+            Assert.Equal("Server=localhost;Database=TestProject;User ID=sa;Password=samprod;", task.AdditionalConfigs["ConnectionString"]);
+        }
+    }
+}

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/DeleteRepositoryTaskTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/DeleteRepositoryTaskTests.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Polyrific.Catapult.Engine.Core;
+using Polyrific.Catapult.Engine.Core.JobTasks;
+using Polyrific.Catapult.Shared.Dto.ExternalService;
+using Polyrific.Catapult.Shared.Dto.ExternalServiceType;
+using Polyrific.Catapult.Shared.Dto.Provider;
+using Polyrific.Catapult.Shared.Dto.Project;
+using Polyrific.Catapult.Shared.Service;
+using Xunit;
+
+namespace Polyrific.Catapult.Engine.UnitTests.Core.JobTasks
+{
+    public class DeleteRepositoryTaskTests
+    {
+        private readonly Mock<IProjectService> _projectService;
+        private readonly Mock<IExternalServiceService> _externalServiceService;
+        private readonly Mock<IExternalServiceTypeService> _externalServiceTypeService;
+        private readonly Mock<IProviderService> _providerService;
+        private readonly Mock<IPluginManager> _pluginManager;
+        private readonly Mock<ILogger<DeleteRepositoryTask>> _logger;
+
+        public DeleteRepositoryTaskTests()
+        {
+            _projectService = new Mock<IProjectService>();
+            _projectService.Setup(s => s.GetProject(It.IsAny<int>()))
+                .ReturnsAsync((int id) => new ProjectDto { Id = id, Name = $"Project {id}" });
+
+            _externalServiceService = new Mock<IExternalServiceService>();
+
+            _pluginManager = new Mock<IPluginManager>();
+            _pluginManager.Setup(p => p.GetPlugins(It.IsAny<string>())).Returns(new List<PluginItem>
+            {
+                new PluginItem("FakeCodeRepositoryProvider", "path/to/FakeCodeRepositoryProvider.dll", new string[] { })
+            });
+
+            _logger = new Mock<ILogger<DeleteRepositoryTask>>();
+
+            _externalServiceTypeService = new Mock<IExternalServiceTypeService>();
+            _externalServiceTypeService.Setup(s => s.GetExternalServiceTypes(It.IsAny<bool>()))
+                .ReturnsAsync(new List<ExternalServiceTypeDto>
+                {
+                    new ExternalServiceTypeDto
+                    {
+                        Name = "GitHub",
+                        ExternalServiceProperties = new List<ExternalServicePropertyDto>
+                        {
+                            new ExternalServicePropertyDto
+                            {
+                                Name = "AuthToken",
+                                IsSecret = true
+                            }
+                        }
+                    }
+                });
+            _providerService = new Mock<IProviderService>();
+            _providerService.Setup(s => s.GetProviderAdditionalConfigByProviderName(It.IsAny<string>()))
+                .ReturnsAsync(new List<ProviderAdditionalConfigDto>
+                {
+                    new ProviderAdditionalConfigDto
+                    {
+                        Name = "ConnectionString",
+                        IsSecret = true
+                    }
+                });
+        }
+
+        [Fact]
+        public async void RunMainTask_Success()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretPluginArgs) => new Dictionary<string, object>
+                {
+                    {"errorMessage", ""}
+                });
+
+            var config = new Dictionary<string, string>()
+            {
+                {"Repository", "https://github.com/test/test"}
+            };
+
+            var task = new DeleteRepositoryTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeCodeRepositoryProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("The remote repository \"https://github.com/test/test\" has been deleted", result.TaskRemarks);
+        }
+
+        [Fact]
+        public async void RunMainTask_Failed()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretPluginArgs) => new Dictionary<string, object>
+                {
+                    {"errorMessage", "error-message"}
+                });
+
+            var config = new Dictionary<string, string>();
+
+            var task = new DeleteRepositoryTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeCodeRepositoryProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("error-message", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async void RunMainTask_NoProvider()
+        {
+            var config = new Dictionary<string, string>();
+
+            var task = new DeleteRepositoryTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "NotExistRepositoryProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("Code repository provider \"NotExistRepositoryProvider\" could not be found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async void RunMainTask_AdditionalConfigSecured()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretPluginArgs) => new Dictionary<string, object>
+                {
+                    {"errorMessage", ""}
+                });
+            _pluginManager.Setup(p => p.GetPlugins(It.IsAny<string>())).Returns(new List<PluginItem>
+            {
+                new PluginItem("FakeCodeRepositoryProvider", "path/to/FakeCodeRepositoryProvider.dll", new string[] { "GitHub" })
+            });
+            _externalServiceService.Setup(p => p.GetExternalServiceByName(It.IsAny<string>())).ReturnsAsync((string name) => new ExternalServiceDto
+            {
+                Name = name,
+                Config = new Dictionary<string, string>
+                {
+                    { "AuthToken", "123" }
+                }
+            });
+
+            var config = new Dictionary<string, string>
+            {
+                {"Repository", "https://github.com/test/test"},
+                { "GitHubExternalService", "github-test" }
+            };
+
+            var task = new DeleteRepositoryTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeCodeRepositoryProvider";
+            task.AdditionalConfigs = new Dictionary<string, string>
+            {
+                { "ConnectionString", "Server=localhost;Database=TestProject;User ID=sa;Password=samprod;" }
+            };
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("", result.ReturnValue);
+            Assert.Equal("The remote repository \"https://github.com/test/test\" has been deleted", result.TaskRemarks);
+
+            Assert.Equal(2, task.AdditionalConfigs.Count);
+            Assert.Equal(2, task.SecuredAdditionalConfigs.Count);
+            Assert.Equal("***", task.SecuredAdditionalConfigs["AuthToken"]);
+            Assert.Equal("***", task.SecuredAdditionalConfigs["ConnectionString"]);
+            Assert.Equal("123", task.AdditionalConfigs["AuthToken"]);
+            Assert.Equal("Server=localhost;Database=TestProject;User ID=sa;Password=samprod;", task.AdditionalConfigs["ConnectionString"]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implement the core execution for deletion job definition in engine

## Coverage
- [x] Modify project entity to include status, so it can have `deleting` status
- [x] Implement the `DeleteRepositoryTask` and `DeleteHostingTask`
- [x] Execute the deletion job tasks
- [x] Invoke project deletion when the deletion job definition has completed, and the project status is `deleting`

## References
- Related Issues: #310 