### PR TITLE
[Doc] Fix typo `AzureAppService` should be `Azure`

### DIFF
--- a/docs/dev-guides/project-template.md
+++ b/docs/dev-guides/project-template.md
@@ -25,7 +25,7 @@ jobs:
         configs:
           [any additional configs which are required by the provider, e.g:]
           GitHubExternalService: [name of the GitHub external service]
-          AzureAppAppServiceExternalService: [name of the AzureAppService external service]
+          AzureExternalService: [name of the Azure external service]
           CreatePullRequest: [true | false]
 ```
 

--- a/docs/task-providers/hosting-provider.md
+++ b/docs/task-providers/hosting-provider.md
@@ -20,7 +20,7 @@ dotnet occli.dll task update -p SampleProject -j Default -n Deploy -prov Polyrif
 
 ### Required services
 
-This provider requires the `Azure` external service to get the connection details. Please refer to the [External Service guideline](../user-guides/external-services.md#AzureAppService) for more info.
+This provider requires the `Azure` external service to get the connection details. Please refer to the [External Service guideline](../user-guides/external-services.md#Azure) for more info.
 
 ### Additional configs
 

--- a/docs/user-guides/sample-project.md
+++ b/docs/user-guides/sample-project.md
@@ -57,7 +57,7 @@ Then you will be prompted to enter the required details for `GitHub`.
 And now, let's create External Service for `Azure App Service`:
 
 ```sh
-dotnet occli.dll service add --name azure-default --type AzureAppService
+dotnet occli.dll service add --name azure-default --type Azure
 ```
 
 Then you will be prompted to enter the required details for `AzureAppService`.

--- a/docs/user-guides/sample-project.md
+++ b/docs/user-guides/sample-project.md
@@ -54,13 +54,13 @@ dotnet occli.dll service add --name github-default --type GitHub
 
 Then you will be prompted to enter the required details for `GitHub`.
 
-And now, let's create External Service for `Azure App Service`:
+And now, let's create External Service for `Azure`:
 
 ```sh
 dotnet occli.dll service add --name azure-default --type Azure
 ```
 
-Then you will be prompted to enter the required details for `AzureAppService`.
+Then you will be prompted to enter the required details for `Azure`.
 
 ## Create project
 


### PR DESCRIPTION
* Fix typo `AzureAppService` should be `Azure` on create required external services in the sample project section.

