### PR TITLE
Improve data model web UI to display suggestion

### DIFF
--- a/src/Web/opencatapultweb/package.json
+++ b/src/Web/opencatapultweb/package.json
@@ -28,6 +28,7 @@
     "hammerjs": "^2.0.8",
     "js-yaml": "^3.12.1",
     "jwt-decode": "^2.2.0",
+    "pluralize": "^7.0.0",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26"

--- a/src/Web/opencatapultweb/src/app/core/constants/property-data-types.ts
+++ b/src/Web/opencatapultweb/src/app/core/constants/property-data-types.ts
@@ -7,5 +7,6 @@ export const propertyDataTypes: [string, string][] = [
   [PropertyDataType.Float, 'Float'],
   [PropertyDataType.Double, 'Double'],
   [PropertyDataType.Decimal, 'Decimal'],
-  [PropertyDataType.Boolean, 'Boolean']
+  [PropertyDataType.Boolean, 'Boolean'],
+  [PropertyDataType.DateTime, 'DateTime']
 ];

--- a/src/Web/opencatapultweb/src/app/core/enums/property-data-type.ts
+++ b/src/Web/opencatapultweb/src/app/core/enums/property-data-type.ts
@@ -2,12 +2,12 @@ export enum PropertyDataType {
   String = 'string',
   Integer = 'int',
   Short = 'short',
+  Byte = 'byte',
   Float = 'float',
   Double = 'double',
   Decimal = 'decimal',
   Boolean = 'bool',
   DateTime = 'datetime',
-  Byte = 'byte',
   Guid = 'guid',
   DbGeography = 'dbgeography'
 }

--- a/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-form/data-model-form.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-form/data-model-form.component.spec.ts
@@ -4,6 +4,7 @@ import { DataModelFormComponent } from './data-model-form.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule, MatCheckboxModule } from '@angular/material';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CoreModule } from '@app/core';
 
 describe('DataModelFormComponent', () => {
   let component: DataModelFormComponent;
@@ -16,7 +17,8 @@ describe('DataModelFormComponent', () => {
         BrowserAnimationsModule,
         ReactiveFormsModule,
         MatInputModule,
-        MatCheckboxModule
+        MatCheckboxModule,
+        CoreModule
       ]
     })
     .compileComponents();

--- a/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-form/data-model-form.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-form/data-model-form.component.ts
@@ -3,6 +3,7 @@ import { DataModelDto } from '@app/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { TextHelperService } from '@app/core/services/text-helper.service';
 
 @Component({
   selector: 'app-data-model-form',
@@ -16,7 +17,10 @@ export class DataModelFormComponent implements OnInit, OnChanges {
   dataModelForm: FormGroup;
   private dataModelName = new Subject<string>();
 
-  constructor(private fb: FormBuilder) { }
+  constructor(
+    private fb: FormBuilder,
+    private textHelperService: TextHelperService
+    ) { }
 
   ngOnInit() {
     this.dataModelForm = this.fb.group({
@@ -62,7 +66,8 @@ export class DataModelFormComponent implements OnInit, OnChanges {
       }
 
       this.dataModelForm.patchValue({
-        name: dataModelName
+        name: dataModelName,
+        label: this.textHelperService.humanizeText(dataModelName)
       });
     });
   }

--- a/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.html
+++ b/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.html
@@ -1,7 +1,7 @@
 <div [formGroup]="dataModelPropertyForm">
   <mat-form-field class="full-width-input">
     <mat-label>Name</mat-label>
-    <input #propertyNameInput matInput placeholder="Name of the proerty"
+    <input #propertyNameInput matInput placeholder="Name of the property"
       formControlName="name" required (input)="onNameChanged(propertyNameInput.value)">
     <mat-error *ngIf="isFieldInvalid('name', 'required')">
       Please inform the property name
@@ -12,7 +12,7 @@
     <input matInput placeholder="The display label of the property" formControlName="label">
   </mat-form-field>
   <mat-form-field class="full-width-input">
-    <mat-select placeholder="Data Type" formControlName="dataType">
+    <mat-select placeholder="Data Type" formControlName="dataType" (selectionChange)="onDataTypeChanged($event)">
       <mat-option *ngFor="let dataType of propertyDataTypes" [value]="dataType[0]">
         {{dataType[1]}}
       </mat-option>
@@ -34,7 +34,7 @@
   <mat-divider class="margin10"></mat-divider>
 
   <mat-form-field class="full-width-input">
-    <mat-select #relatedDataModelControl placeholder="Related Data Model" formControlName="relatedProjectDataModelId">
+    <mat-select #relatedDataModelControl placeholder="Related Data Model" formControlName="relatedProjectDataModelId" (selectionChange)="onRelatedDataModelChanged($event)">
       <mat-option *ngFor="let relatedDataModel of relatedDataModels" [value]="relatedDataModel.id">
         {{relatedDataModel.name}}
       </mat-option>
@@ -42,16 +42,16 @@
   </mat-form-field>
 
   <mat-form-field class="full-width-input">
-    <mat-select #relationalTypeControl placeholder="Relational Type" formControlName="relationalType">
+    <mat-select #relationalTypeControl placeholder="Relational Type" formControlName="relationalType" (selectionChange)="onRelationalTypeChanged($event)">
       <mat-option *ngFor="let relationalType of propertyRelationalTypes" [value]="relationalType[0]">
         {{relationalType[1]}}
       </mat-option>
     </mat-select>
     <mat-hint *ngIf="relationalTypeControl.selected != null">
       <div [ngSwitch]="relationalTypeControl.value">
-        <div *ngSwitchCase="'one-to-one'">One {{dataModelName}} related to one {{relatedDataModelControl.selected.viewValue}}</div>
-        <div *ngSwitchCase="'one-to-many'">One {{dataModelName}} related to many {{relatedDataModelControl.selected.viewValue}}</div>
-        <div *ngSwitchCase="'many-to-many'">many {{dataModelName}} related to many {{relatedDataModelControl.selected.viewValue}}</div>
+        <div *ngSwitchCase="'one-to-one'">One {{dataModelName}} related to one {{relatedDataModelControl.selected ? relatedDataModelControl.selected.viewValue : ''}}</div>
+        <div *ngSwitchCase="'one-to-many'">One {{dataModelName}} related to many {{relatedDataModelControl.selected ? relatedDataModelControl.selected.viewValue : ''}}</div>
+        <div *ngSwitchCase="'many-to-many'">many {{dataModelName}} related to many {{relatedDataModelControl.selected ? relatedDataModelControl.selected.viewValue : ''}}</div>
       </div>
     </mat-hint>
   </mat-form-field>

--- a/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.spec.ts
@@ -4,6 +4,7 @@ import { DataModelPropertyFormComponent } from './data-model-property-form.compo
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule, MatCheckboxModule, MatSelectModule, MatDividerModule } from '@angular/material';
+import { CoreModule } from '@app/core';
 
 describe('DataModelPropertyFormComponent', () => {
   let component: DataModelPropertyFormComponent;
@@ -18,7 +19,8 @@ describe('DataModelPropertyFormComponent', () => {
         MatInputModule,
         MatCheckboxModule,
         MatSelectModule,
-        MatDividerModule
+        MatDividerModule,
+        CoreModule
       ]
     })
     .compileComponents();

--- a/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.ts
@@ -1,9 +1,14 @@
 import { Component, OnInit, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
-import { DataModelPropertyDto, propertyDataTypes, propertyControlTypes, DataModelDto } from '@app/core';
+import { DataModelPropertyDto, propertyDataTypes, propertyControlTypes,
+  DataModelDto, PropertyDataType, PropertyControlType } from '@app/core';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { propertyRelationalTypes } from '@app/core/constants/property-relational-types';
+import { TextHelperService } from '@app/core/services/text-helper.service';
+import { MatSelectChange } from '@angular/material';
+import { PropertyRelationalType } from '@app/core/enums/property-relational-type';
+import * as pluralize from 'pluralize';
 
 @Component({
   selector: 'app-data-model-property-form',
@@ -21,16 +26,55 @@ export class DataModelPropertyFormComponent implements OnInit, OnChanges {
   propertyControlTypes = propertyControlTypes;
   propertyRelationalTypes = propertyRelationalTypes;
 
+  private propertyDefinition = {
+    [PropertyDataType.String]: PropertyControlType.InputText,
+    [PropertyDataType.Integer]: PropertyControlType.InputNumber,
+    [PropertyDataType.Short]: PropertyControlType.InputNumber,
+    [PropertyDataType.Byte]: PropertyControlType.InputNumber,
+    [PropertyDataType.Double]: PropertyControlType.InputNumber,
+    [PropertyDataType.Decimal]: PropertyControlType.InputNumber,
+    [PropertyDataType.Float]: PropertyControlType.InputNumber,
+    [PropertyDataType.DateTime]: PropertyControlType.Calendar,
+    [PropertyDataType.Boolean]: PropertyControlType.Checkbox,
+    [PropertyDataType.Guid]: PropertyControlType.InputText,
+    [PropertyDataType.DbGeography]: PropertyControlType.InputText
+  };
+
+  private propertySuggestion: { [key: string]: { dataType: string, controlType: string }} = {
+    ['date']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['lastupdated']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['lastaccessed']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['datecreated']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['duedate']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['publishdate']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['datepublished']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['publishon']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['startdate']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['enddate']: { dataType: PropertyDataType.DateTime, controlType: PropertyControlType.Calendar },
+    ['notes']: { dataType: PropertyDataType.String, controlType: PropertyControlType.Textarea},
+    ['description']: { dataType: PropertyDataType.String, controlType: PropertyControlType.Textarea },
+    ['summary']: { dataType: PropertyDataType.String, controlType: PropertyControlType.Textarea },
+    ['name']: { dataType: PropertyDataType.String, controlType: PropertyControlType.InputText },
+    ['url']: { dataType: PropertyDataType.String, controlType: PropertyControlType.InputText },
+    ['city']: { dataType: PropertyDataType.String, controlType: PropertyControlType.InputText },
+    ['title']: { dataType: PropertyDataType.String, controlType: PropertyControlType.InputText },
+    ['price']: { dataType: PropertyDataType.Decimal, controlType: PropertyControlType.InputNumber  },
+    ['status']: { dataType: PropertyDataType.Boolean, controlType: PropertyControlType.Checkbox }
+  };
+
   private dataModelPropertyName = new Subject<string>();
 
-  constructor(private fb: FormBuilder) { }
+  constructor(
+    private fb: FormBuilder,
+    private textHelperService: TextHelperService
+    ) { }
 
   ngOnInit() {
     this.dataModelPropertyForm = this.fb.group({
       name: [{value: null, disabled: this.disableForm}, Validators.required],
       label: [{value: null, disabled: this.disableForm}],
-      dataType: [{value: null, disabled: this.disableForm}],
-      controlType: [{value: null, disabled: this.disableForm}],
+      dataType: [{value: PropertyDataType.String, disabled: this.disableForm}],
+      controlType: [{value: PropertyControlType.InputText, disabled: this.disableForm}],
       isRequired: [{value: false, disabled: this.disableForm}],
       relatedProjectDataModelId: [{value: null, disabled: this.disableForm}],
       relationalType: [{value: null, disabled: this.disableForm}],
@@ -61,9 +105,35 @@ export class DataModelPropertyFormComponent implements OnInit, OnChanges {
     this.dataModelPropertyName.next(name);
   }
 
+  onDataTypeChanged(event: MatSelectChange) {
+    this.dataModelPropertyForm.patchValue({controlType: this.propertyDefinition[event.value]});
+  }
+
+  onRelatedDataModelChanged(event: MatSelectChange) {
+    // @ts-ignore
+    this.dataModelPropertyName.next(event.source.selected.viewValue);
+
+    this.dataModelPropertyForm.patchValue({
+      dataType: PropertyDataType.String,
+      controlType: PropertyControlType.InputText
+    });
+  }
+
+  onRelationalTypeChanged(event: MatSelectChange) {
+    if (!this.dataModelPropertyForm.value.name) {
+      return;
+    }
+
+    if (event.value === PropertyRelationalType.OneToOne) {
+      this.dataModelPropertyName.next(pluralize.singular(this.dataModelPropertyForm.value.name));
+    } else {
+      this.dataModelPropertyName.next(pluralize.plural(this.dataModelPropertyForm.value.name));
+    }
+  }
+
   normalizeDataModelPropertyName() {
     this.dataModelPropertyName.pipe(
-      debounceTime(300),
+      debounceTime(200),
       distinctUntilChanged()
     ).subscribe(propertyName => {
       propertyName = propertyName.trim();
@@ -72,8 +142,17 @@ export class DataModelPropertyFormComponent implements OnInit, OnChanges {
       }
 
       this.dataModelPropertyForm.patchValue({
-        name: propertyName
+        name: propertyName,
+        label: this.textHelperService.humanizeText(propertyName)
       });
+
+      const suggestion = this.propertySuggestion[propertyName.toLowerCase()];
+      if (suggestion) {
+        this.dataModelPropertyForm.patchValue({
+          dataType: suggestion.dataType,
+          controlType: suggestion.controlType
+        });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Automatically update label when entering model and property name
- Suggest Data Type and Control type based on entered property name
- Suggest control type based on selected data type
- Update property name & label to related entity name when related entity is selected
- modify property name & label to plural/singular when relational type is selected
