### PR TITLE
use notification config like appsettings.json

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Infrastructure/NotificationInjection.cs
+++ b/src/API/Polyrific.Catapult.Api.Infrastructure/NotificationInjection.cs
@@ -21,8 +21,8 @@ namespace Polyrific.Catapult.Api.Infrastructure
                 services.AddSmtpEmailSender(configuration);
             }
 
-            NotificationConfig.InitConfigFile().Wait();
-            services.AddTransient<NotificationConfig>();
+            var notificationConfig = configuration.GetSection("NotificationConfig").Get<NotificationConfig>();
+            services.AddSingleton(notificationConfig);
             services.AddTransient<INotificationProvider, NotificationProvider>();
         }
     }

--- a/src/API/Polyrific.Catapult.Api/Program.cs
+++ b/src/API/Polyrific.Catapult.Api/Program.cs
@@ -49,6 +49,7 @@ namespace Polyrific.Catapult.Api
         public static IConfiguration Configuration { get; } = new ConfigurationBuilder()
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile("notificationconfig.json", optional: false, reloadOnChange: true)
             .AddJsonFile(
                 $"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json",
                 optional: true)

--- a/src/API/Polyrific.Catapult.Api/notificationconfig.json
+++ b/src/API/Polyrific.Catapult.Api/notificationconfig.json
@@ -1,14 +1,18 @@
 {
   "NotificationConfig": {
-    "RegistrationCompleted": "SmtpEmail",
-    "JobQueueCompleted": "SmtpEmail",
-    "ResetPassword": "SmtpEmail",
-    "ResetPasswordWeb": "SmtpEmail",
-    "ProjectDeleted": "SmtpEmail",
-    "RegistrationCompletedSubject": "Catapult - Please confirm your account",
-    "ResetPasswordSubject": "Catapult - Reset password token",
-    "ResetPasswordWebSubject": "Catapult - Reset password token",
-    "ProjectDeletedSubject": "Catapult - Your project has been deleted",
-    "JobQueueCompletedSubject": "Catapult - Your queued job has been completed"
+    "NotificationProviders": {
+      "RegistrationCompleted": "SmtpEmail",
+      "JobQueueCompleted": "SmtpEmail",
+      "ResetPassword": "SmtpEmail",
+      "ResetPasswordWeb": "SmtpEmail",
+      "ProjectDeleted": "SmtpEmail"
+    },
+    "NotificationSubject": {
+      "RegistrationCompleted": "Catapult - Please confirm your account",
+      "ResetPassword": "Catapult - Reset password token",
+      "ResetPasswordWebSub": "Catapult - Reset password token",
+      "ProjectDeletedSubject": "Catapult - Your project has been deleted",
+      "JobQueueCompletedSubject": "Catapult - Your queued job has been completed"
+    }
   }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Common/Notification/NotificationConfig.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/Notification/NotificationConfig.cs
@@ -1,28 +1,15 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Polyrific.Catapult.Shared.Common.Notification
 {
     public class NotificationConfig
     {
-        private static readonly string NotificationConfigFile = Path.Combine(AppContext.BaseDirectory, "notificationconfig.json");
         private const char _arraySplitChar = ',';
-
-        private Dictionary<string, string> _configs;
 
         public NotificationConfig()
         {
-            _configs = new Dictionary<string, string>();
-
-            InitConfigFile(false).Wait();
-
-            Load().Wait();
         }
 
         public const string RegistrationCompleted = "RegistrationCompleted";
@@ -35,68 +22,29 @@ namespace Polyrific.Catapult.Shared.Common.Notification
 
         public const string ProjectDeleted = "ProjectDeleted";
 
+        public Dictionary<string, string> NotificationProviders { get; set; }
+
+        public Dictionary<string, string> NotificationSubject { get; set; }
+        
+
         public string[] GetNotificationProviders(string messageType)
         {
-            return GetConfigArrayValue(messageType, new string[0]);
+            if (NotificationProviders != null && NotificationProviders.ContainsKey(messageType))
+            {
+                return NotificationProviders[messageType].Split(_arraySplitChar);
+            }
+
+            return new string[0];
         }
 
         public string GetNotificationSubject(string messageType)
         {
-            return GetConfigValue($"{messageType}Subject", "");
-        }
-
-        public async Task Load()
-        {
-            var obj = JObject.Parse(await FileHelper.ReadAllTextAsync(NotificationConfigFile));
-            _configs = obj["NotificationConfig"].ToObject<Dictionary<string, string>>();
-
-            // check against default config
-            var defaultConfigs = GetDefaultConfigs();
-            foreach (var conf in defaultConfigs)
+            if (NotificationProviders != null && NotificationProviders.ContainsKey(messageType))
             {
-                if (!_configs.ContainsKey(conf.Key))
-                    _configs.Add(conf.Key, conf.Value);
-            }
-        }
-        
-        public static async Task InitConfigFile(bool reset = false)
-        {
-            if (reset && File.Exists(NotificationConfigFile))
-            {
-                File.Delete(NotificationConfigFile);
+                return NotificationSubject[messageType];
             }
 
-            if (!File.Exists(NotificationConfigFile))
-            {
-                await FileHelper.WriteAllTextAsync(NotificationConfigFile, JsonConvert.SerializeObject(new { NotificationConfig = GetDefaultConfigs() }));
-            }
-        }
-
-        private string[] GetConfigArrayValue(string key, string[] defaultValue)
-        {
-            return _configs.TryGetValue(key, out var sValue) ? sValue.Split(_arraySplitChar) : defaultValue;
-        }
-
-        private string GetConfigValue(string key, string defaultValue)
-        {
-            return _configs.TryGetValue(key, out var sValue) ? sValue : defaultValue;
-        }
-
-        private static Dictionary<string, string> GetDefaultConfigs()
-        {
-            var configs = new Dictionary<string, string>
-            {
-                {RegistrationCompleted, $"{NotificationProvider.SmtpEmail}"},
-                {ResetPassword, $"{NotificationProvider.SmtpEmail}"},
-                {ResetPasswordWeb, $"{NotificationProvider.SmtpEmail}"},
-                {ProjectDeleted, $"{NotificationProvider.SmtpEmail}"},
-                {$"{RegistrationCompleted}Subject", "Catapult - Please confirm your account"},
-                {$"{ResetPassword}Subject", "Catapult - Reset password token"},
-                {$"{ResetPasswordWeb}Subject", "Catapult - Reset password token"},
-                {$"{ProjectDeleted}Subject", "Catapult - Your project has been deleted"}
-            };
-
-            return configs;
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
Fix issue in `notificationconfig.json` that cannot be created in restricted environment. Instead, make the `notificationconfig.json` similar to appsettings.json, that can be deserialized into `IConfiguration` class

## PR Coverages
- Modify service injection of `NotificationConfig`
- Modify the structure of `notificationconfig.json`

## References
- Related Issues: #458 