### PR TITLE
Fix package downgrade issue

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Data/Polyrific.Catapult.Api.Data.csproj
+++ b/src/API/Polyrific.Catapult.Api.Data/Polyrific.Catapult.Api.Data.csproj
@@ -114,6 +114,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <!--The System packages below are explicitely refferenced to resolve "package downgrade" issues when publishing the app-->
+    <PackageReference Include="System.Collections" Version="4.3.0"></PackageReference>
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0"></PackageReference>
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0"></PackageReference>
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0"></PackageReference>
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0"></PackageReference>
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0"></PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
This PR fixes the `package downgrade` issue when publishing the API with `win-x64` runtime.