### PR TITLE
Fix issue occured after setting secret config in create project

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -155,6 +155,14 @@ namespace Polyrific.Catapult.Api.Core.Services
         Task ValidateJobTaskDefinition(JobDefinition jobDefinition, JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Encrypt all secret additional config in a task
+        /// </summary>
+        /// <param name="jobTaskDefinition">The job task definition object</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
+        /// <returns></returns>
+        Task EncryptSecretAdditionalConfig(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Decrypt the secret additional configs to plain text
         /// </summary>
         /// <param name="jobTaskDefinition">The job task definition object</param>

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -433,9 +433,9 @@ namespace Polyrific.Catapult.Api.Core.Services
 
             if (provider != null)
             {
-                var additionalConfigsDefinitionSpec = new TaskProviderAdditionalConfigFilterSpecification(provider.Id);
+                var additionalConfigsDefinitionSpec = new TaskProviderAdditionalConfigFilterSpecification(provider.Id, true);
                 var additionalConfigsDefinition = await _providerAdditionalConfigRepository.GetBySpec(additionalConfigsDefinitionSpec, cancellationToken);
-                var secretConfigs = additionalConfigsDefinition.Where(c => c.IsSecret).Select(c => c.Name).ToList();
+                var secretConfigs = additionalConfigsDefinition.Select(c => c.Name).ToList();
 
                 var taskAdditionalConfigs = !string.IsNullOrEmpty(jobTaskDefinition.AdditionalConfigString) ?
                     JsonConvert.DeserializeObject<Dictionary<string, string>>(jobTaskDefinition.AdditionalConfigString) : null;

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -302,6 +302,8 @@ namespace Polyrific.Catapult.Api.Core.Services
 
         public async Task ValidateJobTaskDefinition(JobDefinition jobDefinition, JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // validate task type
             bool isTaskTypeNotFitIntoJob = jobDefinition != null && jobTaskDefinition.Type != JobTaskDefinitionType.CustomTask && 
                 ((jobDefinition.IsDeletion && !_deleteTaskTypes.Contains(jobTaskDefinition.Type)) ||
@@ -424,6 +426,8 @@ namespace Polyrific.Catapult.Api.Core.Services
 
         public async Task EncryptSecretAdditionalConfig(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var providerSpec = new TaskProviderFilterSpecification(jobTaskDefinition.Provider, null);
             var provider = await _providerRepository.GetSingleBySpec(providerSpec, cancellationToken);
 
@@ -459,6 +463,8 @@ namespace Polyrific.Catapult.Api.Core.Services
 
         public async Task DecryptSecretAdditionalConfigs(JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (string.IsNullOrEmpty(jobTaskDefinition?.Provider))
                 return;
 
@@ -468,9 +474,9 @@ namespace Polyrific.Catapult.Api.Core.Services
             if (provider == null)
                 return;
 
-            var additionalConfigsDefinitionSpec = new TaskProviderAdditionalConfigFilterSpecification(provider.Id);
+            var additionalConfigsDefinitionSpec = new TaskProviderAdditionalConfigFilterSpecification(provider.Id, true);
             var additionalConfigsDefinition = await _providerAdditionalConfigRepository.GetBySpec(additionalConfigsDefinitionSpec, cancellationToken);
-            var secretConfigs = additionalConfigsDefinition.Where(c => c.IsSecret).Select(c => c.Name).ToList();
+            var secretConfigs = additionalConfigsDefinition.Select(c => c.Name).ToList();
             var taskAdditionalConfigs = !string.IsNullOrEmpty(jobTaskDefinition.AdditionalConfigString) ?
                 JsonConvert.DeserializeObject<Dictionary<string, string>>(jobTaskDefinition.AdditionalConfigString) : null;
             if (secretConfigs.Count > 0 && taskAdditionalConfigs != null)

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectService.cs
@@ -245,6 +245,7 @@ namespace Polyrific.Catapult.Api.Core.Services
                         int sequence = 1;
                         foreach (var task in job.Tasks)
                         {
+                            await _jobDefinitionService.EncryptSecretAdditionalConfig(task, cancellationToken);
                             task.Created = DateTime.UtcNow;
                             task.Sequence = sequence++;
                         }

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/TaskProviderAdditionalConfigFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/TaskProviderAdditionalConfigFilterSpecification.cs
@@ -9,16 +9,17 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         /// <summary>
         /// Filter Provider additional configs by task provider id
         /// </summary>
-        /// <param name="taskProviderId"></param>
-        public TaskProviderAdditionalConfigFilterSpecification(int taskProviderId) 
-            : base(m => m.TaskProviderId == taskProviderId)
+        /// <param name="taskProviderId">Id of the task provider</param>
+        /// <param name="isSecret">is additional config secret?</param>
+        public TaskProviderAdditionalConfigFilterSpecification(int taskProviderId, bool? isSecret = null) 
+            : base(m => m.TaskProviderId == taskProviderId && (isSecret == null || m.IsSecret == isSecret))
         {
         }
 
         /// <summary>
         /// Filter Provider additional configs by task provider name
         /// </summary>
-        /// <param name="taskProviderName"></param>
+        /// <param name="taskProviderName">Name of the task provider</param>
         public TaskProviderAdditionalConfigFilterSpecification(string taskProviderName)
             : base(m => m.TaskProvider.Name == taskProviderName)
         {


### PR DESCRIPTION
## Summary
I found an issue where the job definition cannot be expanded after creating a new project. It turns out it's because the secret config was not properly encrypted. The PR fixes this issue
