### PR TITLE
Add a predefined notificationconfig.json

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
+++ b/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
@@ -19,6 +19,9 @@
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
+    <Content Update="notificationconfig.json">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/API/Polyrific.Catapult.Api/notificationconfig.json
+++ b/src/API/Polyrific.Catapult.Api/notificationconfig.json
@@ -1,0 +1,12 @@
+{
+    "NotificationConfig": {
+        "RegistrationCompleted": "SmtpEmail",
+        "ResetPassword": "SmtpEmail",
+        "ResetPasswordWeb": "SmtpEmail",
+        "ProjectDeleted": "SmtpEmail",
+        "RegistrationCompletedSubject": "Catapult - Please confirm your account",
+        "ResetPasswordSubject": "Catapult - Reset password token",
+        "ResetPasswordWebSubject": "Catapult - Reset password token",
+        "ProjectDeletedSubject": "Catapult - Your project has been deleted"
+    }
+}


### PR DESCRIPTION
## Summary
Add a predefined `notificationconfig.json` file so it doesn't have to be created on startup. This is a temporary workaround for https://github.com/Polyrific-Inc/OpenCatapult/issues/458.

## References
- Related Issues: https://github.com/Polyrific-Inc/OpenCatapult/issues/458
