### PR TITLE
Implement default flag for job definition

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/JobDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/JobDefinition.cs
@@ -27,6 +27,11 @@ namespace Polyrific.Catapult.Api.Core.Entities
         public bool IsDeletion { get; set; }
 
         /// <summary>
+        /// Is the job definition is a default job in the project?
+        /// </summary>
+        public bool IsDefault { get; set; }
+
+        /// <summary>
         /// Tasks of the job definition
         /// </summary>
         public virtual ICollection<JobTaskDefinition> Tasks { get; set; }

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/DefaultJobDefinitionNotFoundException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/DefaultJobDefinitionNotFoundException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class DefaultJobDefinitionNotFoundException : Exception
+    {
+        public int ProjectId { get; set; }
+
+        public DefaultJobDefinitionNotFoundException(int projectId)
+            : base($"Project {projectId} does not have a default job definition")
+        {
+            ProjectId = projectId;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/InvalidDefaultJobDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/InvalidDefaultJobDefinition.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class InvalidDefaultJobDefinition : Exception
+    {
+        public InvalidDefaultJobDefinition()
+            : base($"A deletion job definition cannot be set as the default job definition")
+        {
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -14,10 +14,11 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// </summary>
         /// <param name="projectId">Id of the project</param>
         /// <param name="name">Name of the job definition</param>
+        /// <param name="isDefault">Is the job definition is a default job in the project?</param>
         /// <param name="isDeletion">Is the job definition for resource deletion?</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>Id of the new added job definition</returns>
-        Task<int> AddJobDefinition(int projectId, string name, bool isDeletion, CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> AddJobDefinition(int projectId, string name, bool isDefault, bool isDeletion, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Rename a job definition
@@ -27,6 +28,22 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns></returns>
         Task RenameJobDefinition(int id, string newName, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Set a job definition as the default in project
+        /// </summary>
+        /// <param name="id">Id of the job definition</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
+        /// <returns></returns>
+        Task SetJobDefinitionAsDefault(int id, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Get a default job definition in project
+        /// </summary>
+        /// <param name="projectId">Id of the project</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
+        /// <returns></returns>
+        Task<JobDefinition> GetDefaultJobDefinition(int projectId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Delete a job definition

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobQueueService.cs
@@ -21,6 +21,16 @@ namespace Polyrific.Catapult.Api.Core.Services
         Task<int> AddJobQueue(int projectId, string originUrl, string jobType, int? jobDefinitionId, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Queue a new job of default job definition
+        /// </summary>
+        /// <param name="projectId">The project which we queue</param>
+        /// <param name="originUrl">The origin url where the job is queue</param>
+        /// <param name="jobType">The job type</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
+        /// <returns>The new job queue id</returns>
+        Task<int> AddDefaultJobQueue(int projectId, string originUrl, string jobType, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// update a job queue
         /// </summary>
         /// <param name="updatedJob">The updated job queue</param>

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -43,7 +43,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             JobTaskDefinitionType.DeleteHosting
         };
         
-        public JobDefinitionService(IJobDefinitionRepository dataModelRepository,
+        public JobDefinitionService(IJobDefinitionRepository jobDefinitionRepository,
             IJobTaskDefinitionRepository jobTaskDefinitionRepository,
             IProjectRepository projectRepository,
             ITaskProviderRepository providerRepository,
@@ -51,7 +51,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             ITaskProviderAdditionalConfigRepository providerAdditionalConfigRepository,
             ISecretVault secretVault)
         {
-            _jobDefinitionRepository = dataModelRepository;
+            _jobDefinitionRepository = jobDefinitionRepository;
             _jobTaskDefinitionRepository = jobTaskDefinitionRepository;
             _projectRepository = projectRepository;
             _providerRepository = providerRepository;
@@ -60,9 +60,12 @@ namespace Polyrific.Catapult.Api.Core.Services
             _secretVault = secretVault;
         }
 
-        public async Task<int> AddJobDefinition(int projectId, string name, bool isDeletion, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<int> AddJobDefinition(int projectId, string name, bool isDefault, bool isDeletion, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (isDefault && isDeletion)
+                throw new InvalidDefaultJobDefinition();
 
             var project = await _projectRepository.GetById(projectId, cancellationToken);
             if (project == null)
@@ -85,7 +88,12 @@ namespace Polyrific.Catapult.Api.Core.Services
                 }
             }
 
-            var newJobDefinition = new JobDefinition { ProjectId = projectId, Name = name, IsDeletion = isDeletion };
+            if (isDefault)
+            {
+                await UnsetDefaultJobDefinition(projectId, cancellationToken);
+            }
+
+            var newJobDefinition = new JobDefinition { ProjectId = projectId, Name = name, IsDeletion = isDeletion, IsDefault = true };
             return await _jobDefinitionRepository.Create(newJobDefinition, cancellationToken);
         }
 
@@ -154,19 +162,43 @@ namespace Polyrific.Catapult.Api.Core.Services
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var dataModel = await _jobDefinitionRepository.GetById(id, cancellationToken);
+            var jobDefinition = await _jobDefinitionRepository.GetById(id, cancellationToken);
 
-            if (dataModel != null)
+            if (jobDefinition != null)
             {
-                var dataModelByNameSpec = new JobDefinitionFilterSpecification(newName, dataModel.ProjectId, id);
-                if (await _jobDefinitionRepository.CountBySpec(dataModelByNameSpec, cancellationToken) > 0)
+                var jobDefinitionByNameSpec = new JobDefinitionFilterSpecification(newName, jobDefinition.ProjectId, id);
+                if (await _jobDefinitionRepository.CountBySpec(jobDefinitionByNameSpec, cancellationToken) > 0)
                 {
                     throw new DuplicateJobDefinitionException(newName);
                 }
 
-                dataModel.Name = newName;
-                await _jobDefinitionRepository.Update(dataModel, cancellationToken);
+                jobDefinition.Name = newName;
+                await _jobDefinitionRepository.Update(jobDefinition, cancellationToken);
             }
+        }
+
+        public async Task SetJobDefinitionAsDefault(int id, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var jobDefinition = await _jobDefinitionRepository.GetById(id, cancellationToken);
+
+            if (jobDefinition != null)
+            {
+                if (jobDefinition.IsDeletion)
+                    throw new InvalidDefaultJobDefinition();
+
+                await UnsetDefaultJobDefinition(jobDefinition.ProjectId, cancellationToken);
+
+                jobDefinition.IsDefault = true;
+                await _jobDefinitionRepository.Update(jobDefinition, cancellationToken);
+            }
+        }
+        
+        public async Task<JobDefinition> GetDefaultJobDefinition(int projectId, CancellationToken cancellationToken = default)
+        {
+            var defaultJobSpec = new JobDefinitionFilterSpecification(projectId, null, true);
+            return await _jobDefinitionRepository.GetSingleBySpec(defaultJobSpec, cancellationToken);
         }
 
         public async Task<int> AddJobTaskDefinition(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
@@ -455,6 +487,19 @@ namespace Polyrific.Catapult.Api.Core.Services
                 }
 
                 jobTaskDefinition.AdditionalConfigString = JsonConvert.SerializeObject(taskAdditionalConfigs);
+            }
+        }
+
+        private async Task UnsetDefaultJobDefinition(int projectId, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var currentDefaultJobSpec = new JobDefinitionFilterSpecification(projectId, null, true);
+            var defaultJobs = await _jobDefinitionRepository.GetBySpec(currentDefaultJobSpec, cancellationToken);
+            foreach (var defaultJob in defaultJobs)
+            {
+                defaultJob.IsDefault = false;
+                await _jobDefinitionRepository.Update(defaultJob, cancellationToken);
             }
         }
     }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -494,12 +494,12 @@ namespace Polyrific.Catapult.Api.Core.Services
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var currentDefaultJobSpec = new JobDefinitionFilterSpecification(projectId, null, true);
-            var defaultJobs = await _jobDefinitionRepository.GetBySpec(currentDefaultJobSpec, cancellationToken);
-            foreach (var defaultJob in defaultJobs)
+            var currentDefaultJob = await GetDefaultJobDefinition(projectId);
+
+            if (currentDefaultJob != null)
             {
-                defaultJob.IsDefault = false;
-                await _jobDefinitionRepository.Update(defaultJob, cancellationToken);
+                currentDefaultJob.IsDefault = false;
+                await _jobDefinitionRepository.Update(currentDefaultJob, cancellationToken);
             }
         }
     }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -99,6 +99,15 @@ namespace Polyrific.Catapult.Api.Core.Services
             };
             return await _jobQueueRepository.Create(newJobQueue, cancellationToken);
         }
+        
+        public async Task<int> AddDefaultJobQueue(int projectId, string originUrl, string jobType, CancellationToken cancellationToken = default)
+        {
+            var defaultJobDefinition = await _jobDefinitionService.GetDefaultJobDefinition(projectId);
+            if (defaultJobDefinition == null)
+                throw new DefaultJobDefinitionNotFoundException(projectId);
+
+            return await AddJobQueue(projectId, originUrl, jobType, defaultJobDefinition.Id);
+        }
 
         public async Task UpdateJobQueue(JobQueue updatedJobQueue, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/JobDefinitionFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/JobDefinitionFilterSpecification.cs
@@ -12,16 +12,21 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         public int ExcludedJobDefinitionId { get; set; }
         public int[] JobDefinitionIds { get; set; }
         public bool? IsDeletion { get; set; }
+        public bool? IsDefault { get; set; }
 
         /// <summary>
         /// Filter the job definition by project
         /// </summary>
         /// <param name="projectId">The project id</param>
-        public JobDefinitionFilterSpecification(int projectId, bool? isDeletion = null)
-            : base(m => m.ProjectId == projectId && (isDeletion == null || m.IsDeletion == isDeletion))
+        /// <param name="isDeletion">Is deletion job?</param>
+        /// <param name="isDefault">Is default job?</param>
+        public JobDefinitionFilterSpecification(int projectId, bool? isDeletion = null, bool? isDefault = null)
+            : base(m => m.ProjectId == projectId && (isDeletion == null || m.IsDeletion == isDeletion) &&
+                (isDefault == null || m.IsDefault == isDefault))
         {
             ProjectId = projectId;
             IsDeletion = isDeletion;
+            IsDefault = isDefault;
         }
 
         /// <summary>

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190509085137_DefaultJobDefinition.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190509085137_DefaultJobDefinition.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations
 {
     [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190509085137_DefaultJobDefinition")]
+    partial class DefaultJobDefinition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190509085137_DefaultJobDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190509085137_DefaultJobDefinition.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class DefaultJobDefinition : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDefault",
+                table: "JobDefinitions",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDefault",
+                table: "JobDefinitions");
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190509085239_DefaultJobDefinition.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190509085239_DefaultJobDefinition.Designer.cs
@@ -2,28 +2,26 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
-namespace Polyrific.Catapult.Api.Data.Migrations
+namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
 {
-    [DbContext(typeof(CatapultDbContext))]
-    partial class CatapultDbContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(CatapultSqliteDbContext))]
+    [Migration("20190509085239_DefaultJobDefinition")]
+    partial class DefaultJobDefinition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
 
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalAccountType", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -54,8 +52,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalService", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -83,8 +80,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalServiceProperty", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("AdditionalLogic");
 
@@ -210,8 +206,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalServiceType", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -254,8 +249,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.HelpContext", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -475,8 +469,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobCounter", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -497,8 +490,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobDefinition", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -525,8 +517,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobQueue", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("CatapultEngineIPAddress");
 
@@ -575,8 +566,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobTaskDefinition", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("AdditionalConfigString");
 
@@ -609,8 +599,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ManagedFile", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -631,8 +620,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.Project", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("Client");
 
@@ -660,8 +648,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectDataModel", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -694,8 +681,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectDataModelProperty", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -740,8 +726,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectMember", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -770,8 +755,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectMemberRole", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -820,8 +804,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.Tag", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp");
 
@@ -1055,8 +1038,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.TaskProvider", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("Author");
 
@@ -1184,8 +1166,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.TaskProviderAdditionalConfig", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("AllowedValues");
 
@@ -1435,8 +1416,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.TaskProviderTag", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -1767,8 +1747,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationRole", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -1783,8 +1762,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
 
                     b.HasIndex("NormalizedName")
                         .IsUnique()
-                        .HasName("RoleNameIndex")
-                        .HasFilter("[NormalizedName] IS NOT NULL");
+                        .HasName("RoleNameIndex");
 
                     b.ToTable("Roles");
 
@@ -1822,8 +1800,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationRoleClaim", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ClaimType");
 
@@ -1841,8 +1818,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationUser", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<int>("AccessFailedCount");
 
@@ -1886,8 +1862,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
 
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
-                        .HasName("UserNameIndex")
-                        .HasFilter("[NormalizedUserName] IS NOT NULL");
+                        .HasName("UserNameIndex");
 
                     b.ToTable("Users");
 
@@ -1913,8 +1888,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationUserClaim", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<string>("ClaimType");
 
@@ -1984,8 +1958,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.CatapultEngineProfile", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<int?>("CatapultEngineId");
 
@@ -2006,8 +1979,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("CatapultEngineId")
-                        .IsUnique()
-                        .HasFilter("[CatapultEngineId] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("CatapultEngineProfile");
                 });
@@ -2015,8 +1987,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.UserProfile", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .ValueGeneratedOnAdd();
 
                     b.Property<int?>("ApplicationUserId");
 
@@ -2041,12 +2012,10 @@ namespace Polyrific.Catapult.Api.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("ApplicationUserId")
-                        .IsUnique()
-                        .HasFilter("[ApplicationUserId] IS NOT NULL");
+                        .IsUnique();
 
                     b.HasIndex("AvatarFileId")
-                        .IsUnique()
-                        .HasFilter("[AvatarFileId] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("UserProfile");
 

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190509085239_DefaultJobDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190509085239_DefaultJobDefinition.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
+{
+    public partial class DefaultJobDefinition : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDefault",
+                table: "JobDefinitions",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDefault",
+                table: "JobDefinitions");
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/CatapultSqliteDbContextModelSnapshot.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/CatapultSqliteDbContextModelSnapshot.cs
@@ -495,6 +495,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
 
                     b.Property<DateTime>("Created");
 
+                    b.Property<bool>("IsDefault");
+
                     b.Property<bool>("IsDeletion");
 
                     b.Property<string>("Name");

--- a/src/API/Polyrific.Catapult.Api.Data/Polyrific.Catapult.Api.Data.csproj
+++ b/src/API/Polyrific.Catapult.Api.Data/Polyrific.Catapult.Api.Data.csproj
@@ -7,6 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Migrations\20190509071850_DefaultJobDefinition.cs" />
+    <Compile Remove="Migrations\20190509071850_DefaultJobDefinition.Designer.cs" />
+    <Compile Remove="Migrations\CatapultSqliteDb\20190509071557_DefaultJobDefinition.cs" />
+    <Compile Remove="Migrations\CatapultSqliteDb\20190509071557_DefaultJobDefinition.Designer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="HelpContexts\TaskProvider\Default.txt" />
     <None Remove="HelpContexts\ExternalService\Default.txt" />
     <None Remove="HelpContexts\ExternalService\External Service Type.txt" />

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -66,6 +66,7 @@ namespace Polyrific.Catapult.Api.Controllers
                 newJobDefinitionResponse.ProjectId = projectId;
                 newJobDefinitionResponse.Id = await _jobDefinitionService.AddJobDefinition(projectId,
                     newJobDefinition.Name,
+                    newJobDefinition.IsDefault,
                     newJobDefinition.IsDeletion);
 
                 _logger.LogResponse("Job definitions in project {projectId} created. Reponse body: {@newJobDefinitionResponse}", projectId, newJobDefinitionResponse);
@@ -90,6 +91,11 @@ namespace Polyrific.Catapult.Api.Controllers
             {
                 _logger.LogWarning(jobEx, "A deletion job definition is already exist. A project should only contain one deletion job definition.");
                 return BadRequest(jobEx.Message);
+            }
+            catch (InvalidDefaultJobDefinition delEx)
+            {
+                _logger.LogWarning(delEx, "Job definition cannot be set as default.");
+                return BadRequest(delEx.Message);
             }
         }
 
@@ -147,6 +153,32 @@ namespace Polyrific.Catapult.Api.Controllers
             _logger.LogResponse("Deletion job definition in project {projectId} retrieved. Reponse body: {@result}", projectId, result);
 
             return Ok(result);
+        }
+
+        /// <summary>
+        /// Set a job definition as default
+        /// </summary>
+        /// <param name="projectId">Id of the project</param>
+        /// <param name="jobId">Id of the job definition</param>
+        /// <returns></returns>
+        [HttpPost("Project/{projectId}/job/{jobId}/default")]
+        public async Task<IActionResult> SetJobDefinitionAsDefault(int projectId, int jobId)
+        {
+            _logger.LogRequest("Setting job definition {jobId} in project {projectId} as default", jobId, projectId);
+
+            try
+            {
+                await _jobDefinitionService.SetJobDefinitionAsDefault(jobId);
+
+                _logger.LogResponse("Job definition {jobId} in project {projectId} set as default", jobId, projectId);
+
+                return Ok();
+            }
+            catch (InvalidDefaultJobDefinition delEx)
+            {
+                _logger.LogWarning(delEx, "Job definition cannot be set as default.");
+                return BadRequest(delEx.Message);
+            }
         }
 
         /// <summary>

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/AddCommand.cs
@@ -30,7 +30,10 @@ namespace Polyrific.Catapult.Cli.Commands.Job
         [Option("-n|--name <NAME>", "Name of the job definition", CommandOptionType.SingleValue)]
         public string Name { get; set; }
 
-        [Option("-d|--deletion", "Add the job definition for resource deletion", CommandOptionType.NoValue)]
+        [Option("-d|--default", "Set the new job definition as default", CommandOptionType.NoValue)]
+        public bool IsDefault { get; set; }
+
+        [Option("-dl|--deletion", "Add the job definition for resource deletion", CommandOptionType.NoValue)]
         public bool IsDeletion { get; set; }
 
         public override string Execute()
@@ -46,7 +49,8 @@ namespace Polyrific.Catapult.Cli.Commands.Job
                 var job = _jobDefinitionService.CreateJobDefinition(project.Id, new CreateJobDefinitionDto
                 {
                     Name = Name,
-                    IsDeletion = IsDeletion
+                    IsDeletion = IsDeletion,
+                    IsDefault = IsDefault
                 }).Result;
 
                 message = job.ToCliString($"Job definition has been added:", excludedFields: new string[] {

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Job/SetDefaultCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Job/SetDefaultCommand.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Cli.Commands.Job
+{
+    [Command("setdefault", Description = "set a job definition as default")]
+    public class SetDefaultCommand : BaseCommand
+    {
+        private readonly IProjectService _projectService;
+        private readonly IJobDefinitionService _jobDefinitionService;
+
+        public SetDefaultCommand(IConsole console, ILogger<SetDefaultCommand> logger,
+            IProjectService projectService, IJobDefinitionService jobDefinitionService) : base(console, logger)
+        {
+            _projectService = projectService;
+            _jobDefinitionService = jobDefinitionService;
+        }
+
+        [Required]
+        [Option("-p|--project <PROJECT>", "Name of the project", CommandOptionType.SingleValue)]
+        public string Project { get; set; }
+
+        [Required]
+        [Option("-n|--name <NAME>", "Name of the job definition", CommandOptionType.SingleValue)]
+        public string Name { get; set; }
+
+        public override string Execute()
+        {
+            Console.WriteLine($"Trying to set job definition \"{Name}\" from project {Project} as default...");
+
+            string message;
+
+            var project = _projectService.GetProjectByName(Project).Result;
+
+            if (project != null)
+            {
+                var job = _jobDefinitionService.GetJobDefinitionByName(project.Id, Name).Result;
+
+                if (job != null)
+                {
+                    _jobDefinitionService.SetJobDefinitionAsDefault(project.Id, job.Id).Wait();
+
+                    message = $"Job definition {Name} has been set to default";
+                    Logger.LogInformation(message);
+                    return message;
+                }
+            }
+
+            message = $"Failed to set job definition {Name} as default. Make sure the project and job definition names are correct.";
+
+            return message;
+        }
+    }
+}

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/JobCommand.cs
@@ -11,6 +11,7 @@ namespace Polyrific.Catapult.Cli.Commands
 {
     [Command(Description = "Job definition related command")]
     [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(SetDefaultCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(ListCommand))]
     [Subcommand(typeof(RemoveCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddDefaultCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Queue/AddDefaultCommand.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.Cli.Extensions;
+using Polyrific.Catapult.Shared.Dto.JobQueue;
+using Polyrific.Catapult.Shared.Service;
+
+namespace Polyrific.Catapult.Cli.Commands.Queue
+{
+    [Command("adddefault", Description = "Add job to queue")]
+    public class AddDefaultCommand : BaseCommand
+    {
+        private readonly IProjectService _projectService;
+        private readonly IJobQueueService _jobQueueService;
+
+        public AddDefaultCommand(IConsole console, ILogger<AddDefaultCommand> logger, IProjectService projectService, IJobQueueService jobQueueService) : base(console, logger)
+        {
+            _projectService = projectService;
+            _jobQueueService = jobQueueService;
+        }
+
+        [Required]
+        [Option("-p|--project <PROJECT>", "Name of the project", CommandOptionType.SingleValue)]
+        public string Project { get; set; }
+
+        public override string Execute()
+        {
+            Console.WriteLine($"Trying to queue default job in project {Project}...");
+
+            string message;
+
+            var project = _projectService.GetProjectByName(Project).Result;
+
+            if (project != null)
+            {
+                var queue = _jobQueueService.CreateDefaultJobQueue(project.Id, new NewJobDto
+                {
+                    ProjectId = project.Id,
+                    OriginUrl = Dns.GetHostEntry(Dns.GetHostName()).AddressList.Last(a => a.AddressFamily == AddressFamily.InterNetwork).ToString()
+                }).Result;
+
+                message = queue.ToCliString($"Default job \"{queue.JobDefinitionName}\" has been queued successfully:", excludedFields: new string[]
+                {
+                        "ProjectId",
+                        "JobDefinitionId",
+                        "JobTasksStatus",
+                        "OutputValues",
+                        "CatapultEngineId",
+                        "CatapultEngineMachineName",
+                        "CatapultEngineIPAddress",
+                        "CatapultEngineVersion"
+                });
+                Logger.LogInformation(message);
+
+                message += "\nThe job will be picked up by a running engine shortly.";
+                return message;
+            }
+
+            message = $"Project {Project} was not found";
+
+            return message;
+        }
+    }
+}

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/QueueCommand.cs
@@ -3,7 +3,6 @@
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using Polyrific.Catapult.Cli.Commands.Queue;
-using Polyrific.Catapult.Cli.Extensions;
 using Polyrific.Catapult.Shared.Dto.Constants;
 using Polyrific.Catapult.Shared.Service;
 
@@ -11,6 +10,7 @@ namespace Polyrific.Catapult.Cli.Commands
 {
     [Command(Description = "Job queue related command")]
     [Subcommand(typeof(AddCommand))]
+    [Subcommand(typeof(AddDefaultCommand))]
     [Subcommand(typeof(GetCommand))]
     [Subcommand(typeof(LogCommand))]
     [Subcommand(typeof(ListCommand))]

--- a/src/CLI/Polyrific.Catapult.Cli/Templates/sample-devops.yaml
+++ b/src/CLI/Polyrific.Catapult.Cli/Templates/sample-devops.yaml
@@ -131,6 +131,7 @@ models:
         is-required: false
 jobs:
 - name: Default
+  is-default: true
   tasks:
   - name: Clone
     type: Pull

--- a/src/Shared/Polyrific.Catapult.Shared.ApiClient/JobDefinitionService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.ApiClient/JobDefinitionService.cs
@@ -110,5 +110,12 @@ namespace Polyrific.Catapult.Shared.ApiClient
 
             await Api.Put(path, dto);
         }
+
+        public async Task SetJobDefinitionAsDefault(int projectId, int jobId)
+        {
+            var path = $"project/{projectId}/job/{jobId}/default";
+
+            await Api.Post<object>(path, null);
+        }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.ApiClient/JobQueueService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.ApiClient/JobQueueService.cs
@@ -34,6 +34,13 @@ namespace Polyrific.Catapult.Shared.ApiClient
             return await Api.Post<NewJobDto, JobDto>(path, newJobQueue);
         }
 
+        public async Task<JobDto> CreateDefaultJobQueue(int projectId, NewJobDto newJobQueue)
+        {
+            var path = $"project/{projectId}/queue/default";
+
+            return await Api.Post<NewJobDto, JobDto>(path, newJobQueue);
+        }
+
         public async Task<string> GetJobLogs(int projectId, int queueId)
         {
             var path = $"project/{projectId}/queue/{queueId}/logs";

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/CreateJobDefinitionDto.cs
@@ -16,5 +16,10 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         /// Is the job definition for resource deletion?
         /// </summary>
         public bool IsDeletion { get; set; }
+
+        /// <summary>
+        /// Is the job definition is a default job in the project?
+        /// </summary>
+        public bool IsDefault { get; set; }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobDefinitionDto.cs
@@ -27,6 +27,11 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         public bool IsDeletion { get; set; }
 
         /// <summary>
+        /// Is the job definition is a default job in the project?
+        /// </summary>
+        public bool IsDefault { get; set; }
+
+        /// <summary>
         /// Name of the data model
         /// </summary>
         public List<JobTaskDefinitionDto> Tasks { get; set; }

--- a/src/Shared/Polyrific.Catapult.Shared.Service/IJobDefinitionService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Service/IJobDefinitionService.cs
@@ -56,6 +56,14 @@ namespace Polyrific.Catapult.Shared.Service
         Task UpdateJobDefinition(int projectId, int jobId, UpdateJobDefinitionDto dto);
 
         /// <summary>
+        /// Set a job definition as default
+        /// </summary>
+        /// <param name="projectId">Id of the project</param>
+        /// <param name="jobId">Id of the job definition</param>
+        /// <returns></returns>
+        Task SetJobDefinitionAsDefault(int projectId, int jobId);
+
+        /// <summary>
         /// Delete job definition
         /// </summary>
         /// <param name="projectId">Id of the project</param>

--- a/src/Shared/Polyrific.Catapult.Shared.Service/IJobQueueService.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Service/IJobQueueService.cs
@@ -41,6 +41,14 @@ namespace Polyrific.Catapult.Shared.Service
         Task<JobDto> CreateJobQueue(int projectId, NewJobDto newJobQueue);
 
         /// <summary>
+        /// Add the default job definition to queue
+        /// </summary>
+        /// <param name="projectId">Id of the project</param>
+        /// <param name="newJobQueue">Job details</param>
+        /// <returns></returns>
+        Task<JobDto> CreateDefaultJobQueue(int projectId, NewJobDto newJobQueue);
+
+        /// <summary>
         /// Cancel a job in queue
         /// </summary>
         /// <param name="projectId">Id of the project</param>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/job-definition/create-job-definition-dto.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/job-definition/create-job-definition-dto.ts
@@ -3,5 +3,6 @@ import { CreateJobTaskDefinitionDto } from './create-job-task-definition-dto';
 export interface CreateJobDefinitionDto {
     name: string;
     isDeletion: boolean;
+    isDefault: boolean;
     tasks: CreateJobTaskDefinitionDto[];
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/job-definition/job-definition-dto.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/job-definition/job-definition-dto.ts
@@ -5,5 +5,6 @@ export interface JobDefinitionDto {
   name: string;
   projectId: number;
   isDeletion: boolean;
+  isDefault: boolean;
   tasks: JobTaskDefinitionDto[];
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/services/job-definition.service.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/services/job-definition.service.ts
@@ -27,6 +27,10 @@ export class JobDefinitionService {
     return this.api.post<JobDefinitionDto>(`project/${projectId}/job`, jobDefinition);
   }
 
+  setJobDefinitionAsDefault(projectId: number, jobDefinitionId: number) {
+    return this.api.post(`project/${projectId}/job/${jobDefinitionId}/default`);
+  }
+
   updateJobDefinition(projectId: number, jobDefinition: JobDefinitionDto) {
     return this.api.put(`project/${projectId}/job/${jobDefinition.id}`, jobDefinition);
   }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/services/job-queue.service.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/services/job-queue.service.ts
@@ -35,6 +35,10 @@ export class JobQueueService {
     return this.api.post<JobQueueDto>(`project/${projectId}/queue`, dto);
   }
 
+  addDefaultJobQueue(projectId: number, dto: NewJobDto) {
+    return this.api.post<JobQueueDto>(`project/${projectId}/queue/default`, dto);
+  }
+
   updateJobQueue(projectId: number, queueId: number, dto: JobQueueDto) {
     return this.api.put(`project/${projectId}/queue/${queueId}`, dto);
   }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/components/job-config-form/job-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/components/job-config-form/job-config-form.component.spec.ts
@@ -53,7 +53,8 @@ describe('JobConfigFormComponent', () => {
     component.job = {
       name: 'test',
       tasks: [],
-      isDeletion: false
+      isDeletion: false,
+      isDefault: false
     };
     fixture.detectChanges();
   });

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/components/job-config-form/job-config-form.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/components/job-config-form/job-config-form.component.ts
@@ -17,6 +17,7 @@ export class JobConfigFormComponent implements OnInit, OnChanges {
       {
         name: null,
         isDeletion: false,
+        isDefault: false
       }
     );
   }
@@ -28,7 +29,8 @@ export class JobConfigFormComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     this.jobForm.patchValue({
       name: this.job.name,
-      isDeletion: this.job.isDeletion
+      isDeletion: this.job.isDeletion,
+      isDefault: this.job.isDefault
     });
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.css
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.css
@@ -1,0 +1,3 @@
+.mat-dialog-content {
+  overflow: visible;
+}

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.html
@@ -4,6 +4,9 @@
         <mat-progress-bar mode='indeterminate' *ngIf='loading'></mat-progress-bar>
         <app-job-definition-form (formReady)="onFormReady($event)"></app-job-definition-form>
         <div>
+          <mat-checkbox formControlName="isDefault" (change)="onDefaultChange($event)">Set as default?</mat-checkbox>
+        </div>
+        <div *ngIf="!isDefaultChecked">
           <mat-checkbox formControlName="isDeletion">Is resource deletion job?</mat-checkbox>
         </div>
       </div>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Inject } from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { JobDefinitionService, JobDefinitionDto } from '@app/core';
 import { SnackbarService } from '@app/shared';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { MatDialogRef, MAT_DIALOG_DATA, MatCheckboxChange } from '@angular/material';
 import { NewModelDialogData } from '@app/project/data-model/components/data-model-new-dialog/data-model-new-dialog.component';
 
 export interface NewJobDefinitionDialogData {
@@ -16,9 +16,11 @@ export interface NewJobDefinitionDialogData {
 })
 export class JobDefinitionNewDialogComponent implements OnInit {
   jobDefinitionForm: FormGroup = this.fb.group({
-    isDeletion: false
+    isDeletion: false,
+    isDefault: false
   });
   loading: boolean;
+  isDefaultChecked: boolean;
 
   constructor (
     private fb: FormBuilder,
@@ -53,6 +55,13 @@ export class JobDefinitionNewDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    }
+  }
+
+  onDefaultChange(event: MatCheckboxChange) {
+    this.isDefaultChecked = event.checked;
+    if (this.isDefaultChecked) {
+      this.jobDefinitionForm.get('isDeletion').setValue(false);
     }
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.html
@@ -21,16 +21,20 @@
       <mat-icon *ngIf="jobDefinition.isDeletion" matTooltip="This job can be automatically queued before project deletion">help_outline</mat-icon>
     </mat-panel-title>
     <mat-panel-description>
-      <button mat-icon-button (click)="onQueueJobClick(jobDefinition); $event.stopPropagation();" *appHasAccess="authorizePolicy.ProjectMaintainerAccess">
+      <button mat-icon-button (click)="onQueueJobClick(jobDefinition); $event.stopPropagation();"
+        matTooltip="Queue" *appHasAccess="authorizePolicy.ProjectMaintainerAccess">
         <mat-icon>play_circle_filled</mat-icon>
       </button>
-      <button mat-icon-button (click)="onJobDefinitionInfoClick(jobDefinition); $event.stopPropagation();">
+      <button mat-icon-button (click)="onJobDefinitionInfoClick(jobDefinition); $event.stopPropagation();" matTooltip="View">
         <mat-icon>info</mat-icon>
       </button>
-      <button mat-icon-button (click)="onJobDefinitionDeleteClick(jobDefinition); $event.stopPropagation();">
+      <button mat-icon-button (click)="onJobDefinitionDeleteClick(jobDefinition); $event.stopPropagation();" matTooltip="Delete">
         <mat-icon>delete</mat-icon>
       </button>
-      <button mat-icon-button (click)="onJobTaskDefinitionAddClick(jobDefinition); $event.stopPropagation();">
+      <button mat-icon-button (click)="onSetDefaultClick(jobDefinition); $event.stopPropagation();" matTooltip="Set as Default" *ngIf="!jobDefinition.isDefault && !jobDefinition.isDeletion">
+        <mat-icon>home</mat-icon>
+      </button>
+      <button mat-icon-button (click)="onJobTaskDefinitionAddClick(jobDefinition); $event.stopPropagation();" matTooltip="Add task">
         <mat-icon>add_circle</mat-icon>
       </button>
     </mat-panel-description>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
@@ -6,6 +6,7 @@ import { SnackbarService, ConfirmationWithInputDialogComponent, ConfirmationDial
 import { JobDefinitionNewDialogComponent } from '../components/job-definition-new-dialog/job-definition-new-dialog.component';
 import { JobDefinitionInfoDialogComponent } from '../components/job-definition-info-dialog/job-definition-info-dialog.component';
 import { JobTaskDefinitionNewDialogComponent } from '../components/job-task-definition-new-dialog/job-task-definition-new-dialog.component';
+import { MessageDialogComponent } from '@app/shared/components/message-dialog/message-dialog.component';
 
 interface JobDefinitionViewModel extends JobDefinitionDto {
   selected: boolean;
@@ -136,8 +137,11 @@ export class JobDefinitionComponent implements OnInit {
           originUrl: window.location.origin
         }).subscribe(data => this.router.navigateByUrl(`project/${this.projectId}/job-queue`),
           err => {
-            this.snackbar.open(err, null, {
-              duration: 3000
+            this.dialog.open(MessageDialogComponent, {
+              data: {
+                title: 'Queue Job Failed',
+                message: `${err}\n\nPlease make sure each task configuration is properly set.`
+              }
             });
           });
       }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
@@ -67,7 +67,8 @@ export class JobDefinitionComponent implements OnInit {
     const dialogRef = this.dialog.open(JobDefinitionNewDialogComponent, {
       data: {
         projectId: this.projectId
-      }
+      },
+      minWidth: 480
     });
 
     dialogRef.afterClosed().subscribe(success => {
@@ -211,5 +212,13 @@ export class JobDefinitionComponent implements OnInit {
       this.getJobTaskDefinitions(jobDefinition);
       jobDefinition.expanded = true;
     }
+  }
+
+  onSetDefaultClick(jobDefinition: JobDefinitionDto) {
+    this.jobDefinitionService.setJobDefinitionAsDefault(this.projectId, jobDefinition.id)
+      .subscribe(data => {
+        this.snackbar.open(`Job ${jobDefinition.name} is set to default`);
+        this.getJobDefinitions();
+      }, err => this.snackbar.open(err));
   }
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.html
@@ -13,6 +13,7 @@
         <button mat-raised-button color="primary" routerLink="clone" *appHasAccess="authorizePolicy.ProjectOwnerAccess">Clone</button>
         <button mat-raised-button color="accent" (click)="onArchiveClick()" *appHasAccess="authorizePolicy.ProjectOwnerAccess">Archive</button>
         <button mat-raised-button color="warn" (click)="onDeleteClick()" *appHasAccess="authorizePolicy.ProjectOwnerAccess">Delete</button>
+        <button mat-raised-button (click)="onQueueJobClick()" *appHasAccess="authorizePolicy.ProjectMaintainerAccess">Queue Job</button>
     </div>
   </mat-card-header>
   <mat-card-content>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material';
 import { SnackbarService, ConfirmationWithInputDialogComponent, ConfirmationDialogComponent } from '@app/shared';
 import { filter } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
+import { MessageDialogComponent } from '@app/shared/components/message-dialog/message-dialog.component';
 
 @Component({
   selector: 'app-project-detail',
@@ -158,8 +159,11 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
       jobDefinitionId: null
     }).subscribe(data => this.router.navigateByUrl(`project/${this.project.id}/job-queue`),
       err => {
-        this.snackbar.open(err, null, {
-          duration: 3000
+        this.dialog.open(MessageDialogComponent, {
+          data: {
+            title: 'Queue Job Failed',
+            message: `${err}\n\nPlease make sure each task configuration is properly set.`
+          }
         });
       });
   }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router, NavigationStart } from '@angular/router';
-import { ProjectService, ProjectDto, AuthorizePolicy, ProjectHistoryService, JobDefinitionService } from '@app/core';
+import { ProjectService, ProjectDto, AuthorizePolicy, ProjectHistoryService, JobDefinitionService, JobQueueService } from '@app/core';
 import { MatDialog } from '@angular/material';
 import { SnackbarService, ConfirmationWithInputDialogComponent, ConfirmationDialogComponent } from '@app/shared';
 import { filter } from 'rxjs/operators';
@@ -23,6 +23,7 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
     private projectService: ProjectService,
     private projectHistoryService: ProjectHistoryService,
     private jobDefinitionService: JobDefinitionService,
+    private jobQueueService: JobQueueService,
     private dialog: MatDialog,
     private snackbar: SnackbarService,
     private router: Router
@@ -147,5 +148,19 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
         this.router.navigate(['project', { dummyData: (new Date).getTime()}])
           .then(() => this.router.navigate(['project']));
       }, () => this.loading = false);
+  }
+
+  onQueueJobClick() {
+    this.jobQueueService.addDefaultJobQueue(this.project.id, {
+      projectId: this.project.id,
+      jobType: null,
+      originUrl: window.location.origin,
+      jobDefinitionId: null
+    }).subscribe(data => this.router.navigateByUrl(`project/${this.project.id}/job-queue`),
+      err => {
+        this.snackbar.open(err, null, {
+          duration: 3000
+        });
+      });
   }
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.css
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.css
@@ -1,0 +1,3 @@
+.message {
+  white-space: pre-line;
+}

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.html
@@ -1,0 +1,7 @@
+<h1 mat-dialog-title>{{data.title}}</h1>
+<div mat-dialog-content>
+  <p class="message">{{data.message}}</p>
+</div>
+<div mat-dialog-actions>
+  <button mat-button [mat-dialog-close]="true" cdkFocusInitial>OK</button>
+</div>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.spec.ts
@@ -1,0 +1,35 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MessageDialogComponent } from './message-dialog.component';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material';
+
+describe('MessageDialogComponent', () => {
+  let component: MessageDialogComponent;
+  let fixture: ComponentFixture<MessageDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MessageDialogComponent ],
+      imports: [ MatDialogModule ],
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA, useValue: {
+            title: 'test',
+            message: 'message'
+          }
+        }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MessageDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/message-dialog/message-dialog.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+  selector: 'app-message-dialog',
+  templateUrl: './message-dialog.component.html',
+  styleUrls: ['./message-dialog.component.css']
+})
+export class MessageDialogComponent implements OnInit {
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { title: string, message: string }) { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/shared.module.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/shared.module.ts
@@ -23,6 +23,7 @@ import { DeleteRepositoryConfigFormComponent } from './components/delete-reposit
 import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { ExternalAccountFormComponent } from './components/external-account-form/external-account-form.component';
 import { UtilityService } from './services/utility.service';
+import { MessageDialogComponent } from './components/message-dialog/message-dialog.component';
 
 @NgModule({
   declarations: [
@@ -42,7 +43,8 @@ import { UtilityService } from './services/utility.service';
     HasAccessDirective,
     DeleteRepositoryConfigFormComponent,
     LoadingSpinnerComponent,
-    ExternalAccountFormComponent
+    ExternalAccountFormComponent,
+    MessageDialogComponent
   ],
   imports: [
     CommonModule,
@@ -77,11 +79,13 @@ import { UtilityService } from './services/utility.service';
     HasAccessDirective,
     DeleteRepositoryConfigFormComponent,
     LoadingSpinnerComponent,
-    ExternalAccountFormComponent
+    ExternalAccountFormComponent,
+    MessageDialogComponent
   ],
   entryComponents: [
     ConfirmationWithInputDialogComponent,
-    ConfirmationDialogComponent
+    ConfirmationDialogComponent,
+    MessageDialogComponent
   ]
 })
 export class SharedModule {

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/assets/template/sample-devops.yaml
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/assets/template/sample-devops.yaml
@@ -131,6 +131,7 @@ models:
         is-required: false
 jobs:
 - name: Default
+  is-default: true
   tasks:
   - name: Clone
     type: Pull

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
@@ -58,7 +58,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         public async void CreateJobDefinition_ReturnsCreatedJobDefinition()
         {
             _jobDefinitionService
-                .Setup(s => s.AddJobDefinition(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Setup(s => s.AddJobDefinition(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(1);
 
             var controller = new JobDefinitionController(_jobDefinitionService.Object, _mapper, _logger.Object);
@@ -72,6 +72,18 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
             var okActionResult = Assert.IsType<CreatedAtRouteResult>(result);
             var returnValue = Assert.IsType<JobDefinitionDto>(okActionResult.Value);
             Assert.Equal(1, returnValue.Id);
+        }
+
+        [Fact]
+        public async void SetJobDefinitionAsDefault_ReturnsSuccess()
+        {
+            _jobDefinitionService.Setup(s => s.SetJobDefinitionAsDefault(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var controller = new JobDefinitionController(_jobDefinitionService.Object, _mapper, _logger.Object);
+
+            var result = await controller.SetJobDefinitionAsDefault(1, 1);
+
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobQueueControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobQueueControllerTests.cs
@@ -144,6 +144,32 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         }
 
         [Fact]
+        public async void CreateDefaultJobQueue_ReturnsCreatedJobQueue()
+        {
+            _jobQueueService
+                .Setup(s => s.AddDefaultJobQueue(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+            _jobQueueService.Setup(s => s.GetJobQueueById(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int projectId, int id, CancellationToken cancellationToken) =>
+                    new JobQueue
+                    {
+                        Id = id,
+                        ProjectId = projectId
+                    });
+
+            var controller = new JobQueueController(_jobQueueService.Object, _catapultEngineService.Object, _mapper, _configuration.Object, _logger.Object);
+
+            var result = await controller.CreateDefaultJobQueue(1, new NewJobDto
+            {
+                ProjectId = 1
+            });
+
+            var createAtRouteActionResult = Assert.IsType<CreatedAtRouteResult>(result);
+            var returnValue = Assert.IsType<JobDto>(createAtRouteActionResult.Value);
+            Assert.Equal(1, returnValue.Id);
+        }
+
+        [Fact]
         public async void CancelJobQueue_ReturnsSuccess()
         {
             _jobQueueService.Setup(s => s.CancelJobQueue(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
@@ -159,7 +159,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void AddJobDefinition_ValidItem()
         {
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
-            int newId = await projectJobDefinitionService.AddJobDefinition(1, "Complete CI/CD", false);
+            int newId = await projectJobDefinitionService.AddJobDefinition(1, "Complete CI/CD", false, false);
 
             Assert.True(newId > 1);
             Assert.True(_data.Count > 1);
@@ -169,7 +169,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobDefinition_DuplicateItem()
         {
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
-            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(1, "Default", false));
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(1, "Default", false, false));
 
             Assert.IsType<DuplicateJobDefinitionException>(exception?.Result);
         }
@@ -178,9 +178,18 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddJobDefinition_InvalidProject()
         {
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
-            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(2, "Category", false));
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(2, "Category", false, false));
 
             Assert.IsType<ProjectNotFoundException>(exception?.Result);
+        }
+
+        [Fact]
+        public void AddJobDefinition_InvalidDefaultJobDefinition()
+        {
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(1, "Complete CI/CD", true, true));
+
+            Assert.IsType<InvalidDefaultJobDefinition>(exception?.Result);
         }
 
         [Fact]
@@ -188,7 +197,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         {
             _data[0].IsDeletion = true;
             var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
-            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(1, "Category", true));
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobDefinition(1, "Category", false, true));
 
             Assert.IsType<MultipleDeletionJobException>(exception?.Result);
         }
@@ -294,6 +303,28 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
             var exception = Record.ExceptionAsync(() => projectJobDefinitionService.RenameJobDefinition(1, "newName"));
 
             Assert.IsType<DuplicateJobDefinitionException>(exception?.Result);
+        }
+
+        [Fact]
+        public async void SetJobDefinitionAsDefault_ValidItem()
+        {
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
+            await projectJobDefinitionService.SetJobDefinitionAsDefault(1);
+
+            var dataModel = _data.First(d => d.Id == 1);
+
+            Assert.True(dataModel.IsDefault);
+        }
+
+        [Fact]
+        public void SetJobDefinitionAsDefault_InvalidItem()
+        {
+            _data[0].IsDeletion = true;
+
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.SetJobDefinitionAsDefault(1));
+
+            Assert.IsType<InvalidDefaultJobDefinition>(exception?.Result);
         }
 
         [Fact]

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/JobCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/JobCommandTests.cs
@@ -202,8 +202,37 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
             var resultMessage = command.Execute();
 
             Assert.Equal("Failed to update job definition Default. Make sure the project and job definition names are correct.", resultMessage);
-        }          
-  
+        }
+
+        [Fact]
+        public void SetDefault_Execute_ReturnsSuccessMessage()
+        {
+            _jobDefinitionService.Setup(j => j.SetJobDefinitionAsDefault(It.IsAny<int>(), It.IsAny<int>())).Returns(Task.CompletedTask);
+            var command = new SetDefaultCommand(_console, LoggerMock.GetLogger<SetDefaultCommand>().Object, _projectService.Object, _jobDefinitionService.Object)
+            {
+                Project = "Project 1",
+                Name = "Default"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.Equal("Job definition Default has been set to default", resultMessage);
+        }
+
+        [Fact]
+        public void SetDefault_Execute_ReturnsNotFoundMessage()
+        {
+            var command = new SetDefaultCommand(_console, LoggerMock.GetLogger<SetDefaultCommand>().Object, _projectService.Object, _jobDefinitionService.Object)
+            {
+                Project = "Project 2",
+                Name = "Default"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.Equal("Failed to set job definition Default as default. Make sure the project and job definition names are correct.", resultMessage);
+        }
+
         [Fact]
         public void JobGet_Execute_ReturnsSuccessMessage()
         {

--- a/tests/Polyrific.Catapult.Cli.UnitTests/Commands/QueueCommandTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/Commands/QueueCommandTests.cs
@@ -123,6 +123,43 @@ namespace Polyrific.Catapult.Cli.UnitTests.Commands
         }
 
         [Fact]
+        public void QueueAddDefault_Execute_ReturnsSuccessMessage()
+        {
+            _jobQueueService.Setup(s => s.CreateDefaultJobQueue(It.IsAny<int>(), It.IsAny<NewJobDto>()))
+                   .ReturnsAsync((int projectId, NewJobDto dto) => new JobDto
+                   {
+                       Id = 2,
+                       ProjectId = projectId,
+                       JobType = dto.JobType,
+                       OriginUrl = dto.OriginUrl,
+                       JobDefinitionId = dto.JobDefinitionId,
+                       JobDefinitionName = "Default"
+                   });
+
+            var command = new AddDefaultCommand(_console, LoggerMock.GetLogger<AddDefaultCommand>().Object, _projectService.Object, _jobQueueService.Object)
+            {
+                Project = "Project 1"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.StartsWith("Default job \"Default\" has been queued successfully:", resultMessage);
+        }
+
+        [Fact]
+        public void QueueAddDefault_Execute_ReturnsNotFoundMessage()
+        {
+            var command = new AddDefaultCommand(_console, LoggerMock.GetLogger<AddDefaultCommand>().Object, _projectService.Object, _jobQueueService.Object)
+            {
+                Project = "Project 2"
+            };
+
+            var resultMessage = command.Execute();
+
+            Assert.Equal("Project Project 2 was not found", resultMessage);
+        }
+
+        [Fact]
         public void QueueGet_Execute_ReturnsSuccessMessage()
         {
             var command = new GetCommand(_projectService.Object, _jobQueueService.Object, _console, LoggerMock.GetLogger<GetCommand>().Object)


### PR DESCRIPTION
## Summary
Allow job definition to have default flag, so it can be queued for a project.

## Coverage
- [x] Implement default flag in API
- [x] Implement default flag in Web
- [x] Implement default flag in CLI
- [x] Show modal dialog message instead of fading dialog when error adding queue

## References
- Related Issues: #525, #527 
