### PR TITLE
Fix user basic error & angular route issue in azure

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectController.cs
@@ -40,7 +40,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="getAll">Get all projects</param>
         /// <returns>List of the project</returns>
         [HttpGet]
-        [Authorize(Policy = AuthorizePolicy.ProjectMemberAccess)]
+        [Authorize]
         public async Task<IActionResult> GetProjects(string status = null, bool getAll = false)
         {
             _logger.LogInformation("Getting projects. Filtered by status = {status}", status);

--- a/src/Web/opencatapultweb/src/web.config
+++ b/src/Web/opencatapultweb/src/web.config
@@ -1,5 +1,17 @@
 <configuration>
     <system.webServer>
+		<rewrite>
+			<rules>
+			  <rule name="AngularJS Routes" stopProcessing="true">
+				<match url=".*" />
+				<conditions logicalGrouping="MatchAll">
+				  <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+				  <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+				</conditions>
+				<action type="Rewrite" url="/" />
+			  </rule>
+			</rules>
+		</rewrite>
       <staticContent>
         <remove fileExtension=".json"/>
         <mimeMap fileExtension=".json" mimeType="application/json"/>


### PR DESCRIPTION
## Summary
- When a basic user that has not been assigned to any project tried to login, it'll get 403 error because she does not have a project access in his claim when trying to invoke `GET /project`. My proposal is to change the authorization policy to use `Authorize` so the project claim does not need to be checked. The logic inside the `GET /project` is already getting the project that the current user is a member.

- The current azure app service deployment does not seem to be able to handle angular router properly. This PR also tried to fix this by adding a rewrite rule in the web.config (ref: https://stackoverflow.com/questions/42321275/need-to-fix-routing-issue-with-angular-2-running-on-an-azure-app-service/42872500). However it haven't been tested in real azure app service deployment
