### PR TITLE
Modify the order of deleting a project in engine

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngine.cs
@@ -67,14 +67,6 @@ namespace Polyrific.Catapult.Engine.Core
                         jobQueue.Status = JobStatus.Error;
                     else
                         jobQueue.Status = JobStatus.Completed;
-
-                    if (jobQueue.Status == JobStatus.Completed && 
-                        jobQueue.IsDeletion && 
-                        jobQueue.ProjectStatus == ProjectStatusFilterType.Deleting)
-                    {
-                        _logger.LogInformation($"Deleting project {jobQueue.ProjectId}");
-                        await _projectService.DeleteProjectByEngine(jobQueue.ProjectId);
-                    }
                 }
                 catch (Exception ex)
                 {
@@ -98,6 +90,14 @@ namespace Polyrific.Catapult.Engine.Core
                 await _jobLogWriter.EndJobLog(jobQueue.Id);
 
                 await _jobQueueService.SendNotification(jobQueue.ProjectId, jobQueue.Id);
+
+                if (jobQueue.Status == JobStatus.Completed &&
+                    jobQueue.IsDeletion &&
+                    jobQueue.ProjectStatus == ProjectStatusFilterType.Deleting)
+                {
+                    _logger.LogInformation($"Deleting project {jobQueue.ProjectId}");
+                    await _projectService.DeleteProjectByEngine(jobQueue.ProjectId);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Make the project deletion run last in engine when running deletion job. This is to avoid error when calling SendNotification endpoint, which still require the current Project/Job to be in the database
