### PR TITLE
Sleep the build-all script after opening cli window

### DIFF
--- a/builds/build-all.ps1
+++ b/builds/build-all.ps1
@@ -5,6 +5,8 @@ param(
     [string]$environment = "Development",
     [string]$http = "http://localhost:8005",
     [string]$https = "https://localhost:44305",
+    [string]$webHost = "localhost",
+    [string]$webPort = "44300",
     [switch]$noConfig = $false,
     [switch]$noCli = $false,
     [switch]$noPrompt = $false,
@@ -135,6 +137,12 @@ if (!$allGood) {
     }
 }
 
+$args = "-configuration " + $configuration
+$args += " -url " + $https
+if ($noConfig) {
+    $args += " -noConfig"
+}
+
 ## Build CLI
 if (!$noCli) {
 	Write-Host "Publishing CLI..."
@@ -142,20 +150,17 @@ if (!$noCli) {
 	Start-Sleep -s 5
 }
 
+## Build Engine
+$done = Invoke-BuildScriptNewWindow "build-engine.ps1" $args
+Write-Host "Publishing Engine..."
+
 ## Build Web
 if (!$noWeb) {
 	Write-Host "Publishing Web UI..."
+	$args = "-host " + $webHost
+	$args += " -port " + $webPort
     $done = Invoke-BuildScriptNewWindow "build-web.ps1" $args
 }
-
-## Build Engine
-$args = "-configuration " + $configuration
-$args += " -url " + $https
-if ($noConfig) {
-    $args += " -noConfig"
-}
-$done = Invoke-BuildScriptNewWindow "build-engine.ps1" $args
-Write-Host "Publishing Engine..."
 
 Write-Host "The Engine and CLI are in the new terminal windows. Please go ahead and try to run the commands available there." -ForegroundColor Green 
 Write-Host "To learn more about OpenCatapult components, please follow this link: https://docs.opencatapult.net/home/intro#the-components" -ForegroundColor Green

--- a/builds/build-all.ps1
+++ b/builds/build-all.ps1
@@ -135,6 +135,19 @@ if (!$allGood) {
     }
 }
 
+## Build CLI
+if (!$noCli) {
+	Write-Host "Publishing CLI..."
+    $done = Invoke-BuildScriptNewWindow "build-cli.ps1" $args
+	Start-Sleep -s 5
+}
+
+## Build Web
+if (!$noWeb) {
+	Write-Host "Publishing Web UI..."
+    $done = Invoke-BuildScriptNewWindow "build-web.ps1" $args
+}
+
 ## Build Engine
 $args = "-configuration " + $configuration
 $args += " -url " + $https
@@ -142,16 +155,7 @@ if ($noConfig) {
     $args += " -noConfig"
 }
 $done = Invoke-BuildScriptNewWindow "build-engine.ps1" $args
-
-## Build CLI
-if (!$noCli) {
-    $done = Invoke-BuildScriptNewWindow "build-cli.ps1" $args
-}
-
-## Build Web
-if (!$noWeb) {
-    $done = Invoke-BuildScriptNewWindow "build-web.ps1" $args
-}
+Write-Host "Publishing Engine..."
 
 Write-Host "The Engine and CLI are in the new terminal windows. Please go ahead and try to run the commands available there." -ForegroundColor Green 
 Write-Host "To learn more about OpenCatapult components, please follow this link: https://docs.opencatapult.net/home/intro#the-components" -ForegroundColor Green

--- a/docs/dev-guides/build-scripts.md
+++ b/docs/dev-guides/build-scripts.md
@@ -23,6 +23,8 @@ Options:
 | -environment | Dotnet host environment | Development / Production | Development |
 | -http | Base URL of HTTP protocol | [http url] | http://localhost:8005 |
 | -https | Base URL of HTTPS protocol | [https url] | https://localhost:44305 |
+| -webHost | The host name of the Web UI | [web host name] | localhost |
+| -webPort | The port number of the Web UI | [web port number] | 44300 |
 | -noConfig | Do not replace the config values of the components | true / false | false |
 | -noCli | Do not build and run CLI component | true / false | false |
 | -noPrompt | Run the script without user interaction (just run everything with its default value) | true / false | false |


### PR DESCRIPTION
## Summary
Currently when running `build-all` script, there's occasional error happened in build CLI or Build Engine window, because the .dll is being used by another process. This PR try to mitigate this by adding a thread sleep after opening the CLI window, so that it does not clash with Build Engine.
