### PR TITLE
Fix issue email not sent when adding new user via project member

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/IProjectMemberService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IProjectMemberService.cs
@@ -26,10 +26,11 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <param name="email">Email of the new user</param>
         /// <param name="firstName">First Name of the new user</param>
         /// <param name="lastName">Last Name of the new user</param>
+        /// <param name="password">Password of the new user</param>
         /// <param name="roleId">Id of the role</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>New id of the project member and id of the new user</returns>
-        Task<(int newProjectMemberId, int newUserId)> AddProjectMember(int projectId, string email, string firstName, string lastName, int roleId, CancellationToken cancellationToken = default(CancellationToken));
+        Task<(int newProjectMemberId, int newUserId)> AddProjectMember(int projectId, string email, string firstName, string lastName, string password, int roleId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get members of a project

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectMemberService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectMemberService.cs
@@ -55,7 +55,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             return await _projectMemberRepository.Create(newProjectMember, cancellationToken);
         }
 
-        public async Task<(int newProjectMemberId, int newUserId)> AddProjectMember(int projectId, string email, string firstName, string lastName, int roleId, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<(int newProjectMemberId, int newUserId)> AddProjectMember(int projectId, string email, string firstName, string lastName, string password, int roleId, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
             (int newProjectMemberId, int newUserId) = (0, 0);
@@ -73,7 +73,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             }
 
             var newUser = new User { Email = email, UserName = email, FirstName = firstName, LastName = lastName };
-            newUserId = await _userRepository.Create(newUser, cancellationToken);
+            newUserId = await _userRepository.Create(newUser, password, cancellationToken);
 
             var newProjectMember = new ProjectMember { ProjectId = projectId, ProjectMemberRoleId = roleId, UserId = newUserId };
             newProjectMemberId = await _projectMemberRepository.Create(newProjectMember, cancellationToken);

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/ProjectMemberControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/ProjectMemberControllerTests.cs
@@ -13,6 +13,7 @@ using Polyrific.Catapult.Api.Controllers;
 using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Api.Core.Services;
 using Polyrific.Catapult.Api.UnitTests.Utilities;
+using Polyrific.Catapult.Shared.Common.Notification;
 using Polyrific.Catapult.Shared.Dto.Constants;
 using Polyrific.Catapult.Shared.Dto.ProjectMember;
 using Xunit;
@@ -22,12 +23,16 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
     public class ProjectMemberControllerTests
     {
         private readonly Mock<IProjectMemberService> _projectMemberService;
+        private readonly Mock<IUserService> _userService;
+        private readonly Mock<INotificationProvider> _notificationProvider;
         private readonly IMapper _mapper;
         private readonly Mock<ILogger<ProjectMemberController>> _logger;
 
         public ProjectMemberControllerTests()
         {
             _projectMemberService = new Mock<IProjectMemberService>();
+            _userService = new Mock<IUserService>();
+            _notificationProvider = new Mock<INotificationProvider>();
 
             _mapper = AutoMapperUtils.GetMapper();
 
@@ -56,7 +61,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
                 })
             };
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper,
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper,
                 _logger.Object)
             {
                 ControllerContext = new ControllerContext { HttpContext = httpContext }
@@ -84,7 +89,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
                         ProjectMemberRoleId = 1
                     });
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper, _logger.Object);
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper, _logger.Object);
 
             var dto = new NewProjectMemberDto
             {
@@ -103,7 +108,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         public async void CreateProjectMemberNewUser_ReturnsCreatedProjectMember()
         {
             _projectMemberService
-                .Setup(s => s.AddProjectMember(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Setup(s => s.AddProjectMember(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((1, 1));
             _projectMemberService.Setup(s => s.GetProjectMemberById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((int id, CancellationToken cancellationToken) =>
@@ -114,7 +119,15 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
                         ProjectMemberRoleId = 1
                     });
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper, _logger.Object);
+            var httpContext = new DefaultHttpContext()
+            {
+                Request = { Scheme = "https", Host = new HostString("localhost") }
+            };
+
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper, _logger.Object)
+            {
+                ControllerContext = new ControllerContext { HttpContext = httpContext }
+            };
 
             var dto = new NewProjectMemberDto
             {
@@ -132,7 +145,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         public async void CreateProject_ReturnsBadRequest()
         {
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper, _logger.Object);
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper, _logger.Object);
 
             var dto = new NewProjectMemberDto
             {
@@ -156,7 +169,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
                         ProjectMemberRoleId = 1
                     });
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper,
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper,
                 _logger.Object);
 
             var result = await controller.GetProjectMember(1, 1);
@@ -179,7 +192,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
                         ProjectMemberRoleId = 1
                     });
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper,
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper,
                 _logger.Object);
 
             var result = await controller.GetProjectMemberByUserId(1, 1);
@@ -195,7 +208,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         {
             _projectMemberService.Setup(s => s.UpdateProjectMemberRole(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper, _logger.Object);
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper, _logger.Object);
 
             var result = await controller.UpdateProjectMember(1, 1, new UpdateProjectMemberDto
             {
@@ -208,7 +221,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void UpdateProjectMember_ReturnsBadRequest()
         {
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper, _logger.Object);
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper, _logger.Object);
 
             var result = await controller.UpdateProjectMember(1, 1, new UpdateProjectMemberDto());
 
@@ -242,7 +255,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
                 })
             };
 
-            var controller = new ProjectMemberController(_projectMemberService.Object, _mapper, _logger.Object)
+            var controller = new ProjectMemberController(_projectMemberService.Object, _userService.Object, _notificationProvider.Object, _mapper, _logger.Object)
             {
                 ControllerContext = new ControllerContext { HttpContext = httpContext }
             };

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectMemberServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectMemberServiceTests.cs
@@ -94,7 +94,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             _userRepository.Setup(s => s.GetByUserName(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((string email, CancellationToken cancellationToken) =>
                     userData.FirstOrDefault(u => u.UserName.ToLower() == email.ToLower()));
-            _userRepository.Setup(r => r.Create(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            _userRepository.Setup(r => r.Create(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(2);
         }
 
@@ -143,7 +143,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void AddProjectMember_NewUser()
         {
             var projectMemberService = new ProjectMemberService(_projectMemberRepository.Object, _projectRepository.Object, _userRepository.Object);
-            var (memberId, userId) = await projectMemberService.AddProjectMember(1, "user@example.com", "New", "User", 1);
+            var (memberId, userId) = await projectMemberService.AddProjectMember(1, "user@example.com", "New", "User", "password", 1);
 
             Assert.True(_data.Count > 1);
             Assert.True(memberId > 1);
@@ -163,7 +163,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddProjectMember_DuplicateEmail()
         {
             var projectMemberService = new ProjectMemberService(_projectMemberRepository.Object, _projectRepository.Object, _userRepository.Object);
-            var exception = Record.ExceptionAsync(() => projectMemberService.AddProjectMember(1, "test@test.com", "New", "User", 1));
+            var exception = Record.ExceptionAsync(() => projectMemberService.AddProjectMember(1, "test@test.com", "New", "User", "password", 1));
 
             Assert.IsType<DuplicateUserEmailException>(exception?.Result);
         }


### PR DESCRIPTION
## Summary
Currently when we're adding a new user in Project Member page, the new user would not get the registration email to confirm her account. I fix this for now by copying the code in `POST account/register` into the create project member controller. 

Later when implementing the #469, we can then move the `Create User` logic, including the notification, into the service, so it can be called both in `account/register` and `project/member`. 