### PR TITLE
Fix job queue log hang

### DIFF
--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { JobLogDto } from '@app/core/models/job-queue/job-log-dto';
 import { JobStatus } from '@app/core/enums/job-status';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-job-queue-log',
@@ -53,7 +54,9 @@ export class JobQueueLogComponent implements OnInit, OnDestroy {
   listenQueueLog() {
     this.log$ = this.jobQueueService.listenJobQueueLog(this.projectId, this.jobQueueId);
     let previousTask = '';
-    this.log$.subscribe((log) => {
+    this.log$
+      .pipe(finalize(() => this.getJobQueue()))
+      .subscribe((log) => {
       if (previousTask !== log.taskName) {
         previousTask = log.taskName;
         this.getJobQueue();


### PR DESCRIPTION
## Summary
After investigation, I think the job queue log got hang because the connection is closed prematurely.

This is happened because there's so many message in the queue that there's actually a delay between what is currently sent by the engine, and what is received by the client. The connection closed prematurely because the engine is already in the closing state, and it had sent the event of  `EndJob`, which will make the signalr client to be closed.

My solution is to retrieve all of the log from the API using `queue/{id}/logs` endpoint when the `EndJob` event is received. 

Note that this will need testing in the azure deployment, since I cannot reproduce the same issue in the local. However, I've tested that the changes does not affect the workflow in the local environment.