### PR TITLE
Fix race condition issue when executing build scripts

### DIFF
--- a/builds/build-all.ps1
+++ b/builds/build-all.ps1
@@ -146,13 +146,14 @@ if ($noConfig) {
 ## Build CLI
 if (!$noCli) {
 	Write-Host "Publishing CLI..."
-    $done = Invoke-BuildScriptNewWindow "build-cli.ps1" $args
-	Start-Sleep -s 5
+    $done = Invoke-BuildScript "build-cli.ps1" $args
+    Invoke-BuildScriptNewWindow "build-cli.ps1" "-openShell"
 }
 
 ## Build Engine
-$done = Invoke-BuildScriptNewWindow "build-engine.ps1" $args
 Write-Host "Publishing Engine..."
+$done = Invoke-BuildScript "build-engine.ps1" $args
+Invoke-BuildScriptNewWindow "build-engine.ps1" "-openShell"
 
 ## Build Web
 if (!$noWeb) {

--- a/builds/build-cli.ps1
+++ b/builds/build-cli.ps1
@@ -3,36 +3,39 @@
 param(
     [string]$configuration = "Release",
     [string]$url = "https://localhost:44305",
-    [switch]$noConfig = $false
+    [switch]$noConfig = $false,
+    [switch]$openShell = $false
 )
-
-$host.UI.RawUI.WindowTitle = "OpenCatapult CLI";
 
 $rootPath = Split-Path $PSScriptRoot
 $cliCsprojPath = Join-Path $rootPath "/src/CLI/Polyrific.Catapult.Cli/Polyrific.Catapult.Cli.csproj"
 $cliPublishPath = Join-Path $rootPath "/publish/cli"
 $cliDll = Join-Path $cliPublishPath "/occli.dll"
 
-# build CLI
-Write-Output "Publishing the CLI..."
-Write-Output "dotnet publish $cliCsprojPath -c $configuration -o $cliPublishPath"
-$result = dotnet publish $cliCsprojPath -c $configuration -o $cliPublishPath
-if ($LASTEXITCODE -ne 0) {
-    Write-Error -Message "[ERROR] $result"
-    break
-}
-
-# Set ApiUrl
-if (!$noConfig) {
-    Write-Output "Set ApiUrl config..."
-    Write-Output "dotnet $cliDll config set -n ApiUrl -v $url"
-    $result = dotnet $cliDll config set -n ApiUrl -v $url
+if ($openShell) {
+    $host.UI.RawUI.WindowTitle = "OpenCatapult CLI";
+    Write-Host "CLI is ready. You can start exploring available commands by running: dotnet occli.dll --help" -ForegroundColor Green
+    Set-Location $cliPublishPath
+} else {
+    # build CLI
+    Write-Output "Publishing the CLI..."
+    Write-Output "dotnet publish $cliCsprojPath -c $configuration -o $cliPublishPath"
+    $result = dotnet publish $cliCsprojPath -c $configuration -o $cliPublishPath
     if ($LASTEXITCODE -ne 0) {
         Write-Error -Message "[ERROR] $result"
         break
     }
+
+    # Set ApiUrl
+    if (!$noConfig) {
+        Write-Output "Set ApiUrl config..."
+        Write-Output "dotnet $cliDll config set -n ApiUrl -v $url"
+        $result = dotnet $cliDll config set -n ApiUrl -v $url
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error -Message "[ERROR] $result"
+            break
+        }
+    }
+
+    Write-Host "CLI component was published successfully."
 }
-
-Write-Host "CLI is ready. You can start exploring available commands by running: dotnet occli.dll --help" -ForegroundColor Green
-
-Set-Location $cliPublishPath

--- a/builds/build-engine.ps1
+++ b/builds/build-engine.ps1
@@ -3,67 +3,71 @@
 param(
     [string]$configuration = "Release",
     [string]$url = "https://localhost:44305",
-    [switch]$noConfig = $false
+    [switch]$noConfig = $false,
+    [switch]$openShell = $false
 )
-
-$host.UI.RawUI.WindowTitle = "OpenCatapult Engine";
 
 $rootPath = Split-Path $PSScriptRoot
 $engineCsprojPath = Join-Path $rootPath "/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj"
 $enginePublishPath = Join-Path $rootPath "/publish/engine"
 $engineDll = Join-Path $enginePublishPath "/ocengine.dll"
 
-$aspNetCoreMvcCsprojPath = Join-Path $rootPath "/src/Plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc/src/Polyrific.Catapult.TaskProviders.AspNetCoreMvc.csproj"
-$aspNetCoreMvcPublishPath = Join-Path $enginePublishPath "/plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc"
-$azureAppServiceCsprojPath = Join-Path $rootPath "/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Polyrific.Catapult.TaskProviders.AzureAppService.csproj"
-$azureAppServicePublishPath = Join-Path $enginePublishPath "/plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService"
-$dotNetCoreCsprojPath = Join-Path $rootPath "/src/Plugins/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Polyrific.Catapult.TaskProviders.DotNetCore.csproj"
-$dotNetCorePublishPath = Join-Path $enginePublishPath "/plugins/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore"
-$dotNetCoreTestCsprojPath = Join-Path $rootPath "/src/Plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest/src/Polyrific.Catapult.TaskProviders.DotNetCoreTest.csproj"
-$dotNetCoreTestPublishPath = Join-Path $enginePublishPath "/plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest"
-$entityFrameworkCoreCsprojPath = Join-Path $rootPath "/src/Plugins/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Polyrific.Catapult.TaskProviders.EntityFrameworkCore.csproj"
-$entityFrameworkCorePublishPath = Join-Path $enginePublishPath "/plugins/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore"
-$gitHubCsprojPath = Join-Path $rootPath "/src/Plugins/RepositoryProvider/Polyrific.Catapult.TaskProviders.GitHub/src/Polyrific.Catapult.TaskProviders.GitHub.csproj"
-$gitHubPublishPath = Join-Path $enginePublishPath "/plugins/RepositoryProvider/Polyrific.Catapult.TaskProviders.GitHub"
+if ($openShell) {
+    $host.UI.RawUI.WindowTitle = "OpenCatapult Engine";
+    Write-Host "Engine is ready. You can start exploring available commands by running: dotnet ocengine.dll --help" -ForegroundColor Green
+    Set-Location $enginePublishPath
+} else {
 
-$plugins = [System.Tuple]::Create($aspNetCoreMvcCsprojPath, $aspNetCoreMvcPublishPath),
-[System.Tuple]::Create($azureAppServiceCsprojPath, $azureAppServicePublishPath),
-[System.Tuple]::Create($dotNetCoreCsprojPath, $dotNetCorePublishPath),
-[System.Tuple]::Create($dotNetCoreTestCsprojPath, $dotNetCoreTestPublishPath),
-[System.Tuple]::Create($entityFrameworkCoreCsprojPath, $entityFrameworkCorePublishPath),
-[System.Tuple]::Create($gitHubCsprojPath, $gitHubPublishPath)
+    $aspNetCoreMvcCsprojPath = Join-Path $rootPath "/src/Plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc/src/Polyrific.Catapult.TaskProviders.AspNetCoreMvc.csproj"
+    $aspNetCoreMvcPublishPath = Join-Path $enginePublishPath "/plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc"
+    $azureAppServiceCsprojPath = Join-Path $rootPath "/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Polyrific.Catapult.TaskProviders.AzureAppService.csproj"
+    $azureAppServicePublishPath = Join-Path $enginePublishPath "/plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService"
+    $dotNetCoreCsprojPath = Join-Path $rootPath "/src/Plugins/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Polyrific.Catapult.TaskProviders.DotNetCore.csproj"
+    $dotNetCorePublishPath = Join-Path $enginePublishPath "/plugins/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore"
+    $dotNetCoreTestCsprojPath = Join-Path $rootPath "/src/Plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest/src/Polyrific.Catapult.TaskProviders.DotNetCoreTest.csproj"
+    $dotNetCoreTestPublishPath = Join-Path $enginePublishPath "/plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest"
+    $entityFrameworkCoreCsprojPath = Join-Path $rootPath "/src/Plugins/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Polyrific.Catapult.TaskProviders.EntityFrameworkCore.csproj"
+    $entityFrameworkCorePublishPath = Join-Path $enginePublishPath "/plugins/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore"
+    $gitHubCsprojPath = Join-Path $rootPath "/src/Plugins/RepositoryProvider/Polyrific.Catapult.TaskProviders.GitHub/src/Polyrific.Catapult.TaskProviders.GitHub.csproj"
+    $gitHubPublishPath = Join-Path $enginePublishPath "/plugins/RepositoryProvider/Polyrific.Catapult.TaskProviders.GitHub"
 
-# publish engine
-Write-Output "Publishing the Engine..."
-Write-Output "dotnet publish $engineCsprojPath -c $configuration -o $enginePublishPath"
-$result = dotnet publish $engineCsprojPath -c $configuration -o $enginePublishPath
-if ($LASTEXITCODE -ne 0) {
-    Write-Error -Message "[ERROR] $result"
-    break
-}
+    $plugins = [System.Tuple]::Create($aspNetCoreMvcCsprojPath, $aspNetCoreMvcPublishPath),
+    [System.Tuple]::Create($azureAppServiceCsprojPath, $azureAppServicePublishPath),
+    [System.Tuple]::Create($dotNetCoreCsprojPath, $dotNetCorePublishPath),
+    [System.Tuple]::Create($dotNetCoreTestCsprojPath, $dotNetCoreTestPublishPath),
+    [System.Tuple]::Create($entityFrameworkCoreCsprojPath, $entityFrameworkCorePublishPath),
+    [System.Tuple]::Create($gitHubCsprojPath, $gitHubPublishPath)
 
-# Set ApiUrl
-if (!$noConfig) {
-    Write-Output "Set ApiUrl config..."
-    Write-Output "dotnet $engineDll config set -n ApiUrl -v $url"
-    $result = dotnet $engineDll config set -n ApiUrl -v $url
+    # publish engine
+    Write-Output "Publishing the Engine..."
+    Write-Output "dotnet publish $engineCsprojPath -c $configuration -o $enginePublishPath"
+    $result = dotnet publish $engineCsprojPath -c $configuration -o $enginePublishPath
     if ($LASTEXITCODE -ne 0) {
         Write-Error -Message "[ERROR] $result"
         break
     }
-}
 
-# publish plugins
-Write-Output "Publishing plugins..."
-foreach ($p in $plugins) {
-    "dotnet publish {0} -c {1} -o {2}" -f $p.Item1, $configuration, $p.Item2
-    $result = dotnet publish $p.Item1 -c $configuration -o $p.Item2
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error -Message "[ERROR] $result"
-        break
+    # Set ApiUrl
+    if (!$noConfig) {
+        Write-Output "Set ApiUrl config..."
+        Write-Output "dotnet $engineDll config set -n ApiUrl -v $url"
+        $result = dotnet $engineDll config set -n ApiUrl -v $url
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error -Message "[ERROR] $result"
+            break
+        }
     }
+
+    # publish plugins
+    Write-Output "Publishing plugins..."
+    foreach ($p in $plugins) {
+        "dotnet publish {0} -c {1} -o {2}" -f $p.Item1, $configuration, $p.Item2
+        $result = dotnet publish $p.Item1 -c $configuration -o $p.Item2
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error -Message "[ERROR] $result"
+            break
+        }
+    }
+
+    Write-Host "Engine component was published successfully."
 }
-
-Write-Host "Engine is ready. You can start exploring available commands by running: dotnet ocengine.dll --help" -ForegroundColor Green
-
-Set-Location $enginePublishPath


### PR DESCRIPTION
## Summary
This is an attempt to fix the race condition issue when executing `build-all.ps1` script. In this fix, I differentiate between the publishing process and opening new shell windows. All publishing processes are done in the main shell window so they are executed sequentially. Opening new shell windows after publishing won't raise the race condition issue.