### PR TITLE
Several bugfix in job queue

### DIFF
--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.html
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.html
@@ -1,6 +1,6 @@
 <div class="margin10" fxLayout="row" fxLayoutAlign="space-between center">
   <div fxLayout="row"  fxLayoutAlign="flex-start center">
-      <a mat-button routerLink="../">
+      <a mat-button routerLink="../list/{{currentJobQueueTab}}">
         <mat-icon>arrow_back</mat-icon>
       </a>
       <h4>Job Queue</h4>
@@ -49,11 +49,6 @@
   <div fxLayout="row">
     <div fxFlex="10" fxFlex.sm="30" fxFlex.xs="40">Origin Url</div>
     <div>{{jobQueue?.originUrl}}</div>
-  </div>
-  <mat-divider></mat-divider>
-  <div fxLayout="row">
-    <div fxFlex="10" fxFlex.sm="30" fxFlex.xs="40">Output Values</div>
-    <div *ngIf="jobQueue?.outputValues">{{jobQueue?.outputValues | json}}</div>
   </div>
   <mat-divider></mat-divider>
   <div fxLayout="row">

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-detail/job-queue-detail.component.ts
@@ -17,6 +17,7 @@ export class JobQueueDetailComponent implements OnInit {
   allowRestart: boolean;
   allowCancel: boolean;
   allowRefresh: boolean;
+  currentJobQueueTab: string;
   constructor(
     private route: ActivatedRoute,
     private jobQueueService: JobQueueService,
@@ -43,6 +44,14 @@ export class JobQueueDetailComponent implements OnInit {
       jobQueue.status === JobStatus.Error;
     this.allowCancel = jobQueue.status === JobStatus.Processing || jobQueue.status === JobStatus.Pending;
     this.allowRefresh = jobQueue.status !== JobStatus.Completed;
+
+    if (this.jobQueue.status === JobStatus.Pending) {
+      this.currentJobQueueTab = 'pending';
+    } else if (this.jobQueue.status === JobStatus.Queued || this.jobQueue.status === JobStatus.Processing) {
+      this.currentJobQueueTab = 'current';
+    } else {
+      this.currentJobQueueTab = 'past';
+    }
   }
 
   getJobQueue() {

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-list/job-queue-list.component.html
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-list/job-queue-list.component.html
@@ -1,8 +1,8 @@
 <div class="margin10"></div>
-<div class="no-records" *ngIf="jobList?.length <= 0">
+<div class="no-records" *ngIf="dataSource.data.length <= 0">
   No Jobs Found
 </div>
-<table mat-table [dataSource]="dataSource" matSort matSortActive="created" matSortDirection="desc" *ngIf="jobList?.length > 0" class="mat-elevation-z8">
+<table mat-table [dataSource]="dataSource" matSort matSortActive="created" matSortDirection="desc" *ngIf="dataSource.data?.length > 0" class="mat-elevation-z8">
 
   <!--- Note that these columns can be defined in any order.
         The actual rendered columns are set as a property on the row definition" -->
@@ -29,11 +29,11 @@
   <ng-container matColumnDef="actions">
     <th mat-header-cell *matHeaderCellDef> </th>
     <td mat-cell *matCellDef="let element" class="action-buttons">
-        <button mat-icon-button routerLink="{{element.id}}"
+        <button mat-icon-button routerLink="../../{{element.id}}"
           matTooltip="Info">
           <mat-icon>info</mat-icon>
         </button>
-        <button mat-icon-button routerLink="{{element.id}}/logs"
+        <button mat-icon-button routerLink="../../{{element.id}}/logs"
           matTooltip="View Logs">
           <mat-icon>description</mat-icon>
         </button>
@@ -43,4 +43,4 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
-<mat-paginator [pageSizeOptions]="[10, 20, 30]" showFirstLastButtons *ngIf="jobList?.length > 0 && usePaging"></mat-paginator>
+<mat-paginator [pageSizeOptions]="[10, 20, 30]" showFirstLastButtons *ngIf="dataSource.data?.length > 0 && usePaging"></mat-paginator>

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-list/job-queue-list.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-list/job-queue-list.component.spec.ts
@@ -6,6 +6,8 @@ import { MatTabsModule, MatIconModule, MatBadgeModule, MatTableModule, MatButton
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { JobQueueStatusComponent } from '../components/job-queue-status/job-queue-status.component';
 import { RouterTestingModule } from '@angular/router/testing';
+import { CoreModule } from '@app/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('JobQueueListComponent', () => {
   let component: JobQueueListComponent;
@@ -26,7 +28,9 @@ describe('JobQueueListComponent', () => {
         FlexLayoutModule,
         MatPaginatorModule,
         MatSortModule,
-        MatChipsModule
+        MatChipsModule,
+        CoreModule,
+        HttpClientTestingModule
       ]
     })
     .compileComponents();

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.css
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.css
@@ -13,3 +13,7 @@
   justify-content: flex-end;
   align-items: center;
 }
+
+.action-buttons button {
+  margin-left: 10px;
+}

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.html
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-log/job-queue-log.component.html
@@ -5,6 +5,10 @@
       </a>
       <h4>Job Queue Log</h4>
   </div>
+  <div class="action-buttons">
+    <button mat-raised-button color="accent" (click)="onCancelClick()" *ngIf="allowCancel">Cancel</button>
+    <button mat-raised-button color="primary" (click)="onRestartClick()" *ngIf="allowRestart">Restart</button>
+  </div>
 </div>
 
 <div fxLayout="column" fxLayoutAlign="center center" *ngIf="jobQueue?.status === 'QUEUED'">

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-routing.module.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue-routing.module.ts
@@ -5,11 +5,19 @@ import { JobQueueDetailComponent } from './job-queue-detail/job-queue-detail.com
 import { JobQueueLogComponent } from './job-queue-log/job-queue-log.component';
 import { JobQueueResolverService } from './services/job-queue-resolver.service';
 import { JobQueueErrorComponent } from './job-queue-error/job-queue-error.component';
+import { JobQueueListComponent } from './job-queue-list/job-queue-list.component';
 
 const routes: Routes = [
   {
-    path: '', component: JobQueueComponent
+    path: 'list', component: JobQueueComponent,
+    children: [
+      {path: '', redirectTo: 'current', pathMatch: 'full'},
+      {path: 'current', component: JobQueueListComponent},
+      {path: 'pending', component: JobQueueListComponent},
+      {path: 'past', component: JobQueueListComponent},
+    ]
   },
+  {path: '', redirectTo: 'list', pathMatch: 'full'},
   {
     path: ':id', component: JobQueueDetailComponent,
     resolve: {

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue/job-queue.component.html
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue/job-queue.component.html
@@ -1,28 +1,15 @@
 <div class="project-module-description">
   <span>Monitor the status of your queued job. (<a href="https://docs.opencatapult.net/home/concept#job-queue" target="_blank">more...</a>)</span>
 </div>
-<mat-tab-group (selectedTabChange)="onTabChanged($event)">
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <span matBadge="{{currentJobs.length}}" matBadgeOverlap="false" [matBadgeHidden]="currentJobs.length <= 0">Current Items</span>
-    </ng-template>
-    <app-loading-spinner *ngIf="loading"></app-loading-spinner>
-    <app-job-queue-list [jobList]="currentJobs" *ngIf="!loading"></app-job-queue-list>
-  </mat-tab>
 
-  <mat-tab>
-    <ng-template mat-tab-label>
-        <span matBadge="{{pendingJobs.length}}" matBadgeOverlap="false" [matBadgeHidden]="pendingJobs.length <= 0">Pending Items</span>
-    </ng-template>
-    <app-loading-spinner *ngIf="loading"></app-loading-spinner>
-    <app-job-queue-list [jobList]="pendingJobs" *ngIf="!loading"></app-job-queue-list>
-  </mat-tab>
-
-  <mat-tab>
-    <ng-template mat-tab-label>
-        <span>Past Items</span>
-    </ng-template>
-    <app-loading-spinner *ngIf="loading"></app-loading-spinner>
-    <app-job-queue-list [jobList]="pastJobs" [usePaging]="true" *ngIf="!loading"></app-job-queue-list>
-  </mat-tab>
-</mat-tab-group>
+<nav mat-tab-nav-bar flex>
+  <a mat-tab-link (click)="getCurrentJobQueues()" [routerLink]="['current']" routerLinkActive #rlaCurrent="routerLinkActive" [active]="rlaCurrent.isActive">
+    <span matBadge="{{currentJobs.length}}" matBadgeOverlap="false" [matBadgeHidden]="currentJobs.length <= 0">Current Items</span>
+  </a>
+  <a mat-tab-link (click)="getCurrentJobQueues()" [routerLink]="['pending']" routerLinkActive #rlaPending="routerLinkActive" [active]="rlaPending.isActive">
+      <span matBadge="{{pendingJobs.length}}" matBadgeOverlap="false" [matBadgeHidden]="pendingJobs.length <= 0">Pending Items</span>
+  </a>
+  <a mat-tab-link (click)="getPastJobQueues()" [routerLink]="['past']" routerLinkActive #rlaPast="routerLinkActive" [active]="rlaPast.isActive">Past Items</a>
+</nav>
+<app-loading-spinner *ngIf="loading"></app-loading-spinner>
+<router-outlet *ngIf="!loading"></router-outlet>

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue/job-queue.component.spec.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue/job-queue.component.spec.ts
@@ -38,17 +38,6 @@ describe('JobQueueComponent', () => {
         CoreModule,
         MatChipsModule,
         SharedModule
-      ],
-      providers: [
-        {
-          provide: ActivatedRoute, useValue: {
-            parent: {
-              parent: {
-                snapshot: { params: of({ id: 1}) }
-              }
-            }
-          }
-        }
       ]
     })
     .compileComponents();

--- a/src/Web/opencatapultweb/src/app/project/job-queue/job-queue/job-queue.component.ts
+++ b/src/Web/opencatapultweb/src/app/project/job-queue/job-queue/job-queue.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { JobQueueService, JobQueueDto, JobQueueFilterType, ProjectService } from '@app/core';
 import { JobStatus } from '@app/core/enums/job-status';
-import { MatTabChangeEvent } from '@angular/material';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-job-queue',
@@ -17,12 +17,18 @@ export class JobQueueComponent implements OnInit {
 
   constructor(
     private jobQueueService: JobQueueService,
-    private projectService: ProjectService
+    private projectService: ProjectService,
+    private router: Router
   ) { }
 
   ngOnInit() {
     this.projectId = this.projectService.currentProjectId;
-    this.getCurrentJobQueues();
+
+    if (this.router.url.toLowerCase().endsWith('past')) {
+      this.getPastJobQueues();
+    } else {
+      this.getCurrentJobQueues();
+    }
   }
 
   getCurrentJobQueues(): void {
@@ -42,14 +48,6 @@ export class JobQueueComponent implements OnInit {
         this.pastJobs = jobs;
         this.loading = false;
       });
-  }
-
-  onTabChanged(evt: MatTabChangeEvent) {
-    if (evt.index === 2) {
-      this.getPastJobQueues();
-    } else {
-      this.getCurrentJobQueues();
-    }
   }
 
 }


### PR DESCRIPTION
## Summary
- Add restart and cancel button in queue log page
- remove output values from job queue detail fields
-  use routing in job queue tabs so when user `back` from job queue detail, it is shown the job queue list containing the opened job queue