### PR TITLE
Implement generic task provider

### DIFF
--- a/Polyrific.Catapult.Engine.sln
+++ b/Polyrific.Catapult.Engine.sln
@@ -74,6 +74,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polyrific.Catapult.TaskProv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polyrific.Catapult.TaskProviders.DotNetCoreTest.UnitTests", "src\Plugins\TestProvider\Polyrific.Catapult.TaskProviders.DotNetCoreTest\tests\Polyrific.Catapult.TaskProviders.DotNetCoreTest.UnitTests.csproj", "{7883B10F-C23D-4045-B0D1-160EBE06FEE4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GenericTaskProvider", "GenericTaskProvider", "{D1366660-366B-4D93-A8B1-B8A47D18BDF2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polyrific.Catapult.TaskProviders.GenericCommand", "src\Plugins\GenericTaskProvider\Polyrific.Catapult.TaskProviders.GenericCommand\src\Polyrific.Catapult.TaskProviders.GenericCommand.csproj", "{481F2824-7F79-4BCF-8C1A-3456CBC79601}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polyrific.Catapult.TaskProviders.GenericCommand.UnitTests", "src\Plugins\GenericTaskProvider\Polyrific.Catapult.TaskProviders.GenericCommand\tests\Polyrific.Catapult.TaskProviders.GenericCommand.UnitTests.csproj", "{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -348,6 +354,30 @@ Global
 		{7883B10F-C23D-4045-B0D1-160EBE06FEE4}.Release|x64.Build.0 = Release|Any CPU
 		{7883B10F-C23D-4045-B0D1-160EBE06FEE4}.Release|x86.ActiveCfg = Release|Any CPU
 		{7883B10F-C23D-4045-B0D1-160EBE06FEE4}.Release|x86.Build.0 = Release|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Debug|x64.Build.0 = Debug|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Debug|x86.Build.0 = Debug|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Release|Any CPU.Build.0 = Release|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Release|x64.ActiveCfg = Release|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Release|x64.Build.0 = Release|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Release|x86.ActiveCfg = Release|Any CPU
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601}.Release|x86.Build.0 = Release|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Debug|x64.Build.0 = Debug|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Debug|x86.Build.0 = Debug|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Release|x64.ActiveCfg = Release|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Release|x64.Build.0 = Release|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Release|x86.ActiveCfg = Release|Any CPU
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -384,6 +414,9 @@ Global
 		{30069801-C8AE-48DB-850E-10703DEF80CD} = {4E071EF4-E175-40AC-BE21-07CD6A3E3ECA}
 		{73A389BE-FDD1-4E0C-90FA-8AAC1BAD01ED} = {4E071EF4-E175-40AC-BE21-07CD6A3E3ECA}
 		{7883B10F-C23D-4045-B0D1-160EBE06FEE4} = {4E071EF4-E175-40AC-BE21-07CD6A3E3ECA}
+		{D1366660-366B-4D93-A8B1-B8A47D18BDF2} = {531811D2-AA96-456D-B1FA-B2820DF16D63}
+		{481F2824-7F79-4BCF-8C1A-3456CBC79601} = {D1366660-366B-4D93-A8B1-B8A47D18BDF2}
+		{41A1371D-5061-4E0E-86C2-8FD826A9EF5F} = {4E071EF4-E175-40AC-BE21-07CD6A3E3ECA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7E5C87EB-EEBD-4A9B-A955-07A34F904FF1}

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/DeletionJobDefinitionNotFound.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/DeletionJobDefinitionNotFound.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
 
 namespace Polyrific.Catapult.Api.Core.Exceptions
 {

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/JobTaskDefinitionTypeException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/JobTaskDefinitionTypeException.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
 
 namespace Polyrific.Catapult.Api.Core.Exceptions
 {

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/MultipleDeletionJobException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/MultipleDeletionJobException.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
 
 namespace Polyrific.Catapult.Api.Core.Exceptions
 {

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteHostingTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteHostingTask.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteRepositoryTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/DeleteRepositoryTask.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteHostingTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteHostingTask.cs
@@ -1,4 +1,6 @@
-﻿namespace Polyrific.Catapult.Engine.Core.JobTasks
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+namespace Polyrific.Catapult.Engine.Core.JobTasks
 {
     public interface IDeleteHostingTask : IJobTask
     {

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteRepositoryTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/IDeleteRepositoryTask.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 namespace Polyrific.Catapult.Engine.Core.JobTasks
 {

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/plugin.yml
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/plugin.yml
@@ -1,5 +1,5 @@
 name: 'Polyrific.Catapult.TaskProviders.GenericCommand'
-type: 'GeneratorProvider'
+type: 'GenericTaskProvider'
 author: 'Polyrific'
 version: '1.0.0-beta3'
 additional-configs:

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/plugin.yml
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/plugin.yml
@@ -1,0 +1,17 @@
+name: 'Polyrific.Catapult.TaskProviders.GenericCommand'
+type: 'GeneratorProvider'
+author: 'Polyrific'
+version: '1.0.0-beta3'
+additional-configs:
+  - name: CommandTool
+    label: Command Tool
+    hint: The command tool to be used to run the command. Defaults based on OS.
+    type: string
+    is-required: false
+    is-secret: false
+  - name: Commands
+    label: Commands
+    hint: The command sequences separated by line
+    type: string
+    is-required: true
+    is-secret: false

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandHelper.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandHelper.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Polyrific.Catapult.TaskProviders.GenericCommand.CommandProviders
+{
+    public static class CommandHelper
+    {
+        public static async Task<(string output, string error)> Execute(string commandTool, string[] commands, string workingDirectory, ILogger logger = null)
+        {
+            var returnValue = new StringBuilder();
+            var error = "";
+
+            var info = new ProcessStartInfo(commandTool)
+            {
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using (var process = Process.Start(info))
+            {
+                if (process != null)
+                {
+                    using (var sw = process.StandardInput)
+                    {
+                        if (sw.BaseStream.CanWrite)
+                        {
+                            sw.WriteLine($"cd {workingDirectory}");
+
+                            foreach (var command in commands)
+                                sw.WriteLine(command);
+                        }
+                    }
+
+                    var reader = process.StandardOutput;
+                    while (!reader.EndOfStream)
+                    {
+                        var line = await reader.ReadLineAsync();
+
+                        logger?.LogDebug(line);
+
+                        returnValue.AppendLine(line);
+                    }
+
+                    error = await process.StandardError.ReadToEndAsync();
+                }
+            }
+
+            return (returnValue.ToString(), error);
+        }
+    }
+}

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandHelper.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandTextHelper.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandTextHelper.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
 using System.Linq;
 
 namespace Polyrific.Catapult.TaskProviders.GenericCommand.CommandProviders

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandTextHelper.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/CommandProviders/CommandTextHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+
+namespace Polyrific.Catapult.TaskProviders.GenericCommand.CommandProviders
+{
+    public static class CommandTextHelper
+    {
+        public static string[] SplitOnNewLine(this string input, string[] splitters = null, bool removeEmptyEntries = true)
+        {
+            if (splitters == null)
+                splitters = new string[] { "\r\n", "\r", "\n" };
+
+            return input.Split(splitters, removeEmptyEntries ? StringSplitOptions.RemoveEmptyEntries : StringSplitOptions.None)
+                .Select(s => s.Trim()).ToArray();
+        }
+    }
+}

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/Polyrific.Catapult.TaskProviders.GenericCommand.csproj
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/Polyrific.Catapult.TaskProviders.GenericCommand.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Polyrific.Catapult.TaskProviders.Core\Polyrific.Catapult.TaskProviders.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/Program.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/Program.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Polyrific.Catapult.TaskProviders.Core;
+using Polyrific.Catapult.TaskProviders.GenericCommand.CommandProviders;
+
+namespace Polyrific.Catapult.TaskProviders.GenericCommand
+{
+    public class Program : GenericTaskProvider
+    {
+        public override string Name => "Polyrific.Catapult.TaskProviders.GenericCommand";
+
+        public Program(string[] args) : base(args)
+        {
+        }
+
+        public async override Task<(Dictionary<string, string> outputValues, string errorMessage)> GenericExecution()
+        {
+            string commandTool = null;
+            if (AdditionalConfigs.ContainsKey("CommandTool") && !string.IsNullOrEmpty(AdditionalConfigs["CommandTool"]))
+                commandTool = AdditionalConfigs["CommandTool"];
+            
+            // set default value for command tool
+            if (string.IsNullOrEmpty(commandTool))
+            {
+                bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+                if (isWindows)
+                    commandTool = "cmd.exe";
+                else
+                    commandTool = "/bin/bash";
+            }
+            
+            string commands = null;
+            if (AdditionalConfigs.ContainsKey("Commands") && !string.IsNullOrEmpty(AdditionalConfigs["Commands"]))
+                commands = AdditionalConfigs["Commands"];
+            else
+                return (null, "Commands additional config is required");
+
+            var result = await CommandHelper.Execute(commandTool, commands.SplitOnNewLine(), Config.WorkingLocation, Logger);
+
+            return (null, result.error);
+        }
+
+        private static async Task Main(string[] args)
+        {
+            var app = new Program(args);
+
+            var result = await app.Execute();
+            app.ReturnOutput(result);
+        }
+    }
+}

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/Program.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/Program.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Polyrific.Catapult.TaskProviders.Core;

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/GenericTaskProviderTests.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/GenericTaskProviderTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Newtonsoft.Json;
+using Polyrific.Catapult.TaskProviders.Core.Configs;
+using Xunit;
+
+namespace Polyrific.Catapult.TaskProviders.GenericCommand.UnitTests
+{
+    public class GenericTaskProviderTests
+    {
+        [Fact]
+        public async void GenericExecution_Success()
+        {
+            var workingLocation = Path.Combine(AppContext.BaseDirectory, "working");
+
+            var config = new BaseJobTaskConfig
+            {
+                WorkingLocation = workingLocation
+            };
+
+            if (Directory.Exists(workingLocation))
+                Directory.Delete(workingLocation, true);
+
+            Directory.CreateDirectory(workingLocation);
+
+            var additionalConfig = new Dictionary<string, string>();
+
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("echo test-text > test.txt");
+            if (isWindows)
+            {
+                sb.AppendLine("copy test.txt test2.txt");
+            }
+            else
+            {
+                sb.AppendLine("cp test.txt test2.txt");
+            }
+            
+            additionalConfig["Commands"] = sb.ToString();
+
+            var provider = new Program(new string[] { GetArgString("main", config, additionalConfig) });
+            var result = await provider.GenericExecution();
+
+            Assert.True(File.Exists(Path.Combine(workingLocation, "test.txt")));
+            Assert.True(File.Exists(Path.Combine(workingLocation, "test2.txt")));
+        }
+
+        private string GetArgString(string process, BaseJobTaskConfig taskConfig, Dictionary<string, string> additionalConfigs)
+        {
+            var dict = new Dictionary<string, object>
+            {
+                {"process", process},
+                {"config", taskConfig},
+                {"additional", additionalConfigs}
+            };
+
+            return JsonConvert.SerializeObject(dict);
+        }
+    }
+}

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/GenericTaskProviderTests.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/GenericTaskProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/Polyrific.Catapult.TaskProviders.GenericCommand.UnitTests.csproj
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/Polyrific.Catapult.TaskProviders.GenericCommand.UnitTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Polyrific.Catapult.TaskProviders.GenericCommand.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/Configs/DeleteRepositoryTaskConfig.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/Configs/DeleteRepositoryTaskConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Polyrific.Catapult.TaskProviders.Core.Configs
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+namespace Polyrific.Catapult.TaskProviders.Core.Configs
 {
     public class DeleteRepositoryTaskConfig : BaseJobTaskConfig
     {

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/GenericTaskProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/GenericTaskProvider.cs
@@ -1,0 +1,103 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Polyrific.Catapult.Shared.Dto.Constants;
+using Polyrific.Catapult.TaskProviders.Core.Configs;
+
+namespace Polyrific.Catapult.TaskProviders.Core
+{
+    public abstract class GenericTaskProvider : TaskProvider
+    {
+        protected GenericTaskProvider(string[] args) : base(args)
+        {
+            ParseArguments();
+        }
+
+        public override string Type => PluginType.GenericTaskProvider;
+
+        public sealed override void ParseArguments()
+        {
+            base.ParseArguments();
+
+            foreach (var key in ParsedArguments.Keys)
+            {
+                switch (key.ToLower())
+                {
+                    case "config":
+                        Config = JsonConvert.DeserializeObject<BaseJobTaskConfig>(ParsedArguments[key].ToString());
+                        break;
+                    case "additional":
+                        AdditionalConfigs = JsonConvert.DeserializeObject<Dictionary<string, string>>(ParsedArguments[key].ToString());
+                        break;
+                }
+            }
+        }
+
+        public override async Task<string> Execute()
+        {
+            var result = new Dictionary<string, object>();
+
+            switch (ProcessToExecute)
+            {
+                case "pre":
+                    var error = await BeforeGenericExecution();
+                    if (!string.IsNullOrEmpty(error))
+                        result.Add("errorMessage", error);
+                    break;
+                case "main":
+                    (var outputValues, string errorMessage) = await GenericExecution();
+                    result.Add("outputValues", outputValues);
+                    result.Add("errorMessage", errorMessage);
+                    break;
+                case "post":
+                    error = await AfterGenericExecution();
+                    if (!string.IsNullOrEmpty(error))
+                        result.Add("errorMessage", error);
+                    break;
+                default:
+                    await BeforeGenericExecution();
+                    (outputValues, errorMessage) = await GenericExecution();
+                    await AfterGenericExecution();
+                    result.Add("outputValues", outputValues);
+                    result.Add("errorMessage", errorMessage);
+                    break;
+            }
+
+            return JsonConvert.SerializeObject(result);
+        }
+
+        /// <summary>
+        /// Generic task provider config
+        /// </summary>
+        public BaseJobTaskConfig Config { get; set; }
+
+        /// <summary>
+        /// Additional configurations for specific provider
+        /// </summary>
+        public Dictionary<string, string> AdditionalConfigs { get; set; }
+
+        /// <summary>
+        /// Process to run before executing a generic action
+        /// </summary>
+        /// <returns></returns>
+        public virtual Task<string> BeforeGenericExecution()
+        {
+            return Task.FromResult("");
+        }
+
+        /// <summary>
+        /// Execute a generic action
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task<(Dictionary<string, string> outputValues, string errorMessage)> GenericExecution();
+
+        /// <summary>
+        /// Process to run after executing a generic action
+        /// </summary>
+        /// <returns></returns>
+        public virtual Task<string> AfterGenericExecution()
+        {
+            return Task.FromResult("");
+        }
+    }
+}

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/GenericTaskProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/GenericTaskProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Polyrific.Catapult.Shared.Dto.Constants;

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/RepositoryProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/RepositoryProvider.cs
@@ -180,6 +180,9 @@ namespace Polyrific.Catapult.TaskProviders.Core
         /// </summary>
         public MergeTaskConfig MergeTaskConfig { get; set; }
 
+        /// <summary>
+        /// Delete task configuration
+        /// </summary>
         public DeleteRepositoryTaskConfig DeleteTaskConfig { get; set; }
 
         /// <summary>

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/PluginType.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/PluginType.cs
@@ -11,5 +11,6 @@ namespace Polyrific.Catapult.Shared.Dto.Constants
         public const string RepositoryProvider = "RepositoryProvider";
         public const string StorageProvider = "StorageProvider";
         public const string TestProvider = "TestProvider";
+        public const string GenericTaskProvider = "GenericTaskProvider";
     }
 }


### PR DESCRIPTION
## Summary
- Create generic task providers base class
- Implement a built-in generic task providers that run generic commands

## Coverage
- [x] Create a new task provider type and base class `GenericTaskProvider`
- [x] Implement `Polyrific.Catapult.TaskProviders.GenericCommand`

## References
- Related Issues: #400 
