### PR TITLE
Add Version Page in Web UI

### DIFF
--- a/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.css
+++ b/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.css
@@ -5,3 +5,14 @@ mat-sidenav {
 mat-sidenav button {
   text-align: left;
 }
+
+.version {
+	position: absolute;
+	width: 100%;
+    font-size: 14px;
+    text-align: right;
+    text-decoration: none;
+    color: inherit;
+    bottom: 0.5%;
+    right: 0.5%;
+}

--- a/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.html
+++ b/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.html
@@ -12,5 +12,6 @@
   </mat-sidenav>
   <mat-sidenav-content>
     <router-outlet></router-outlet>
+    <a href="https://releases.opencatapult.net/" target="_blank" class="version">OpenCatapult Web UI {{version}}</a>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.ts
+++ b/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.ts
@@ -8,7 +8,8 @@ import { AuthorizePolicy } from '@app/core';
 })
 export class HomeLayoutComponent implements OnInit {
   authorizePolicyEnum = AuthorizePolicy;
-
+  public version: string = 'v' + require('../../../../package.json').version;
+  
   constructor(
     ) { }
 

--- a/src/Web/opencatapultweb/src/app/layouts/login-layout/login-layout.component.css
+++ b/src/Web/opencatapultweb/src/app/layouts/login-layout/login-layout.component.css
@@ -1,0 +1,10 @@
+.version {
+	position: absolute;
+	width: 100%;
+    font-size: 14px;
+    text-align: right;
+    text-decoration: none;
+    color: inherit;
+    bottom: 0.5%;
+    right: 0.5%;
+}

--- a/src/Web/opencatapultweb/src/app/layouts/login-layout/login-layout.component.html
+++ b/src/Web/opencatapultweb/src/app/layouts/login-layout/login-layout.component.html
@@ -1,1 +1,2 @@
 <router-outlet></router-outlet>
+<a href="https://releases.opencatapult.net/" target="_blank" class="version">OpenCatapult Web UI {{version}}</a>

--- a/src/Web/opencatapultweb/src/app/layouts/login-layout/login-layout.component.ts
+++ b/src/Web/opencatapultweb/src/app/layouts/login-layout/login-layout.component.ts
@@ -6,6 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./login-layout.component.css']
 })
 export class LoginLayoutComponent implements OnInit {
+  public version: string = 'v' + require('../../../../package.json').version;
 
   constructor() { }
 


### PR DESCRIPTION
## Summary
Add a current web version used on footer Web UI

## Coverage
- [x] Add Version Page in Web UI on login layout
- [x] Add Version Page in Web UI on home layout

## References
- Related Issues: https://github.com/Polyrific-Inc/OpenCatapult/issues/485
- Related Work Items:
- Other links:
