### PR TITLE
Fix azure web deployment could not load yaml file

### DIFF
--- a/src/Web/opencatapultweb/src/web.config
+++ b/src/Web/opencatapultweb/src/web.config
@@ -14,7 +14,9 @@
 		</rewrite>
       <staticContent>
         <remove fileExtension=".json"/>
+        <remove fileExtension=".yaml"/>
         <mimeMap fileExtension=".json" mimeType="application/json"/>
+        <mimeMap fileExtension=".yaml" mimeType="text/x-yaml" />
       </staticContent>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
## Summary
Fix 404 error that happened in Web in AzureAppService deployment when trying to request for yaml file, e.g. `sample.yaml` template file