### PR TITLE
Add Authorize functionality to API swagger

### DIFF
--- a/src/API/Polyrific.Catapult.Api/SecurityRequirementsOperationFilter .cs
+++ b/src/API/Polyrific.Catapult.Api/SecurityRequirementsOperationFilter .cs
@@ -1,0 +1,41 @@
+// Copyright (c) Polyrific, Inc 2019. All rights reserved.
+
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace Polyrific.Catapult.Api
+{
+    public class SecurityRequirementsOperationFilter : IOperationFilter
+    {
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            var controllerAuthAttr = context.MethodInfo.DeclaringType
+                .GetCustomAttributes(true)
+                .OfType<AuthorizeAttribute>()
+                .Select(attr => attr.Policy)
+                .Distinct();
+
+            var actionAuthAttr = context.MethodInfo
+                .GetCustomAttributes(true)
+                .OfType<AuthorizeAttribute>()
+                .Select(attr => attr.Policy)
+                .Distinct();
+
+            if (controllerAuthAttr.Any() || actionAuthAttr.Any())
+            {
+                operation.Responses.Add("401", new Response { Description = "Unauthorized" });
+                operation.Responses.Add("403", new Response { Description = "Forbidden" });
+
+                operation.Security = new List<IDictionary<string, IEnumerable<string>>>
+                {
+                    new Dictionary<string, IEnumerable<string>> {
+                        {"Bearer", Enumerable.Empty<string>()}
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/Startup.cs
+++ b/src/API/Polyrific.Catapult.Api/Startup.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using AutoMapper;
@@ -104,6 +106,8 @@ namespace Polyrific.Catapult.Api
             {
                 c.SwaggerDoc("v1", new Info { Title = "OpenCatapult API", Version = "v1" });
                 c.CustomSchemaIds(x => x.FullName);
+                c.AddSecurityDefinition("Bearer", new ApiKeyScheme { In = "header", Description = "Please enter JWT with Bearer into field", Name = "Authorization", Type = "apiKey" });
+                c.AddSecurityRequirement(new Dictionary<string, IEnumerable<string>> {{ "Bearer", Enumerable.Empty<string>() }});
 
                 // Set the comments path for the Swagger JSON and UI.
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";

--- a/src/API/Polyrific.Catapult.Api/Startup.cs
+++ b/src/API/Polyrific.Catapult.Api/Startup.cs
@@ -107,7 +107,7 @@ namespace Polyrific.Catapult.Api
                 c.SwaggerDoc("v1", new Info { Title = "OpenCatapult API", Version = "v1" });
                 c.CustomSchemaIds(x => x.FullName);
                 c.AddSecurityDefinition("Bearer", new ApiKeyScheme { In = "header", Description = "Please enter JWT with Bearer into field", Name = "Authorization", Type = "apiKey" });
-                c.AddSecurityRequirement(new Dictionary<string, IEnumerable<string>> {{ "Bearer", Enumerable.Empty<string>() }});
+                c.OperationFilter<SecurityRequirementsOperationFilter>();
 
                 // Set the comments path for the Swagger JSON and UI.
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";


### PR DESCRIPTION
## Summary
Add Authorize functionality to API swagger. It adds the `Authorize` button to the Swagger UI, which allow the user to enter the bearer token.

![Swagger UI](https://user-images.githubusercontent.com/1967854/54751518-cda5ed00-4c0d-11e9-839a-59441e1c1d81.png)
