### PR TITLE
Use select control for additional config with allowed values

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Exceptions/TaskProviderAdditionalConfigAllowedValuesException.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Exceptions/TaskProviderAdditionalConfigAllowedValuesException.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System;
+
+namespace Polyrific.Catapult.Api.Core.Exceptions
+{
+    public class TaskProviderAdditionalConfigAllowedValuesException : Exception
+    {
+        public string AdditionalConfigName { get; set; }
+        public string ProviderName { get; set; }
+        public string AllowedValues { get; set; }
+
+        public TaskProviderAdditionalConfigAllowedValuesException(string additionalConfigName, string providerName, string allowedValues)
+            : base($"Additional config \"{additionalConfigName}\" in Task Provider {providerName} only allows the follwing values: {allowedValues}")
+        {
+            AdditionalConfigName = additionalConfigName;
+            ProviderName = providerName;
+            AllowedValues = allowedValues;
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -387,6 +387,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             var additionalConfigsDefinitionSpec = new TaskProviderAdditionalConfigFilterSpecification(provider.Id);
             var additionalConfigsDefinition = await _providerAdditionalConfigRepository.GetBySpec(additionalConfigsDefinitionSpec, cancellationToken);
             var requiredConfigs = additionalConfigsDefinition.Where(c => c.IsRequired).Select(c => c.Name).ToList();
+            var configsWithAllowedValues = additionalConfigsDefinition.Where(c => !string.IsNullOrEmpty(c.AllowedValues)).ToList();
             var taskAdditionalConfigs = !string.IsNullOrEmpty(jobTaskDefinition.AdditionalConfigString) ?
                 JsonConvert.DeserializeObject<Dictionary<string, string>>(jobTaskDefinition.AdditionalConfigString) : null;
             if (requiredConfigs.Count > 0)
@@ -402,6 +403,19 @@ namespace Polyrific.Catapult.Api.Core.Services
                     if (conf == null)
                     {
                         throw new TaskProviderAdditionalConfigRequiredException(requiredConfig, provider.Name);
+                    }
+                }
+            }
+
+            if (configsWithAllowedValues.Count > 0)
+            {
+                foreach (var configWithAllowedValues in configsWithAllowedValues)
+                {
+                    var allowedValues = configWithAllowedValues.AllowedValues.ToLower().Split(DataDelimiter.Comma).Select(av => av.Trim()).ToList();
+                    taskAdditionalConfigs.TryGetValue(configWithAllowedValues.Name, out var conf);
+                    if (!string.IsNullOrEmpty(conf) && !allowedValues.Contains(conf.ToLower()))
+                    {
+                        throw new TaskProviderAdditionalConfigAllowedValuesException(configWithAllowedValues.Name, provider.Name, configWithAllowedValues.AllowedValues);
                     }
                 }
             }

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -320,6 +320,21 @@ namespace Polyrific.Catapult.Api.Controllers
                 _logger.LogWarning(taskEx, "Incorrect task definition type");
                 return BadRequest(taskEx.Message);
             }
+            catch (TaskConfigRequiredException tcEx)
+            {
+                _logger.LogWarning(tcEx, "Incorrect task config");
+                return BadRequest(tcEx.Message);
+            }
+            catch (TaskProviderAdditionalConfigRequiredException acReqEx)
+            {
+                _logger.LogWarning(acReqEx, "Incorrect task additional config");
+                return BadRequest(acReqEx.Message);
+            }
+            catch (TaskProviderAdditionalConfigAllowedValuesException avEx)
+            {
+                _logger.LogWarning(avEx, "Incorrect task additional config");
+                return BadRequest(avEx.Message);
+            }            
         }
 
         /// <summary>
@@ -400,6 +415,21 @@ namespace Polyrific.Catapult.Api.Controllers
             {
                 _logger.LogWarning(taskEx, "Incorrect task definition type");
                 return BadRequest(taskEx.Message);
+            }
+            catch (TaskConfigRequiredException tcEx)
+            {
+                _logger.LogWarning(tcEx, "Incorrect task config");
+                return BadRequest(tcEx.Message);
+            }
+            catch (TaskProviderAdditionalConfigRequiredException acReqEx)
+            {
+                _logger.LogWarning(acReqEx, "Incorrect task additional config");
+                return BadRequest(acReqEx.Message);
+            }
+            catch (TaskProviderAdditionalConfigAllowedValuesException avEx)
+            {
+                _logger.LogWarning(avEx, "Incorrect task additional config");
+                return BadRequest(avEx.Message);
             }
         }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/additional-config-field/additional-config-field.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/additional-config-field/additional-config-field.component.html
@@ -1,4 +1,18 @@
-<div [ngSwitch]="additionalConfig.type" [formGroup]="form">
+<div [ngSwitch]="additionalConfig.type" [formGroup]="form" *ngIf="additionalConfig.allowedValues && additionalConfig.allowedValues.length > 0">
+  <mat-form-field *ngSwitchCase="'string'" class="full-width-input">
+      <mat-label>{{additionalConfig.label}}</mat-label>
+      <mat-select [formControlName]="additionalConfig.name" [required]="additionalConfig.isRequired && !skipValidation ? 'required' : null">
+        <mat-option *ngFor="let allowedValue of additionalConfig.allowedValues" [value]="allowedValue">
+          {{allowedValue}}
+        </mat-option>
+      </mat-select>
+      <mat-error *ngIf="isFieldInvalid(additionalConfig.name, 'required')">
+        Please inform the {{additionalConfig.label}}
+      </mat-error>
+  </mat-form-field>
+
+</div>
+<div [ngSwitch]="additionalConfig.type" [formGroup]="form" *ngIf="!additionalConfig.allowedValues || additionalConfig.allowedValues.length == 0">
     <mat-form-field *ngSwitchCase="'string'" class="full-width-input">
         <mat-label>{{additionalConfig.label}}</mat-label>
         <input matInput placeholder="{{additionalConfig.hint}}" [formControlName]="additionalConfig.name" [required]="additionalConfig.isRequired && !skipValidation ? 'required' : null">

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/additional-config-field/additional-config-field.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/additional-config-field/additional-config-field.component.spec.ts
@@ -1,8 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AdditionalConfigFieldComponent } from './additional-config-field.component';
-import { ReactiveFormsModule, FormGroup, FormBuilder } from '@angular/forms';
-import { MatInputModule, MatCheckboxModule } from '@angular/material';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('AdditionalConfigFieldComponent', () => {
@@ -16,7 +16,8 @@ describe('AdditionalConfigFieldComponent', () => {
         BrowserAnimationsModule,
         ReactiveFormsModule,
         MatInputModule,
-        MatCheckboxModule
+        MatCheckboxModule,
+        MatSelectModule
       ]
     })
     .compileComponents();

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/additional-config-form/additional-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/additional-config-form/additional-config-form.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AdditionalConfigFormComponent } from './additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { UtilityService } from '@app/shared/services/utility.service';
 
@@ -13,7 +13,7 @@ describe('AdditionalConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ],
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ],
       providers: [ UtilityService ]
     })
     .compileComponents();

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/build-task-config-form/build-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/build-task-config-form/build-task-config-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BuildTaskConfigFormComponent } from './build-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('BuildTaskConfigFormComponent', () => {
@@ -13,7 +13,7 @@ describe('BuildTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ BuildTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ]
     })
     .compileComponents();
   }));

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/deploy-db-task-config-form/deploy-db-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/deploy-db-task-config-form/deploy-db-task-config-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DeployDbTaskConfigFormComponent } from './deploy-db-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('DeployDbTaskConfigFormComponent', () => {
@@ -13,7 +13,7 @@ describe('DeployDbTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ DeployDbTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ]
     })
     .compileComponents();
   }));

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/deploy-task-config-form/deploy-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/deploy-task-config-form/deploy-task-config-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DeployTaskConfigFormComponent } from './deploy-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('DeployTaskConfigFormComponent', () => {
@@ -13,7 +13,7 @@ describe('DeployTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ DeployTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ]
     })
     .compileComponents();
   }));

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/generate-task-config-form/generate-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/generate-task-config-form/generate-task-config-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { GenerateTaskConfigFormComponent } from './generate-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('GenerateTaskConfigFormComponent', () => {
@@ -13,7 +13,7 @@ describe('GenerateTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ GenerateTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ]
     })
     .compileComponents();
   }));

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/merge-task-config-form/merge-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/merge-task-config-form/merge-task-config-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MergeTaskConfigFormComponent } from './merge-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('MergeTaskConfigFormComponent', () => {
@@ -13,7 +13,7 @@ describe('MergeTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ MergeTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ]
     })
     .compileComponents();
   }));

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/pull-task-config-form/pull-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/pull-task-config-form/pull-task-config-form.component.spec.ts
@@ -3,18 +3,18 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PullTaskConfigFormComponent } from './pull-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { UtilityService } from '@app/shared/services/utility.service';
 
-describe('CloneTaskConfigFormComponent', () => {
+describe('PullTaskConfigFormComponent', () => {
   let component: PullTaskConfigFormComponent;
   let fixture: ComponentFixture<PullTaskConfigFormComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ PullTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ],
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ],
       providers: [ UtilityService ]
     })
     .compileComponents();

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/push-task-config-form/push-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/push-task-config-form/push-task-config-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PushTaskConfigFormComponent } from './push-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { UtilityService } from '@app/shared/services/utility.service';
 
@@ -14,7 +14,7 @@ describe('PushTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ PushTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ],
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ],
       providers: [ UtilityService ]
     })
     .compileComponents();

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/test-task-config-form/test-task-config-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/components/test-task-config-form/test-task-config-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TestTaskConfigFormComponent } from './test-task-config-form.component';
 import { AdditionalConfigFormComponent } from '../additional-config-form/additional-config-form.component';
 import { AdditionalConfigFieldComponent } from '../additional-config-field/additional-config-field.component';
-import { MatExpansionModule, MatInputModule, MatCheckboxModule } from '@angular/material';
+import { MatExpansionModule, MatInputModule, MatCheckboxModule, MatSelectModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 
 describe('TestTaskConfigFormComponent', () => {
@@ -13,7 +13,7 @@ describe('TestTaskConfigFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ TestTaskConfigFormComponent, AdditionalConfigFormComponent, AdditionalConfigFieldComponent ],
-      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule ]
+      imports: [ MatExpansionModule, ReactiveFormsModule, MatInputModule, MatCheckboxModule, MatSelectModule ]
     })
     .compileComponents();
   }));

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobDefinitionServiceTests.cs
@@ -636,6 +636,36 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         }
 
         [Fact]
+        public void AddJobTaskDefinition_TaskProviderAdditionalConfigAllowedValuesException()
+        {
+            _providerRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<TaskProvider>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TaskProvider { Id = 3, Name = "GitHubProvider", Type = TaskProviderType.RepositoryProvider });
+
+            _providerAdditionalConfigRepository.Setup(r => r.GetBySpec(It.IsAny<ISpecification<TaskProviderAdditionalConfig>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<TaskProviderAdditionalConfig>
+                {
+                    new TaskProviderAdditionalConfig
+                    {
+                        Id = 1,
+                        Name = "testconfig",
+                        AllowedValues = "test_value"
+                    }
+                });
+
+            var projectJobDefinitionService = new JobDefinitionService(_jobDefinitionRepository.Object, _jobTaskDefinitionRepository.Object, _projectRepository.Object, _providerRepository.Object, _externalServiceRepository.Object, _providerAdditionalConfigRepository.Object, _secretVault.Object);
+            var exception = Record.ExceptionAsync(() => projectJobDefinitionService.AddJobTaskDefinition(new JobTaskDefinition
+            {
+                JobDefinitionId = 1,
+                Type = JobTaskDefinitionType.Push,
+                AdditionalConfigString = "{\"testconfig\":\"test\"}",
+                ConfigString = "{\"Repository\":\"test\"}",
+                Provider = "GitHubProvider"
+            }));
+
+            Assert.IsType<TaskProviderAdditionalConfigAllowedValuesException>(exception?.Result);
+        }
+
+        [Fact]
         public async void AddJobTaskDefinitions_ValidItem()
         {
             _providerRepository.Setup(r => r.GetSingleBySpec(It.IsAny<ISpecification<TaskProvider>>(), It.IsAny<CancellationToken>()))


### PR DESCRIPTION
## Summary
When an additional config have allowed values, the web ui should use select control, instead of plain textbox.

## PR Coverange
- [x] Changes in Web UI
- [x] Add validation in API
