### PR TITLE
Fix checkbox task config always checked

### DIFF
--- a/src/Web/opencatapultweb/src/app/shared/components/additional-config-form/additional-config-form.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/additional-config-form/additional-config-form.component.spec.ts
@@ -4,6 +4,7 @@ import { AdditionalConfigFormComponent } from './additional-config-form.componen
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
 import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 describe('AdditionalConfigFormComponent', () => {
   let component: AdditionalConfigFormComponent;
@@ -12,7 +13,8 @@ describe('AdditionalConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ],
+      providers: [ UtilityService ]
     })
     .compileComponents();
   }));

--- a/src/Web/opencatapultweb/src/app/shared/components/additional-config-form/additional-config-form.component.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/additional-config-form/additional-config-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnChanges, Input, Output, EventEmitter, SimpleChanges } from '@angular/core';
 import { TaskProviderDto, AdditionalConfigDto } from '@app/core';
 import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 @Component({
   selector: 'app-additional-config-form',
@@ -17,7 +18,10 @@ export class AdditionalConfigFormComponent implements OnInit, OnChanges {
   requiredAdditionalConfigs: AdditionalConfigDto[] = [];
   optionalAdditionalConfigs: AdditionalConfigDto[] = [];
 
-  constructor(private fb: FormBuilder) {
+  constructor(
+    private fb: FormBuilder,
+    private utilityService: UtilityService
+    ) {
     this.additionalConfigs = this.additionalConfigs || {};
   }
 
@@ -29,9 +33,10 @@ export class AdditionalConfigFormComponent implements OnInit, OnChanges {
     if (changes.taskProvider && !changes.taskProvider.firstChange) {
 
       if (this.taskProvider.additionalConfigs && this.taskProvider.additionalConfigs.length > 0) {
+        const normalizedAdditionalConfig = this.utilityService.convertStringToBoolean(this.additionalConfigs);
         this.showForm = true;
         for (const additionalConfig of this.taskProvider.additionalConfigs) {
-          const additionalConfigValue = this.additionalConfigs ? this.additionalConfigs[additionalConfig.name] : null;
+          const additionalConfigValue = normalizedAdditionalConfig ? normalizedAdditionalConfig[additionalConfig.name] : null;
           const additionalConfigControl = additionalConfig.isRequired ? new FormControl(additionalConfigValue, Validators.required)
             : new FormControl(additionalConfigValue);
           this.additionalConfigForm.setControl(additionalConfig.name, additionalConfigControl);

--- a/src/Web/opencatapultweb/src/app/shared/components/pull-task-config-form/pull-task-config-form.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/pull-task-config-form/pull-task-config-form.component.spec.ts
@@ -5,6 +5,7 @@ import { AdditionalConfigFormComponent } from '../additional-config-form/additio
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
 import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 describe('CloneTaskConfigFormComponent', () => {
   let component: PullTaskConfigFormComponent;
@@ -13,7 +14,8 @@ describe('CloneTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ PullTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ],
+      providers: [ UtilityService ]
     })
     .compileComponents();
   }));

--- a/src/Web/opencatapultweb/src/app/shared/components/pull-task-config-form/pull-task-config-form.component.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/pull-task-config-form/pull-task-config-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input, OnChanges, Output, EventEmitter, SimpleChanges } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { JobTaskDefinitionType } from '@app/core';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 @Component({
   selector: 'app-pull-task-config-form',
@@ -15,7 +16,8 @@ export class PullTaskConfigFormComponent implements OnInit, OnChanges {
   showForm: boolean;
 
   constructor(
-    private fb: FormBuilder
+    private fb: FormBuilder,
+    private utilityService: UtilityService
   ) {
     this.pullConfigForm = this.fb.group({
       Repository: [null, Validators.required],
@@ -35,7 +37,7 @@ export class PullTaskConfigFormComponent implements OnInit, OnChanges {
     this.showForm = this.taskType === JobTaskDefinitionType.Pull;
 
     if (changes.taskConfigs && this.taskConfigs) {
-      this.pullConfigForm.patchValue(this.taskConfigs);
+      this.pullConfigForm.patchValue(this.utilityService.convertStringToBoolean(this.taskConfigs));
     }
   }
 

--- a/src/Web/opencatapultweb/src/app/shared/components/push-task-config-form/push-task-config-form.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/push-task-config-form/push-task-config-form.component.spec.ts
@@ -5,6 +5,7 @@ import { AdditionalConfigFormComponent } from '../additional-config-form/additio
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
 import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 describe('PushTaskConfigFormComponent', () => {
   let component: PushTaskConfigFormComponent;
@@ -13,7 +14,8 @@ describe('PushTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ PushTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ],
+      providers: [ UtilityService ]
     })
     .compileComponents();
   }));

--- a/src/Web/opencatapultweb/src/app/shared/components/push-task-config-form/push-task-config-form.component.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/push-task-config-form/push-task-config-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnChanges, Input, SimpleChanges, Output, EventEmitter } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { JobTaskDefinitionType } from '@app/core';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 @Component({
   selector: 'app-push-task-config-form',
@@ -14,7 +15,10 @@ export class PushTaskConfigFormComponent implements OnInit, OnChanges {
   pushConfigForm: FormGroup;
   showForm: boolean;
 
-  constructor(private fb: FormBuilder) {
+  constructor(
+    private fb: FormBuilder,
+    private utilityService: UtilityService
+    ) {
     this.pushConfigForm = this.fb.group({
       Repository: [null, Validators.required],
       SourceLocation: null,
@@ -37,7 +41,7 @@ export class PushTaskConfigFormComponent implements OnInit, OnChanges {
     this.showForm = this.taskType === JobTaskDefinitionType.Push;
 
     if (changes.taskConfigs && this.taskConfigs) {
-      this.pushConfigForm.patchValue(this.taskConfigs);
+      this.pushConfigForm.patchValue(this.utilityService.convertStringToBoolean(this.taskConfigs));
     }
   }
 

--- a/src/Web/opencatapultweb/src/app/shared/components/task-config-form/task-config-form.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/shared/components/task-config-form/task-config-form.component.spec.ts
@@ -17,6 +17,7 @@ import { CoreModule } from '@app/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DeleteRepositoryConfigFormComponent } from '../delete-repository-config-form/delete-repository-config-form.component';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 describe('TaskConfigFormComponent', () => {
   let component: TaskConfigFormComponent;
@@ -48,6 +49,9 @@ describe('TaskConfigFormComponent', () => {
         CoreModule,
         HttpClientTestingModule,
         MatSelectModule
+      ],
+      providers: [
+        UtilityService
       ]
     })
     .compileComponents();

--- a/src/Web/opencatapultweb/src/app/shared/services/utility.service.spec.ts
+++ b/src/Web/opencatapultweb/src/app/shared/services/utility.service.spec.ts
@@ -1,0 +1,14 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UtilityService } from './utility.service';
+
+describe('UtilityService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [UtilityService]
+  }));
+
+  it('should be created', () => {
+    const service: UtilityService = TestBed.get(UtilityService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/Web/opencatapultweb/src/app/shared/services/utility.service.ts
+++ b/src/Web/opencatapultweb/src/app/shared/services/utility.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class UtilityService {
+
+  constructor() { }
+
+  convertStringToBoolean(dictionary: { [key: string]: string}): { [key: string]: any } {
+    if (dictionary) {
+      const convertedDictionary: { [key: string]: any } = {};
+
+      for (const key in dictionary) {
+        if (typeof key === 'string') {
+          const value = dictionary[key];
+          if (typeof value === 'string' && (value.toLowerCase() === 'true' || value.toLowerCase() === 'false')) {
+            convertedDictionary[key] = value === 'true';
+          } else {
+            convertedDictionary[key] = value;
+          }
+        }
+      }
+
+      return convertedDictionary;
+    }
+
+    return dictionary;
+  }
+}

--- a/src/Web/opencatapultweb/src/app/shared/shared.module.ts
+++ b/src/Web/opencatapultweb/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { HasAccessDirective } from './directives/has-access.directive';
 import { DeleteRepositoryConfigFormComponent } from './components/delete-repository-config-form/delete-repository-config-form.component';
 import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { ExternalAccountFormComponent } from './components/external-account-form/external-account-form.component';
+import { UtilityService } from './services/utility.service';
 
 @NgModule({
   declarations: [
@@ -97,7 +98,8 @@ export class SharedModule {
     return {
       ngModule: SharedModule,
       providers: [
-        SnackbarService
+        SnackbarService,
+        UtilityService
       ]
     };
   }


### PR DESCRIPTION
## Summary
Fix the checkbox in task config and additional config always get checked due to the config object is deserialized from `Dictionary<string, string>` type, and the `'false'` string in javascript is truthy 