### PR TITLE
API: Show default html file when not in Development

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Startup.cs
+++ b/src/API/Polyrific.Catapult.Api/Startup.cs
@@ -149,6 +149,14 @@ namespace Polyrific.Catapult.Api
             {
                 app.UseHttpsRedirection();
                 app.UseHsts();
+                app.UseDefaultFiles(new DefaultFilesOptions
+                {
+                    DefaultFileNames = new List<string>
+                    {
+                        "Default.html"
+                    }
+                });
+                app.UseStaticFiles();
             }
 
             app.UseCorrelationId();

--- a/src/API/Polyrific.Catapult.Api/wwwroot/Default.html
+++ b/src/API/Polyrific.Catapult.Api/wwwroot/Default.html
@@ -1,0 +1,13 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Opencatapult API</title>
+</head>
+<body>
+    <h1>Opencatapult API</h1>
+    <p>
+        This is the Opencatapult API site. For more information related to the API, please follow the link <a href="https://docs.opencatapult.net/references/api" target="_blank">here</a>.
+    </p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Show a default html static file when opening API website hosted not in Development enviroment