### PR TITLE
[Doc] Fix typo `Job Queues` should be `Job Definitions`

### DIFF
--- a/docs/user-guides/create-first-project-web.md
+++ b/docs/user-guides/create-first-project-web.md
@@ -54,6 +54,7 @@ As explained in [introduction](./intro.md#the-circle-of-magic), the automation l
 The project that you've just created contains a `Default` job definition with a `Generate` task in it. Let's add the job to the queue so Engine can pick and execute it.
 
 Go to the `Job Definitions` tab, and click the play button of the `Default` job definition
+
 ![Job Definition](../img/queue-job.JPG)
 
 You can monitor the live progress of the job queue, by clicking the log icon

--- a/docs/user-guides/create-first-project-web.md
+++ b/docs/user-guides/create-first-project-web.md
@@ -53,7 +53,7 @@ As explained in [introduction](./intro.md#the-circle-of-magic), the automation l
 
 The project that you've just created contains a `Default` job definition with a `Generate` task in it. Let's add the job to the queue so Engine can pick and execute it.
 
-Go to the `Job Queues` tab, and click the play button of the `Default` job definition
+Go to the `Job Definitions` tab, and click the play button of the `Default` job definition
 ![Job Definition](../img/queue-job.JPG)
 
 You can monitor the live progress of the job queue, by clicking the log icon


### PR DESCRIPTION
## Summary
Fix typo **Job Queues** should be **Job Definitions** on `create-first-project-web.md` page, section **Queue the job**
