### PR TITLE
Several build script improvement

### DIFF
--- a/builds/build-all.ps1
+++ b/builds/build-all.ps1
@@ -142,18 +142,19 @@ $args += " -url " + $https
 if ($noConfig) {
     $args += " -noConfig"
 }
+$args += " -noOpenShell"
 
 ## Build CLI
 if (!$noCli) {
 	Write-Host "Publishing CLI..."
     $done = Invoke-BuildScript "build-cli.ps1" $args
-    Invoke-BuildScriptNewWindow "build-cli.ps1" "-openShell"
+    Invoke-BuildScriptNewWindow "build-cli.ps1" "-noBuild"
 }
 
 ## Build Engine
 Write-Host "Publishing Engine..."
 $done = Invoke-BuildScript "build-engine.ps1" $args
-Invoke-BuildScriptNewWindow "build-engine.ps1" "-openShell"
+Invoke-BuildScriptNewWindow "build-engine.ps1" "-noBuild"
 
 ## Build Web
 if (!$noWeb) {

--- a/builds/build-api.ps1
+++ b/builds/build-api.ps1
@@ -51,7 +51,7 @@ if ($connString -eq "") {
 
     if (!$noPrompt) {
         $enteredConnString = Read-Host -Prompt "Please enter new connection string (or just ENTER if you want to use current value)"    
-        if ($enteredConnString -ne "") {
+        if (![string]::IsNullOrWhiteSpace($enteredConnString)) {
             $connString = $enteredConnString
         }
     }

--- a/builds/build-cli.ps1
+++ b/builds/build-cli.ps1
@@ -4,7 +4,8 @@ param(
     [string]$configuration = "Release",
     [string]$url = "https://localhost:44305",
     [switch]$noConfig = $false,
-    [switch]$openShell = $false
+    [switch]$noOpenShell = $false,
+    [switch]$noBuild = $false
 )
 
 $rootPath = Split-Path $PSScriptRoot
@@ -12,11 +13,11 @@ $cliCsprojPath = Join-Path $rootPath "/src/CLI/Polyrific.Catapult.Cli/Polyrific.
 $cliPublishPath = Join-Path $rootPath "/publish/cli"
 $cliDll = Join-Path $cliPublishPath "/occli.dll"
 
-if ($openShell) {
+if (!$noOpenShell) {
     $host.UI.RawUI.WindowTitle = "OpenCatapult CLI";
-    Write-Host "CLI is ready. You can start exploring available commands by running: dotnet occli.dll --help" -ForegroundColor Green
-    Set-Location $cliPublishPath
-} else {
+} 
+
+if (!$noBuild) {
     # build CLI
     Write-Output "Publishing the CLI..."
     Write-Output "dotnet publish $cliCsprojPath -c $configuration -o $cliPublishPath"
@@ -39,3 +40,9 @@ if ($openShell) {
 
     Write-Host "CLI component was published successfully."
 }
+
+
+if (!$noOpenShell) {
+    Write-Host "CLI is ready. You can start exploring available commands by running: dotnet occli.dll --help" -ForegroundColor Green
+    Set-Location $cliPublishPath
+} 

--- a/builds/build-engine.ps1
+++ b/builds/build-engine.ps1
@@ -4,7 +4,8 @@ param(
     [string]$configuration = "Release",
     [string]$url = "https://localhost:44305",
     [switch]$noConfig = $false,
-    [switch]$openShell = $false
+    [switch]$noOpenShell = $false,
+    [switch]$noBuild = $false
 )
 
 $rootPath = Split-Path $PSScriptRoot
@@ -12,11 +13,11 @@ $engineCsprojPath = Join-Path $rootPath "/src/Engine/Polyrific.Catapult.Engine/P
 $enginePublishPath = Join-Path $rootPath "/publish/engine"
 $engineDll = Join-Path $enginePublishPath "/ocengine.dll"
 
-if ($openShell) {
+if (!$noOpenShell) {
     $host.UI.RawUI.WindowTitle = "OpenCatapult Engine";
-    Write-Host "Engine is ready. You can start exploring available commands by running: dotnet ocengine.dll --help" -ForegroundColor Green
-    Set-Location $enginePublishPath
-} else {
+} 
+
+if (!$noBuild) {
 
     $aspNetCoreMvcCsprojPath = Join-Path $rootPath "/src/Plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc/src/Polyrific.Catapult.TaskProviders.AspNetCoreMvc.csproj"
     $aspNetCoreMvcPublishPath = Join-Path $enginePublishPath "/plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc"
@@ -71,3 +72,8 @@ if ($openShell) {
 
     Write-Host "Engine component was published successfully."
 }
+
+if (!$noOpenShell) {
+    Write-Host "Engine is ready. You can start exploring available commands by running: dotnet ocengine.dll --help" -ForegroundColor Green
+    Set-Location $enginePublishPath
+} 

--- a/docs/dev-guides/build-scripts.md
+++ b/docs/dev-guides/build-scripts.md
@@ -66,6 +66,8 @@ Options:
 | --- | --- | --- | --- |
 | -configuration | Build configuration | Debug / Release | Release |
 | -noConfig | Do not replace the config values | true / false | false |
+| -noOpenShell | Do not go to publish directory and modify shell window title | true / false | false |
+| -noBuild | Do not perform build operation | true / false | false |
 | -url | Base URL of API endpoint | [https url] | https://localhost:44305 |
 
 ## build-engine.ps1
@@ -82,6 +84,8 @@ Options:
 | --- | --- | --- | --- |
 | -configuration | Build configuration | Debug / Release | Release |
 | -noConfig | Do not replace the config values | true / false | false |
+| -noOpenShell | Do not go to publish directory and modify shell window title | true / false | false |
+| -noBuild | Do not perform build operation | true / false | false |
 | -url | Base URL of API endpoint | [https url] | https://localhost:44305 |
 
 ## build-web.ps1


### PR DESCRIPTION
## Summary
- The `build-engine` and `build-cli` when run individually does not change the directory to its published folder. This PR fixes this.
- Avoid issue #412 by using the IsNullOrWhitespace function

## Coverage
- [x] Update build-all script
- [x] update build-engine script
- [x] update build-cli script
- [x] update build-api script

## References
- Related Issues: #412 
