### PR TITLE
Add `web.config` to Web UI

### DIFF
--- a/src/Web/opencatapultweb/angular.json
+++ b/src/Web/opencatapultweb/angular.json
@@ -21,7 +21,8 @@
             "assets": [
               "src/favicon.ico",
               "src/assets",
-              "src/config.json"
+              "src/config.json",
+              "src/web.config"
             ],
             "styles": [
               "src/styles.css"

--- a/src/Web/opencatapultweb/src/web.config
+++ b/src/Web/opencatapultweb/src/web.config
@@ -1,0 +1,16 @@
+<configuration>
+    <system.webServer>
+      <rewrite>
+        <rules>
+          <rule name="Angular" stopProcessing="true">
+            <match url=".*" />
+            <conditions logicalGrouping="MatchAll">
+              <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+              <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+            </conditions>
+            <action type="Rewrite" url="/" />
+          </rule>
+        </rules>
+      </rewrite>
+    </system.webServer>
+</configuration>

--- a/src/Web/opencatapultweb/src/web.config
+++ b/src/Web/opencatapultweb/src/web.config
@@ -1,16 +1,8 @@
 <configuration>
     <system.webServer>
-      <rewrite>
-        <rules>
-          <rule name="Angular" stopProcessing="true">
-            <match url=".*" />
-            <conditions logicalGrouping="MatchAll">
-              <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
-              <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
-            </conditions>
-            <action type="Rewrite" url="/" />
-          </rule>
-        </rules>
-      </rewrite>
+      <staticContent>
+        <remove fileExtension=".json"/>
+        <mimeMap fileExtension=".json" mimeType="application/json"/>
+      </staticContent>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
## Summary
Add `web.config` to Web UI to map JSON file as static content. This mapping is required when hosting the Web UI in Azure App Service. Without this mapping, the `config.json` file is failed to be served.
