### PR TITLE
Fix issue in clone project

### DIFF
--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectServiceTests.cs
@@ -38,7 +38,14 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                 {
                     Id = 1,
                     Name = "Project-A",
-                    Status = ProjectStatusFilterType.Active
+                    Status = ProjectStatusFilterType.Active,
+                    Models = new List<ProjectDataModel>
+                    {
+                        new ProjectDataModel
+                        {
+                            Properties = new List<ProjectDataModelProperty>()
+                        }
+                    }
                 }
             };
 


### PR DESCRIPTION
## Summary
Fix issue in clone project where the property with `RelatedDataModelId` is still referencing the model from the source project, instead of the new cloned project.

## Coverage
- [x] Fix clone project api endpoint
