### PR TITLE
Fix job queue reference so it does not tied to job definition

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/JobQueue.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/JobQueue.cs
@@ -61,7 +61,15 @@ namespace Polyrific.Catapult.Api.Core.Entities
         /// </summary>
         public int? JobDefinitionId { get; set; }
 
-        public virtual JobDefinition JobDefinition { get; set; }
+        /// <summary>
+        /// Name of the job definition
+        /// </summary>
+        public string JobDefinitionName { get; set; }
+
+        /// <summary>
+        /// Is the job definition is a deletion job?
+        /// </summary>
+        public bool IsDeletion { get; set; }
 
         /// <summary>
         /// JSON string of the job task status

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190507025653_RemoveRelationJobQueueDefinition.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190507025653_RemoveRelationJobQueueDefinition.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190507025653_RemoveRelationJobQueueDefinition")]
+    partial class RemoveRelationJobQueueDefinition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190507025653_RemoveRelationJobQueueDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190507025653_RemoveRelationJobQueueDefinition.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class RemoveRelationJobQueueDefinition : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_JobQueues_JobDefinitions_JobDefinitionId",
+                table: "JobQueues");
+
+            migrationBuilder.DropIndex(
+                name: "IX_JobQueues_JobDefinitionId",
+                table: "JobQueues");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeletion",
+                table: "JobQueues",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "JobDefinitionName",
+                table: "JobQueues",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeletion",
+                table: "JobQueues");
+
+            migrationBuilder.DropColumn(
+                name: "JobDefinitionName",
+                table: "JobQueues");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobQueues_JobDefinitionId",
+                table: "JobQueues",
+                column: "JobDefinitionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_JobQueues_JobDefinitions_JobDefinitionId",
+                table: "JobQueues",
+                column: "JobDefinitionId",
+                principalTable: "JobDefinitions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
+++ b/src/API/Polyrific.Catapult.Api/AutoMapperProfiles/JobQueueAutoMapperProfile.cs
@@ -15,8 +15,6 @@ namespace Polyrific.Catapult.Api.AutoMapperProfiles
             CreateMap<JobQueue, JobDto>()
                 .ForMember(dest => dest.JobTasksStatus, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<List<JobTaskStatusDto>>(src.JobTasksStatus)))
                 .ForMember(dest => dest.OutputValues, opt => opt.MapFrom(src => JsonConvert.DeserializeObject<Dictionary<string, string>>(src.OutputValues)))
-                .ForMember(dest => dest.JobDefinitionName, opt => opt.MapFrom(src => src.JobDefinition.Name))
-                .ForMember(dest => dest.IsDeletion, opt => opt.MapFrom(src => src.JobDefinition.IsDeletion))
                 .ForMember(dest => dest.ProjectStatus, opt => opt.MapFrom(src => src.Project.Status));
 
             CreateMap<NewJobDto, JobDto>();

--- a/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.css
+++ b/src/Web/opencatapultweb/src/app/layouts/home-layout/home-layout.component.css
@@ -12,3 +12,10 @@ mat-sidenav button {
   min-width: 100%;
   width: 100%;
 }
+
+@media(max-width: 600px) {
+  .layout-container {
+    height: calc(100% - 112px);
+    min-height: calc(100% - 112px);
+  }
+}

--- a/src/Web/opencatapultweb/src/app/login/login.component.css
+++ b/src/Web/opencatapultweb/src/app/login/login.component.css
@@ -10,7 +10,10 @@ mat-spinner {
 }
 
 .signin-content {
-    padding: 60px 1rem;
+    padding-left: 1rem;
+    padding-left: 1rem;
+    padding-top: 60px;
+    height: calc(100% - 124px);
 }
 
 mat-progress-bar {
@@ -26,4 +29,10 @@ mat-error {
 
 .forgot-password-link {
   color: #337ab7;
+}
+
+@media (max-width: 600px) {
+  .signin-content {
+      height: calc(100% - 116px);
+  }
 }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -55,11 +55,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                             }
                         }
                     },
-                    JobDefinition = new JobDefinition
-                    {
-                        Id = 1,
-                        Name = "test"
-                    }
+                    JobDefinitionName = "test"
                 }
             };
             


### PR DESCRIPTION
## Summary
Remove the foreign key reference from `JobQueue` to `JobDefinition`, so that a job definition can still be deleted even it has a previously run queue

## Coverage
- [x] Changes in API
- [x] small fix in web ui styling

## References
- Related Issues: #499 
