### PR TITLE
Implement custom task

### DIFF
--- a/builds/build-engine.ps1
+++ b/builds/build-engine.ps1
@@ -30,13 +30,16 @@ if ($openShell) {
     $entityFrameworkCorePublishPath = Join-Path $enginePublishPath "/plugins/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore"
     $gitHubCsprojPath = Join-Path $rootPath "/src/Plugins/RepositoryProvider/Polyrific.Catapult.TaskProviders.GitHub/src/Polyrific.Catapult.TaskProviders.GitHub.csproj"
     $gitHubPublishPath = Join-Path $enginePublishPath "/plugins/RepositoryProvider/Polyrific.Catapult.TaskProviders.GitHub"
+    $genericCommandCsprojPath = Join-Path $rootPath "/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/src/Polyrific.Catapult.TaskProviders.GenericCommand.csproj"
+    $genericCommandPublishPath = Join-Path $enginePublishPath "/plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand"
 
     $plugins = [System.Tuple]::Create($aspNetCoreMvcCsprojPath, $aspNetCoreMvcPublishPath),
     [System.Tuple]::Create($azureAppServiceCsprojPath, $azureAppServicePublishPath),
     [System.Tuple]::Create($dotNetCoreCsprojPath, $dotNetCorePublishPath),
     [System.Tuple]::Create($dotNetCoreTestCsprojPath, $dotNetCoreTestPublishPath),
     [System.Tuple]::Create($entityFrameworkCoreCsprojPath, $entityFrameworkCorePublishPath),
-    [System.Tuple]::Create($gitHubCsprojPath, $gitHubPublishPath)
+    [System.Tuple]::Create($gitHubCsprojPath, $gitHubPublishPath),
+    [System.Tuple]::Create($genericCommandCsprojPath, $genericCommandPublishPath)
 
     # publish engine
     Write-Output "Publishing the Engine..."

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
@@ -222,9 +222,11 @@ namespace Polyrific.Catapult.Api.Core.Services
                             throw new DuplicateJobTaskDefinitionException(string.Join(DataDelimiter.Comma.ToString(), duplicateTasks));
                         }
 
+                        int sequence = 1;
                         foreach (var task in job.Tasks)
                         {
                             task.Created = DateTime.UtcNow;
+                            task.Sequence = sequence++;
                             await _jobDefinitionService.ValidateJobTaskDefinition(job, task);
                         }
                     }

--- a/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginAdditionalConfigConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginAdditionalConfigConfig.cs
@@ -41,6 +41,13 @@ namespace Polyrific.Catapult.Api.Data.EntityConfigs
                 new PluginAdditionalConfig { Id = 13, PluginId = 6, Name = "Region", Label = "Default Region", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382264" },
                 new PluginAdditionalConfig { Id = 14, PluginId = 6, Name = "AppServicePlan", Label = "Default App Service Plan", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382265" }
             );
+
+            // Additional configs for EntityFrameworkCore plugin
+            builder.HasData(
+                new PluginAdditionalConfig { Id = 15, PluginId = 7, Name = "CommandTool", Label = "Command Tool", Type = "string", Hint = "The command tool to be used to run the command (e.g. Powershell). Defaults based on OS.", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382267" },
+                new PluginAdditionalConfig { Id = 16, PluginId = 7, Name = "CommandText", Label = "Command Text", Type = "string", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382268" },
+                new PluginAdditionalConfig { Id = 17, PluginId = 7, Name = "CommandScriptPath", Label = "Command Script Path", Hint = "You can provide a script file (it is recommended to use this if the input contains multiple lines of commands)", Type = "file", IsRequired = false, IsSecret = false, Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "c48cafcc-b3e9-4375-a2c2-f30404382269" }
+            );
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/PluginConfig.cs
@@ -18,7 +18,8 @@ namespace Polyrific.Catapult.Api.Data.EntityConfigs
                 new Plugin { Id = 3, Name = "Polyrific.Catapult.TaskProviders.DotNetCore", Type = "BuildProvider", Author = "Polyrific", Version = "1.0.0-beta2", Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "976e0533-360a-4e46-8220-7c1cfdf0e0a3" },
                 new Plugin { Id = 4, Name = "Polyrific.Catapult.TaskProviders.DotNetCoreTest", Type = "TestProvider", Author = "Polyrific", Version = "1.0.0-beta2", Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "976e0533-360a-4e46-8220-7c1cfdf0e0a4" },
                 new Plugin { Id = 5, Name = "Polyrific.Catapult.TaskProviders.EntityFrameworkCore", Type = "DatabaseProvider", Author = "Polyrific", Version = "1.0.0-beta2", Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "976e0533-360a-4e46-8220-7c1cfdf0e0a5" },
-                new Plugin { Id = 6, Name = "Polyrific.Catapult.TaskProviders.AzureAppService", Type = "HostingProvider", Author = "Polyrific", RequiredServicesString = "Azure", Version = "1.0.0-beta2", Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "976e0533-360a-4e46-8220-7c1cfdf0e0a6" }
+                new Plugin { Id = 6, Name = "Polyrific.Catapult.TaskProviders.AzureAppService", Type = "HostingProvider", Author = "Polyrific", RequiredServicesString = "Azure", Version = "1.0.0-beta2", Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "976e0533-360a-4e46-8220-7c1cfdf0e0a6" },
+                new Plugin { Id = 7, Name = "Polyrific.Catapult.TaskProviders.GenericCommand", Type = "GenericTaskProvider", Author = "Polyrific", Version = "1.0.0-beta3", Created = new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), ConcurrencyStamp = "976e0533-360a-4e46-8220-7c1cfdf0e0a7" }
             );
         }
     }

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190327090322_GenericTaskProvider.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190327090322_GenericTaskProvider.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190327090322_GenericTaskProvider")]
+    partial class GenericTaskProvider
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190327090322_GenericTaskProvider.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190327090322_GenericTaskProvider.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class GenericTaskProvider : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Plugins",
+                columns: new[] { "Id", "Author", "ConcurrencyStamp", "Created", "Name", "RequiredServicesString", "Type", "Updated", "Version" },
+                values: new object[] { 7, "Polyrific", "976e0533-360a-4e46-8220-7c1cfdf0e0a7", new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), "Polyrific.Catapult.TaskProviders.GenericCommand", null, "GenericTaskProvider", null, "1.0.0-beta3" });
+
+            migrationBuilder.InsertData(
+                table: "PluginAdditionalConfigs",
+                columns: new[] { "Id", "AllowedValues", "ConcurrencyStamp", "Created", "Hint", "IsInputMasked", "IsRequired", "IsSecret", "Label", "Name", "PluginId", "Type", "Updated" },
+                values: new object[] { 15, null, "c48cafcc-b3e9-4375-a2c2-f30404382267", new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), "The command tool to be used to run the command (e.g. Powershell). Defaults based on OS.", null, false, false, "Command Tool", "CommandTool", 7, "string", null });
+
+            migrationBuilder.InsertData(
+                table: "PluginAdditionalConfigs",
+                columns: new[] { "Id", "AllowedValues", "ConcurrencyStamp", "Created", "Hint", "IsInputMasked", "IsRequired", "IsSecret", "Label", "Name", "PluginId", "Type", "Updated" },
+                values: new object[] { 16, null, "c48cafcc-b3e9-4375-a2c2-f30404382268", new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), null, null, false, false, "Command Text", "CommandText", 7, "string", null });
+
+            migrationBuilder.InsertData(
+                table: "PluginAdditionalConfigs",
+                columns: new[] { "Id", "AllowedValues", "ConcurrencyStamp", "Created", "Hint", "IsInputMasked", "IsRequired", "IsSecret", "Label", "Name", "PluginId", "Type", "Updated" },
+                values: new object[] { 17, null, "c48cafcc-b3e9-4375-a2c2-f30404382269", new DateTime(2018, 9, 28, 7, 23, 37, 58, DateTimeKind.Utc), "You can provide a script file (it is recommended to use this if the input contains multiple lines of commands)", null, false, false, "Command Script Path", "CommandScriptPath", 7, "file", null });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "PluginAdditionalConfigs",
+                keyColumns: new[] { "Id", "ConcurrencyStamp" },
+                keyValues: new object[] { 15, "c48cafcc-b3e9-4375-a2c2-f30404382267" });
+
+            migrationBuilder.DeleteData(
+                table: "PluginAdditionalConfigs",
+                keyColumns: new[] { "Id", "ConcurrencyStamp" },
+                keyValues: new object[] { 16, "c48cafcc-b3e9-4375-a2c2-f30404382268" });
+
+            migrationBuilder.DeleteData(
+                table: "PluginAdditionalConfigs",
+                keyColumns: new[] { "Id", "ConcurrencyStamp" },
+                keyValues: new object[] { 17, "c48cafcc-b3e9-4375-a2c2-f30404382269" });
+
+            migrationBuilder.DeleteData(
+                table: "Plugins",
+                keyColumns: new[] { "Id", "ConcurrencyStamp" },
+                keyValues: new object[] { 7, "976e0533-360a-4e46-8220-7c1cfdf0e0a7" });
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
@@ -311,6 +311,11 @@ namespace Polyrific.Catapult.Api.Controllers
                 _logger.LogWarning(ex, "Deletion job definition not found");
                 return BadRequest(ex.Message);
             }
+            catch (JobQueueInProgressException jex)
+            {
+                _logger.LogWarning(jex, "There is already a running job in project");
+                return BadRequest(jex.Message);
+            }
         }
 
         /// <summary>

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Project/CreateCommand.cs
@@ -16,6 +16,7 @@ using Polyrific.Catapult.Shared.Dto.ProjectDataModel;
 using Polyrific.Catapult.Shared.Service;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using System.IO;
 
 namespace Polyrific.Catapult.Cli.Commands.Project
 {
@@ -169,6 +170,22 @@ namespace Polyrific.Catapult.Cli.Commands.Project
                                 {
                                     Console.WriteLine($"Input is not valid. Please enter valid number value.");
                                     validInput = false;
+                                }
+                                else if (additionalConfig.Type == ConfigType.File)
+                                {
+                                    try
+                                    {
+                                        validInput = File.Exists(input);
+
+                                        if (validInput)
+                                            input = File.ReadAllText(input);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Console.WriteLine("The file path is not valid");
+                                        Logger.LogError("Error while reading file", ex);
+                                        validInput = false;
+                                    }
                                 }
                                 else if (additionalConfig.AllowedValues?.Length > 0 && !additionalConfig.AllowedValues.Contains(input))
                                 {

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/AddCommand.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
@@ -55,7 +56,7 @@ namespace Polyrific.Catapult.Cli.Commands.Task
         [Option("-t|--type <TYPE>", "Type of the task", CommandOptionType.SingleValue)]
         [AllowedValues(JobTaskDefinitionType.Clone, JobTaskDefinitionType.Generate, JobTaskDefinitionType.Push, JobTaskDefinitionType.Merge, JobTaskDefinitionType.Build, 
             JobTaskDefinitionType.PublishArtifact, JobTaskDefinitionType.Deploy, JobTaskDefinitionType.DeployDb, JobTaskDefinitionType.Test,
-            JobTaskDefinitionType.DeleteRepository, JobTaskDefinitionType.DeleteHosting)]
+            JobTaskDefinitionType.DeleteRepository, JobTaskDefinitionType.DeleteHosting, JobTaskDefinitionType.CustomTask)]
         public string Type { get; set; } = JobTaskDefinitionType.Generate;
 
         [Option("-prop|--property <KEY>:<PROPERTY>", "Property of the task", CommandOptionType.MultipleValue)]
@@ -152,6 +153,22 @@ namespace Polyrific.Catapult.Cli.Commands.Task
                                     {
                                         Console.WriteLine($"Input is not valid. Please enter valid number value.");
                                         validInput = false;
+                                    }
+                                    else if (additionalConfig.Type == ConfigType.File)
+                                    {
+                                        try
+                                        {
+                                            validInput = File.Exists(input);
+
+                                            if (validInput)
+                                                input = File.ReadAllText(input);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            Console.WriteLine("The file path is not valid");
+                                            Logger.LogError("Error while reading file", ex);
+                                            validInput = false;
+                                        }
                                     }
                                     else if (additionalConfig.AllowedValues?.Length > 0 && !additionalConfig.AllowedValues.Contains(input))
                                     {

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Task/UpdateCommand.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
@@ -54,7 +55,7 @@ namespace Polyrific.Catapult.Cli.Commands.Task
         [Option("-t|--type <TYPE>", "Type of the task", CommandOptionType.SingleValue)]
         [AllowedValues(JobTaskDefinitionType.Clone, JobTaskDefinitionType.Generate, JobTaskDefinitionType.Push, JobTaskDefinitionType.Merge, JobTaskDefinitionType.Build,
             JobTaskDefinitionType.PublishArtifact, JobTaskDefinitionType.Deploy, JobTaskDefinitionType.DeployDb, JobTaskDefinitionType.Test,
-            JobTaskDefinitionType.DeleteRepository, JobTaskDefinitionType.DeleteHosting)]
+            JobTaskDefinitionType.DeleteRepository, JobTaskDefinitionType.DeleteHosting, JobTaskDefinitionType.CustomTask)]
         public string Type { get; set; }
 
         [Option("-prov|--provider <PROVIDER>", "Provider of the job task definition", CommandOptionType.SingleValue)]
@@ -170,6 +171,22 @@ namespace Polyrific.Catapult.Cli.Commands.Task
                                             {
                                                 Console.WriteLine($"Input is not valid. Please enter valid number value.");
                                                 validInput = false;
+                                            }
+                                            else if (additionalConfig.Type == ConfigType.File)
+                                            {
+                                                try
+                                                {
+                                                    validInput = File.Exists(input);
+
+                                                    if (validInput)
+                                                        input = File.ReadAllText(input);
+                                                }
+                                                catch (Exception ex)
+                                                {
+                                                    Console.WriteLine("The file path is not valid");
+                                                    Logger.LogError("Error while reading file", ex);
+                                                    validInput = false;
+                                                }
                                             }
                                             else if (additionalConfig.AllowedValues?.Length > 0 && !additionalConfig.AllowedValues.Contains(input))
                                             {

--- a/src/Engine/Polyrific.Catapult.Engine.Core/EngineCoreInjection.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/EngineCoreInjection.cs
@@ -24,6 +24,7 @@ namespace Polyrific.Catapult.Engine.Core
             services.AddTransient<ITestTask, TestTask>();
             services.AddTransient<IDeleteRepositoryTask, DeleteRepositoryTask>();
             services.AddTransient<IDeleteHostingTask, DeleteHostingTask>();
+            services.AddTransient<ICustomTask, CustomTask>();
             services.AddTransient<JobTaskService, JobTaskService>();
         }
     }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTaskService.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTaskService.cs
@@ -19,7 +19,8 @@ namespace Polyrific.Catapult.Engine.Core
             IPushTask pushTask,
             ITestTask testTask,
             IDeleteRepositoryTask deleteRepositoryTask,
-            IDeleteHostingTask deleteHostingTask)
+            IDeleteHostingTask deleteHostingTask,
+            ICustomTask customTask)
         {
             BuildTask = buildTask;
             CloneTask = cloneTask;
@@ -32,6 +33,7 @@ namespace Polyrific.Catapult.Engine.Core
             TestTask = testTask;
             DeleteRepositoryTask = deleteRepositoryTask;
             DeleteHostingTask = deleteHostingTask;
+            CustomTask = customTask;
         }
 
         /// <summary>
@@ -88,5 +90,10 @@ namespace Polyrific.Catapult.Engine.Core
         /// Instance of <see cref="IDeleteHostingTask"/>
         /// </summary>
         public IDeleteHostingTask DeleteHostingTask { get; }
+
+        /// <summary>
+        /// Instance of <see cref="ICustomTask"/>
+        /// </summary>
+        public ICustomTask CustomTask { get; }
     }
 }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/CustomTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/CustomTask.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Polyrific.Catapult.TaskProviders.Core.Configs;
+using Polyrific.Catapult.Shared.Dto.Constants;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Engine.Core.JobTasks
+{
+    public class CustomTask : BaseJobTask<BaseJobTaskConfig>, ICustomTask
+    {
+        /// <inheritdoc />
+        public CustomTask(IProjectService projectService, IExternalServiceService externalServiceService, IExternalServiceTypeService externalServiceTypeService, IProviderService providerService, IPluginManager pluginManager, ILogger<CustomTask> logger)
+            : base(projectService, externalServiceService, externalServiceTypeService, providerService, pluginManager, logger)
+        {
+        }
+
+        public override string Type => JobTaskDefinitionType.CustomTask;
+
+        public List<PluginItem> GenericTaskProviders => PluginManager.GetPlugins(PluginType.GenericTaskProvider);
+
+        public override async Task<TaskRunnerResult> RunPreprocessingTask()
+        {
+            var provider = GenericTaskProviders?.FirstOrDefault(p => p.Name == Provider);
+            if (provider == null)
+                return new TaskRunnerResult($"Generic task provider \"{Provider}\" could not be found.");
+
+            await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
+
+            var arg = GetArgString("pre");
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
+            if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
+                return new TaskRunnerResult(result["errorMessage"].ToString(), TaskConfig.PreProcessMustSucceed);
+
+            return new TaskRunnerResult(true, "");
+        }
+
+        public override async Task<TaskRunnerResult> RunMainTask(Dictionary<string, string> previousTasksOutputValues)
+        {
+            var provider = GenericTaskProviders?.FirstOrDefault(p => p.Name == Provider);
+            if (provider == null)
+                return new TaskRunnerResult($"Generic task provider \"{Provider}\" could not be found.");
+
+            await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
+
+            var arg = GetArgString("main");
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
+            if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
+                return new TaskRunnerResult(result["errorMessage"].ToString(), !TaskConfig.ContinueWhenError);
+            
+            var outputValues = new Dictionary<string, string>();
+            if (result.ContainsKey("outputValues") && !string.IsNullOrEmpty(result["outputValues"]?.ToString()))
+                outputValues = JsonConvert.DeserializeObject<Dictionary<string, string>>(result["outputValues"].ToString());
+
+            string taskRemarks = "";
+            if (result.ContainsKey("successMessage"))
+            {
+                taskRemarks = result["successMessage"]?.ToString();
+            }
+
+            return new TaskRunnerResult(true, null, outputValues)
+            {
+                TaskRemarks = taskRemarks
+            };
+        }
+
+        public override async Task<TaskRunnerResult> RunPostprocessingTask()
+        {
+            var provider = GenericTaskProviders?.FirstOrDefault(p => p.Name == Provider);
+            if (provider == null)
+                return new TaskRunnerResult($"Generic task provider \"{Provider}\" could not be found.");
+
+            await LoadRequiredServicesToAdditionalConfigs(provider.RequiredServices);
+
+            var arg = GetArgString("post");
+            var result = await PluginManager.InvokeTaskProvider(provider.StartFilePath, arg.argString, arg.securedArgString);
+            if (result.ContainsKey("errorMessage") && !string.IsNullOrEmpty(result["errorMessage"].ToString()))
+                return new TaskRunnerResult(result["errorMessage"].ToString(), TaskConfig.PostProcessMustSucceed);
+
+            return new TaskRunnerResult(true, "");
+        }
+
+        private (string argString, string securedArgString) GetArgString(string process)
+        {
+            var dict = new Dictionary<string, object>
+            {
+                {"process", process},
+                {"config", TaskConfig},
+                {"additional", AdditionalConfigs}
+            };
+
+            var argString = JsonConvert.SerializeObject(dict);
+
+            dict["additional"] = SecuredAdditionalConfigs;
+            var securedArgString = JsonConvert.SerializeObject(dict);
+
+            return (argString, securedArgString);
+        }
+    }
+}

--- a/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/ICustomTask.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/JobTasks/ICustomTask.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+namespace Polyrific.Catapult.Engine.Core.JobTasks
+{
+    public interface ICustomTask : IJobTask
+    {
+    }
+}

--- a/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
@@ -224,6 +224,9 @@ namespace Polyrific.Catapult.Engine.Core
                 case JobTaskDefinitionType.DeleteHosting:
                     task = _jobTaskService.DeleteHostingTask;
                     break;
+                case JobTaskDefinitionType.CustomTask:
+                    task = _jobTaskService.CustomTask;
+                    break;
                 default:
                     throw new InvalidJobTaskTypeException(jobTask.Type);
             }

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/plugin.yml
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/plugin.yml
@@ -9,9 +9,14 @@ additional-configs:
     type: string
     is-required: false
     is-secret: false
-  - name: Commands
-    label: Commands
-    hint: The command sequences separated by line
+  - name: CommandText
+    label: Command Text
     type: string
-    is-required: true
+    is-required: false
+    is-secret: false
+  - name: CommandScriptPath
+    label: Command Script Path
+    hint: You can provide a script file, if the commands include many lines
+    type: file
+    is-required: false
     is-secret: false

--- a/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/GenericTaskProviderTests.cs
+++ b/src/Plugins/GenericTaskProvider/Polyrific.Catapult.TaskProviders.GenericCommand/tests/GenericTaskProviderTests.cs
@@ -26,8 +26,6 @@ namespace Polyrific.Catapult.TaskProviders.GenericCommand.UnitTests
             if (Directory.Exists(workingLocation))
                 Directory.Delete(workingLocation, true);
 
-            Directory.CreateDirectory(workingLocation);
-
             var additionalConfig = new Dictionary<string, string>();
 
             bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -43,13 +41,14 @@ namespace Polyrific.Catapult.TaskProviders.GenericCommand.UnitTests
                 sb.AppendLine("cp test.txt test2.txt");
             }
             
-            additionalConfig["Commands"] = sb.ToString();
+            additionalConfig["CommandScriptPath"] = sb.ToString();
 
             var provider = new Program(new string[] { GetArgString("main", config, additionalConfig) });
             var result = await provider.GenericExecution();
 
             Assert.True(File.Exists(Path.Combine(workingLocation, "test.txt")));
             Assert.True(File.Exists(Path.Combine(workingLocation, "test2.txt")));
+            Assert.Equal("The commands has been run successfully", result.successMessage);
         }
 
         private string GetArgString(string process, BaseJobTaskConfig taskConfig, Dictionary<string, string> additionalConfigs)

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/GenericTaskProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/GenericTaskProvider.cs
@@ -47,7 +47,8 @@ namespace Polyrific.Catapult.TaskProviders.Core
                         result.Add("errorMessage", error);
                     break;
                 case "main":
-                    (var outputValues, string errorMessage) = await GenericExecution();
+                    (string successMessage, var outputValues, string errorMessage) = await GenericExecution();
+                    result.Add("successMessage", successMessage);
                     result.Add("outputValues", outputValues);
                     result.Add("errorMessage", errorMessage);
                     break;
@@ -58,8 +59,9 @@ namespace Polyrific.Catapult.TaskProviders.Core
                     break;
                 default:
                     await BeforeGenericExecution();
-                    (outputValues, errorMessage) = await GenericExecution();
+                    (successMessage, outputValues, errorMessage) = await GenericExecution();
                     await AfterGenericExecution();
+                    result.Add("successMessage", successMessage);
                     result.Add("outputValues", outputValues);
                     result.Add("errorMessage", errorMessage);
                     break;
@@ -91,7 +93,7 @@ namespace Polyrific.Catapult.TaskProviders.Core
         /// Execute a generic action
         /// </summary>
         /// <returns></returns>
-        public abstract Task<(Dictionary<string, string> outputValues, string errorMessage)> GenericExecution();
+        public abstract Task<(string successMessage, Dictionary<string, string> outputValues, string errorMessage)> GenericExecution();
 
         /// <summary>
         /// Process to run after executing a generic action

--- a/src/Plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest/tests/TestProviderTests.cs
+++ b/src/Plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest/tests/TestProviderTests.cs
@@ -41,7 +41,7 @@ namespace Polyrific.Catapult.TaskProviders.DotNetCoreTest.UnitTests
         [Fact]
         public async void Test_Failed()
         {
-            var workingLocation = Path.Combine("c:\\opencatapult\\working", "20180817.1");
+            var workingLocation = Path.Combine(AppContext.BaseDirectory, "working", "20180817.1");
 
             if (Directory.Exists(workingLocation))
                 Directory.Delete(workingLocation, true);

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/ConfigType.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/ConfigType.cs
@@ -7,5 +7,6 @@ namespace Polyrific.Catapult.Shared.Dto.Constants
         public const string String = "string";
         public const string Boolean = "boolean";
         public const string Number = "number";
+        public const string File = "file";
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/JobTaskDefinitionType.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/Constants/JobTaskDefinitionType.cs
@@ -15,5 +15,6 @@ namespace Polyrific.Catapult.Shared.Dto.Constants
         public const string Test = "Test";
         public const string DeleteRepository = "DeleteRepository";
         public const string DeleteHosting = "DeleteHosting";
+        public const string CustomTask = "CustomTask";
     }
 }

--- a/src/Web/opencatapultweb/src/app/core/constants/deletion-job-task-definition-types.ts
+++ b/src/Web/opencatapultweb/src/app/core/constants/deletion-job-task-definition-types.ts
@@ -3,4 +3,5 @@ import { JobTaskDefinitionType } from '../enums/job-task-definition-type';
 export const DeletionJobTaskDefinitionTypes: [string, string][] = [
   [JobTaskDefinitionType.DeleteRepository, 'Delete Repository'],
   [JobTaskDefinitionType.DeleteHosting, 'Delete Hosting'],
+  [JobTaskDefinitionType.CustomTask, 'Custom Task'],
 ];

--- a/src/Web/opencatapultweb/src/app/core/constants/job-task-definition-types.ts
+++ b/src/Web/opencatapultweb/src/app/core/constants/job-task-definition-types.ts
@@ -10,4 +10,5 @@ export const jobTaskDefinitionTypes: [string, string][] = [
   [JobTaskDefinitionType.Deploy, 'Deploy'],
   [JobTaskDefinitionType.PublishArtifact, 'Publish Artifact'],
   [JobTaskDefinitionType.Test, 'Test'],
+  [JobTaskDefinitionType.CustomTask, 'Custom Task'],
 ];

--- a/src/Web/opencatapultweb/src/app/core/enums/job-task-definition-type.ts
+++ b/src/Web/opencatapultweb/src/app/core/enums/job-task-definition-type.ts
@@ -9,5 +9,6 @@ export enum JobTaskDefinitionType {
     PublishArtifact = 'PublishArtifact',
     Test = 'Test',
     DeleteRepository = 'DeleteRepository',
-    DeleteHosting = 'DeleteHosting'
+    DeleteHosting = 'DeleteHosting',
+    CustomTask = 'CustomTask'
 }

--- a/src/Web/opencatapultweb/src/app/core/enums/provider-type.ts
+++ b/src/Web/opencatapultweb/src/app/core/enums/provider-type.ts
@@ -6,4 +6,5 @@ export enum ProviderType {
   RepositoryProvider = 'RepositoryProvider',
   StorageProvider = 'StorageProvider',
   TestProvider = 'TestProvider',
+  GenericTaskProvider = 'GenericTaskProvider',
 }

--- a/src/Web/opencatapultweb/src/app/core/services/task-provider.service.ts
+++ b/src/Web/opencatapultweb/src/app/core/services/task-provider.service.ts
@@ -51,6 +51,8 @@ export class TaskProviderService {
         return ProviderType.StorageProvider;
       case JobTaskDefinitionType.Test:
         return ProviderType.TestProvider;
+      case JobTaskDefinitionType.CustomTask:
+        return ProviderType.GenericTaskProvider;
       default:
         return '';
     }

--- a/src/Web/opencatapultweb/src/app/project/job-definition/components/job-task-definition-form/job-task-definition-form.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-definition/components/job-task-definition-form/job-task-definition-form.component.ts
@@ -28,7 +28,8 @@ export class JobTaskDefinitionFormComponent implements OnInit, OnChanges {
     this.jobTaskDefinitionForm = this.fb.group({
       name: [{value: null, disabled: this.disableForm}, Validators.required],
       type: [{value: null, disabled: this.disableForm}],
-      provider: [{value: null, disabled: this.disableForm}]
+      provider: [{value: null, disabled: this.disableForm}],
+      sequence: this.jobTaskDefinition ? this.jobTaskDefinition.sequence : null
     });
 
     this.taskProviderService.getTaskProviders('all')

--- a/src/Web/opencatapultweb/src/app/shared/components/additional-config-field/additional-config-field.component.css
+++ b/src/Web/opencatapultweb/src/app/shared/components/additional-config-field/additional-config-field.component.css
@@ -1,0 +1,7 @@
+.upload-container{
+  margin-bottom: 15px;
+}
+
+.custom-file {
+  margin-left: 5px;
+}

--- a/src/Web/opencatapultweb/src/app/shared/components/additional-config-field/additional-config-field.component.html
+++ b/src/Web/opencatapultweb/src/app/shared/components/additional-config-field/additional-config-field.component.html
@@ -10,7 +10,23 @@
     <mat-form-field *ngSwitchCase="'number'" class="full-width-input">
         <mat-label>{{additionalConfig.label}}</mat-label>
         <input matInput placeholder="{{additionalConfig.hint}}" [formControlName]="additionalConfig.name" [required]="additionalConfig.isRequired ? 'required' : null">
+        <mat-error *ngIf="isFieldInvalid(additionalConfig.name, 'required')">
+          Please inform the {{additionalConfig.label}}
+        </mat-error>
     </mat-form-field>
-    
-  <mat-checkbox *ngSwitchCase="'boolean'" [formControlName]="additionalConfig.name">{{additionalConfig.label}}</mat-checkbox>
+
+    <mat-checkbox *ngSwitchCase="'boolean'" [formControlName]="additionalConfig.name">{{additionalConfig.label}}</mat-checkbox>
+
+    <div class="upload-container" *ngSwitchCase="'file'">
+      <input class="hidden" id="input-file-{{additionalConfig.name}}" type="file"
+        (change)="onFileChanged($event)" />
+      <label for="input-file-{{additionalConfig.name}}" class="mat-raised-button">Choose {{additionalConfig.label}}</label>
+      <span class="custom-file">{{additionalConfigFile}}</span>
+      <div class="margin10">
+        <span>{{additionalConfig.hint}}</span>
+      </div>
+      <mat-error *ngIf="isFieldInvalid(additionalConfig.name, 'required')">
+        Please inform the {{additionalConfig.label}}
+      </mat-error>
+  </div>
 </div>

--- a/src/Web/opencatapultweb/src/app/shared/components/additional-config-field/additional-config-field.component.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/additional-config-field/additional-config-field.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { AdditionalConfigDto } from '@app/core';
 import { FormGroup } from '@angular/forms';
+import { formArrayNameProvider } from '@angular/forms/src/directives/reactive_directives/form_group_name';
 
 @Component({
   selector: 'app-additional-config-field',
@@ -10,6 +11,8 @@ import { FormGroup } from '@angular/forms';
 export class AdditionalConfigFieldComponent implements OnInit {
   @Input() additionalConfig: AdditionalConfigDto;
   @Input() form: FormGroup;
+  additionalConfigFile: string;
+
   constructor() { }
 
   ngOnInit() {
@@ -18,6 +21,18 @@ export class AdditionalConfigFieldComponent implements OnInit {
   isFieldInvalid(controlName: string, errorCode: string) {
     const control = this.form.get(controlName);
     return control.invalid && control.errors && control.getError(errorCode);
+  }
+
+  onFileChanged(event) {
+    if (event.target.value) {
+      this.additionalConfigFile = event.target.value.split(/(\\|\/)/g).pop();
+
+      const fileReader = new FileReader();
+      fileReader.onload = (e) => {
+        this.form.get(this.additionalConfig.name).setValue(fileReader.result);
+      };
+      fileReader.readAsText(event.target.files[0]);
+    }
   }
 
 }

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/CustomTaskTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/JobTasks/CustomTaskTests.cs
@@ -1,0 +1,175 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Polyrific.Catapult.Engine.Core;
+using Polyrific.Catapult.Engine.Core.JobTasks;
+using Polyrific.Catapult.Shared.Dto.ExternalService;
+using Polyrific.Catapult.Shared.Dto.ExternalServiceType;
+using Polyrific.Catapult.Shared.Dto.Provider;
+using Polyrific.Catapult.Shared.Dto.Project;
+using Polyrific.Catapult.Shared.Service;
+using Xunit;
+
+namespace Polyrific.Catapult.Engine.UnitTests.Core.JobTasks
+{
+    public class CustomTaskTests
+    {
+        private readonly Mock<IProjectService> _projectService;
+        private readonly Mock<IExternalServiceService> _externalServiceService;
+        private readonly Mock<IExternalServiceTypeService> _externalServiceTypeService;
+        private readonly Mock<IProviderService> _providerService;
+        private readonly Mock<IPluginManager> _pluginManager;
+        private readonly Mock<ILogger<CustomTask>> _logger;
+
+        public CustomTaskTests()
+        {
+            _projectService = new Mock<IProjectService>();
+            _projectService.Setup(s => s.GetProject(It.IsAny<int>()))
+                .ReturnsAsync((int id) => new ProjectDto { Id = id, Name = $"Project {id}" });
+
+            _externalServiceService = new Mock<IExternalServiceService>();
+
+            _pluginManager = new Mock<IPluginManager>();
+            _pluginManager.Setup(p => p.GetPlugins(It.IsAny<string>())).Returns(new List<PluginItem>
+            {
+                new PluginItem("FakeGenericTaskProvider", "path/to/FakeGenericTaskProvider.dll", new string[] { })
+            });
+
+            _logger = new Mock<ILogger<CustomTask>>();
+
+            _externalServiceTypeService = new Mock<IExternalServiceTypeService>();
+            _externalServiceTypeService.Setup(s => s.GetExternalServiceTypes(It.IsAny<bool>()))
+                .ReturnsAsync(new List<ExternalServiceTypeDto>
+                {
+                    new ExternalServiceTypeDto
+                    {
+                        Name = "GitHub",
+                        ExternalServiceProperties = new List<ExternalServicePropertyDto>
+                        {
+                            new ExternalServicePropertyDto
+                            {
+                                Name = "AuthToken",
+                                IsSecret = true
+                            }
+                        }
+                    }
+                });
+            _providerService = new Mock<IProviderService>();
+            _providerService.Setup(s => s.GetProviderAdditionalConfigByProviderName(It.IsAny<string>()))
+                .ReturnsAsync(new List<ProviderAdditionalConfigDto>
+                {
+                    new ProviderAdditionalConfigDto
+                    {
+                        Name = "ConnectionString",
+                        IsSecret = true
+                    }
+                });
+        }
+
+        [Fact]
+        public async void RunMainTask_Success()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretPluginArgs) => new Dictionary<string, object>
+                {
+                    {"successMessage", "success"}
+                });
+
+            var config = new Dictionary<string, string>();
+
+            var task = new CustomTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeGenericTaskProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("success", result.TaskRemarks);
+        }
+
+        [Fact]
+        public async void RunMainTask_Failed()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretPluginArgs) => new Dictionary<string, object>
+                {
+                    {"errorMessage", "error-message"}
+                });
+
+            var config = new Dictionary<string, string>();
+
+            var task = new CustomTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeGenericTaskProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("error-message", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async void RunMainTask_NoProvider()
+        {
+            var config = new Dictionary<string, string>();
+
+            var task = new CustomTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "NotExistGenericTaskProvider";
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("Generic task provider \"NotExistGenericTaskProvider\" could not be found.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async void RunMainTask_AdditionalConfigSecured()
+        {
+            _pluginManager.Setup(p => p.InvokeTaskProvider(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string pluginDll, string pluginArgs, string secretPluginArgs) => new Dictionary<string, object>
+                {
+                    {"successMessage", "success"}
+                });
+            _pluginManager.Setup(p => p.GetPlugins(It.IsAny<string>())).Returns(new List<PluginItem>
+            {
+                new PluginItem("FakeGenericTaskProvider", "path/to/FakeGenericTaskProvider.dll", new string[] { "GitHub" })
+            });
+            _externalServiceService.Setup(p => p.GetExternalServiceByName(It.IsAny<string>())).ReturnsAsync((string name) => new ExternalServiceDto
+            {
+                Name = name,
+                Config = new Dictionary<string, string>
+                {
+                    { "AuthToken", "123" }
+                }
+            });
+
+            var config = new Dictionary<string, string>
+            {
+                { "GitHubExternalService", "github-test" }
+            };
+
+            var task = new CustomTask(_projectService.Object, _externalServiceService.Object, _externalServiceTypeService.Object, _providerService.Object, _pluginManager.Object, _logger.Object);
+            task.SetConfig(config, "working");
+            task.Provider = "FakeGenericTaskProvider";
+            task.AdditionalConfigs = new Dictionary<string, string>
+            {
+                { "ConnectionString", "Server=localhost;Database=TestProject;User ID=sa;Password=samprod;" }
+            };
+
+            var result = await task.RunMainTask(new Dictionary<string, string>());
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal("success", result.TaskRemarks);
+
+            Assert.Equal(2, task.AdditionalConfigs.Count);
+            Assert.Equal(2, task.SecuredAdditionalConfigs.Count);
+            Assert.Equal("***", task.SecuredAdditionalConfigs["AuthToken"]);
+            Assert.Equal("***", task.SecuredAdditionalConfigs["ConnectionString"]);
+            Assert.Equal("123", task.AdditionalConfigs["AuthToken"]);
+            Assert.Equal("Server=localhost;Database=TestProject;User ID=sa;Password=samprod;", task.AdditionalConfigs["ConnectionString"]);
+        }
+    }
+}

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/TaskRunnerTests.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/TaskRunnerTests.cs
@@ -29,6 +29,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
         private readonly Mock<ITestTask> _testTask;
         private readonly Mock<IDeleteRepositoryTask> _deleteRepositoryTask;
         private readonly Mock<IDeleteHostingTask> _deleteHostingTask;
+        private readonly Mock<ICustomTask> _customTask;
         private readonly JobTaskService _jobTaskService;
         private readonly Mock<IJobQueueService> _jobQueueService;
         private readonly List<JobTaskDefinitionDto> _data;
@@ -98,9 +99,11 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
 
             _deleteHostingTask = new Mock<IDeleteHostingTask>();
 
+            _customTask = new Mock<ICustomTask>();
+
             _jobTaskService = new JobTaskService(_buildTask.Object, _cloneTask.Object, _deployTask.Object,
                 _deployDbTask.Object, _generateTask.Object, _mergeTask.Object, _publishArtifactTask.Object,
-                _pushTask.Object, _testTask.Object, _deleteRepositoryTask.Object, _deleteHostingTask.Object);
+                _pushTask.Object, _testTask.Object, _deleteRepositoryTask.Object, _deleteHostingTask.Object, _customTask.Object);
 
             _jobQueueService = new Mock<IJobQueueService>();
             _pluginManager = new Mock<IPluginManager>();


### PR DESCRIPTION
## Summary
Implement custom task type, and integrate it with GenericTaskProvider.

## Coverage
- [x] Implement custom task in engine core
- [x] Modify engine build script to deploy `Polyrific.Catapult.TaskProviders.GenericCommand`
- [x] Implement custom task in CLI
- [x] Implement custom task in Engine
- [x] Add additional config type `file`
- [x] Bugfixes in Web

## References
- Related Issues: #399 