### PR TITLE
Allow adding global external service

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/ExternalService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/ExternalService.cs
@@ -4,13 +4,35 @@ namespace Polyrific.Catapult.Api.Core.Entities
 {
     public class ExternalService : BaseEntity
     {
+        /// <summary>
+        /// Name of the external service
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Description of the external service
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// Id of the user
+        /// </summary>
         public int UserId { get; set; }
 
+        /// <summary>
+        /// Id of the External service type
+        /// </summary>
         public int? ExternalServiceTypeId { get; set; }
         public virtual ExternalServiceType ExternalServiceType { get; set; }
 
+        /// <summary>
+        /// Serialized external service configuration value
+        /// </summary>
         public string ConfigString { get; set; }
+
+        /// <summary>
+        /// Is the external service can be access globally?
+        /// </summary>
+        public bool IsGlobal { get; set; }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ExternalServiceService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ExternalServiceService.cs
@@ -23,7 +23,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             _secretVault = secretVault;
         }
 
-        public async Task<int> AddExternalService(string name, string description, int typeId, string configString, int userId, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<int> AddExternalService(string name, string description, int typeId, string configString, int userId, bool isGlobal, CancellationToken cancellationToken = default(CancellationToken))
         {
             var externalServiceByNameSpec = new ExternalServiceFilterSpecification(0, name);
             if (await _repository.CountBySpec(externalServiceByNameSpec, cancellationToken) > 0)
@@ -38,7 +38,8 @@ namespace Polyrific.Catapult.Api.Core.Services
                 Name = name,
                 Description = description,
                 ExternalServiceTypeId = typeId,
-                UserId = userId
+                UserId = userId,
+                IsGlobal = isGlobal
             };
 
             return await _repository.Create(newExternalService, cancellationToken);
@@ -95,6 +96,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             if (entity != null)
             {
                 entity.Description = externalService.Description;
+                entity.IsGlobal = externalService.IsGlobal;
 
                 if (!string.IsNullOrEmpty(externalService.ConfigString))
                 {

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IExternalServiceService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IExternalServiceService.cs
@@ -17,9 +17,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <param name="typeId">Id of the external service type</param>
         /// <param name="configString">Configuration string of the external service</param>
         /// <param name="userId">Id of the user</param>
+        /// <param name="isGlobal">Is the external service can be access globally?</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>Id of the new external service</returns>
-        Task<int> AddExternalService(string name, string description, int typeId, string configString, int userId, CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> AddExternalService(string name, string description, int typeId, string configString, int userId, bool isGlobal, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get the list of external services related to current user

--- a/src/API/Polyrific.Catapult.Api.Core/Specifications/ExternalServiceFilterSpecification.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Specifications/ExternalServiceFilterSpecification.cs
@@ -20,7 +20,7 @@ namespace Polyrific.Catapult.Api.Core.Specifications
         }
 
         public ExternalServiceFilterSpecification(int userId)
-            : base(m => m.UserId == userId)
+            : base(m => m.UserId == userId || m.IsGlobal)
         {
             UserId = userId;
         }

--- a/src/API/Polyrific.Catapult.Api.Data/CatapultEngineRepository.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/CatapultEngineRepository.cs
@@ -63,6 +63,7 @@ namespace Polyrific.Catapult.Api.Data
 
             var profile = _mapper.Map<CatapultEngineProfile>(entity);
             profile.CatapultEngine = user;
+            profile.IsActive = true;
             await _profileRepository.Create(profile, cancellationToken);
 
             return user.Id;

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190513025236_ExternalServiceGlobal.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190513025236_ExternalServiceGlobal.Designer.cs
@@ -2,24 +2,30 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
-namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
+namespace Polyrific.Catapult.Api.Data.Migrations
 {
-    [DbContext(typeof(CatapultSqliteDbContext))]
-    partial class CatapultSqliteDbContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(CatapultDbContext))]
+    [Migration("20190513025236_ExternalServiceGlobal")]
+    partial class ExternalServiceGlobal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
+                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128)
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalAccountType", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -50,7 +56,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalService", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -80,7 +87,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalServiceProperty", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("AdditionalLogic");
 
@@ -206,7 +214,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ExternalServiceType", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -249,7 +258,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.HelpContext", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -469,7 +479,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobCounter", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -490,7 +501,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobDefinition", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -517,7 +529,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobQueue", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("CatapultEngineIPAddress");
 
@@ -566,7 +579,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.JobTaskDefinition", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("AdditionalConfigString");
 
@@ -599,7 +613,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ManagedFile", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -620,7 +635,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.Project", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Client");
 
@@ -648,7 +664,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectDataModel", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -681,7 +698,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectDataModelProperty", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -726,7 +744,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectMember", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -755,7 +774,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.ProjectMemberRole", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -804,7 +824,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.Tag", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp");
 
@@ -1038,7 +1059,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.TaskProvider", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("Author");
 
@@ -1166,7 +1188,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.TaskProviderAdditionalConfig", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("AllowedValues");
 
@@ -1416,7 +1439,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Core.Entities.TaskProviderTag", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -1747,7 +1771,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationRole", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -1762,7 +1787,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
 
                     b.HasIndex("NormalizedName")
                         .IsUnique()
-                        .HasName("RoleNameIndex");
+                        .HasName("RoleNameIndex")
+                        .HasFilter("[NormalizedName] IS NOT NULL");
 
                     b.ToTable("Roles");
 
@@ -1800,7 +1826,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationRoleClaim", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ClaimType");
 
@@ -1818,7 +1845,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationUser", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int>("AccessFailedCount");
 
@@ -1862,7 +1890,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
 
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
-                        .HasName("UserNameIndex");
+                        .HasName("UserNameIndex")
+                        .HasFilter("[NormalizedUserName] IS NOT NULL");
 
                     b.ToTable("Users");
 
@@ -1888,7 +1917,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.ApplicationUserClaim", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<string>("ClaimType");
 
@@ -1958,7 +1988,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.CatapultEngineProfile", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("CatapultEngineId");
 
@@ -1979,7 +2010,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
                     b.HasKey("Id");
 
                     b.HasIndex("CatapultEngineId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[CatapultEngineId] IS NOT NULL");
 
                     b.ToTable("CatapultEngineProfile");
                 });
@@ -1987,7 +2019,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
             modelBuilder.Entity("Polyrific.Catapult.Api.Data.Identity.UserProfile", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
                     b.Property<int?>("ApplicationUserId");
 
@@ -2012,10 +2045,12 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
                     b.HasKey("Id");
 
                     b.HasIndex("ApplicationUserId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[ApplicationUserId] IS NOT NULL");
 
                     b.HasIndex("AvatarFileId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[AvatarFileId] IS NOT NULL");
 
                     b.ToTable("UserProfile");
 

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/20190513025236_ExternalServiceGlobal.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/20190513025236_ExternalServiceGlobal.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations
+{
+    public partial class ExternalServiceGlobal : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsGlobal",
+                table: "ExternalServices",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsGlobal",
+                table: "ExternalServices");
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultDbContextModelSnapshot.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultDbContextModelSnapshot.cs
@@ -66,6 +66,8 @@ namespace Polyrific.Catapult.Api.Data.Migrations
 
                     b.Property<int?>("ExternalServiceTypeId");
 
+                    b.Property<bool>("IsGlobal");
+
                     b.Property<string>("Name")
                         .IsRequired();
 

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190513025442_ExternalServiceGlobal.Designer.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190513025442_ExternalServiceGlobal.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Polyrific.Catapult.Api.Data;
 
 namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
 {
     [DbContext(typeof(CatapultSqliteDbContext))]
-    partial class CatapultSqliteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190513025442_ExternalServiceGlobal")]
+    partial class ExternalServiceGlobal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190513025442_ExternalServiceGlobal.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190513025442_ExternalServiceGlobal.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
+{
+    public partial class ExternalServiceGlobal : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsGlobal",
+                table: "ExternalServices",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsGlobal",
+                table: "ExternalServices");
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api.Data/UserRepository.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/UserRepository.cs
@@ -62,6 +62,7 @@ namespace Polyrific.Catapult.Api.Data
 
             var userProfile = _mapper.Map<UserProfile>(entity);
             userProfile.ApplicationUser = user;
+            userProfile.IsActive = true;
             await _userProfileRepository.Create(userProfile, cancellationToken);
 
             return user.Id;
@@ -79,6 +80,7 @@ namespace Polyrific.Catapult.Api.Data
 
             var userProfile = _mapper.Map<UserProfile>(entity);
             userProfile.ApplicationUser = user;
+            userProfile.IsActive = true;
             await _userProfileRepository.Create(userProfile, cancellationToken);
 
             return user.Id;

--- a/src/API/Polyrific.Catapult.Api/Controllers/ExternalServiceController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ExternalServiceController.cs
@@ -102,7 +102,8 @@ namespace Polyrific.Catapult.Api.Controllers
             {
                 Name = dto.Name,
                 Description = dto.Description,
-                ExternalServiceTypeId = dto.ExternalServiceTypeId
+                ExternalServiceTypeId = dto.ExternalServiceTypeId,
+                IsGlobal = dto.IsGlobal
             };
             _logger.LogRequest("Creating external service. Request body: {@requestBodyToLog}", requestBodyToLog);
 
@@ -114,7 +115,8 @@ namespace Polyrific.Catapult.Api.Controllers
                     dto.Description,
                     dto.ExternalServiceTypeId,
                     JsonConvert.SerializeObject(dto.Config),
-                    currentUserId);
+                    currentUserId,
+                    dto.IsGlobal);
 
                 var externalService = await _externalServiceService.GetExternalService(serviceId);
                 var result = _mapper.Map<ExternalServiceDto>(externalService);

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/AddCommand.cs
@@ -39,6 +39,9 @@ namespace Polyrific.Catapult.Cli.Commands.Service
         [Option("-d|--description <DESCRIPTION>", "Description of the external service", CommandOptionType.SingleValue)]
         public string Description { get; set; }
 
+        [Option("-g|--global", "Indicates whether the external service can be accessed globally?", CommandOptionType.NoValue)]
+        public bool Global { get; set; }
+
         [Option("-prop|--property <KEY>:<PROPERTY>", "Property of the external service", CommandOptionType.MultipleValue)]
         public (string, string)[] Property { get; set; }
 
@@ -106,6 +109,7 @@ namespace Polyrific.Catapult.Cli.Commands.Service
                         Name = Name,
                         Description = Description,
                         ExternalServiceTypeId = serviceType.Id,
+                        IsGlobal = Global,
                         Config = config
                     }).Result;
 

--- a/src/CLI/Polyrific.Catapult.Cli/Commands/Service/UpdateCommand.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Commands/Service/UpdateCommand.cs
@@ -36,6 +36,9 @@ namespace Polyrific.Catapult.Cli.Commands.Service
         [Option("-prop|--property <KEY>:<PROPERTY>", "Property of the external service", CommandOptionType.MultipleValue)]
         public (string, string)[] Property { get; set; }
 
+        [Option("-g|--global <ISGLOBAL>", "Indicates whether the external service can be accessed globally?", CommandOptionType.SingleValue)]
+        public bool? Global { get; set; }
+
         public override string Execute()
         {
             Console.WriteLine($"Trying to update external service \"{Name}\"...");
@@ -95,6 +98,7 @@ namespace Polyrific.Catapult.Cli.Commands.Service
                 _externalServiceService.UpdateExternalService(service.Id, new UpdateExternalServiceDto
                 {
                     Description = Description ?? service.Description,
+                    IsGlobal = Global ?? service.IsGlobal,
                     Config = service.Config
                 }).Wait();
                 message = $"External Service {Name} has been updated successfully";

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/ExternalService/CreateExternalServiceDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/ExternalService/CreateExternalServiceDto.cs
@@ -28,5 +28,10 @@ namespace Polyrific.Catapult.Shared.Dto.ExternalService
         /// </summary>
         [Required]
         public Dictionary<string, string> Config { get; set; }
+
+        /// <summary>
+        /// Is the external service can be access globally?
+        /// </summary>
+        public bool IsGlobal { get; set; }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/ExternalService/ExternalServiceDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/ExternalService/ExternalServiceDto.cs
@@ -35,5 +35,10 @@ namespace Polyrific.Catapult.Shared.Dto.ExternalService
         /// Config of the external service
         /// </summary>
         public Dictionary<string, string> Config { get; set; }
+
+        /// <summary>
+        /// Is the external service can be access globally?
+        /// </summary>
+        public bool IsGlobal { get; set; }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/ExternalService/UpdateExternalServiceDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/ExternalService/UpdateExternalServiceDto.cs
@@ -15,5 +15,10 @@ namespace Polyrific.Catapult.Shared.Dto.ExternalService
         /// Config of the external service
         /// </summary>
         public Dictionary<string, string> Config { get; set; }
+
+        /// <summary>
+        /// Is the external service can be access globally?
+        /// </summary>
+        public bool IsGlobal { get; set; }
     }
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/external-service/create-external-service-dto.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/external-service/create-external-service-dto.ts
@@ -3,4 +3,5 @@ export interface CreateExternalServiceDto {
   description: string;
   externalServiceTypeId: number;
   config: { [key: string]: string };
+  isGlobal: boolean;
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/external-service/external-service-dto.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/external-service/external-service-dto.ts
@@ -5,4 +5,5 @@ export interface ExternalServiceDto {
     externalServiceTypeId: number;
     externalServiceTypeName: string;
     config: { [key: string]: string };
+    isGlobal: boolean;
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/external-service/update-external-service-dto.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/external-service/update-external-service-dto.ts
@@ -1,4 +1,5 @@
 export interface UpdateExternalServiceDto {
   description: string;
   config: { [key: string]: string };
+  isGlobal: boolean;
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-form/external-service-form.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-form/external-service-form.component.html
@@ -1,5 +1,15 @@
 <div [formGroup]="externalServiceForm">
   <mat-form-field class="full-width-input">
+    <mat-select #serviceTypeControl placeholder="External Service Type" formControlName="externalServiceTypeId" (selectionChange)="onServiceTypeChanged($event)">
+      <mat-option *ngFor="let serviceType of externalServiceTypes$ | async" [value]="serviceType.id">
+        {{serviceType.name}}
+      </mat-option>
+    </mat-select>
+    <mat-error *ngIf="isFieldInvalid('externalServiceTypeId', 'required')">
+      Please inform the external service type
+    </mat-error>
+  </mat-form-field>
+  <mat-form-field class="full-width-input">
     <mat-label>Name</mat-label>
     <input matInput placeholder="Name of the external service"
       formControlName="name" required>
@@ -11,16 +21,9 @@
       <mat-label>Description</mat-label>
       <textarea matInput placeholder="The description of the external service" formControlName="description"></textarea>
   </mat-form-field>
-  <mat-form-field class="full-width-input">
-    <mat-select #serviceTypeControl placeholder="External Service Type" formControlName="externalServiceTypeId" (selectionChange)="onServiceTypeChanged($event)">
-      <mat-option *ngFor="let serviceType of externalServiceTypes$ | async" [value]="serviceType.id">
-        {{serviceType.name}}
-      </mat-option>
-    </mat-select>
-    <mat-error *ngIf="isFieldInvalid('externalServiceTypeId', 'required')">
-      Please inform the external service type
-    </mat-error>
-  </mat-form-field>
+  <div *ngIf="!isDefaultChecked">
+    <mat-checkbox formControlName="isGlobal">Allow global access?</mat-checkbox>
+  </div>
 
   <div *ngIf="showGenericProperties">
       <app-external-service-generic-form *ngFor="let genericForm of genericServiceProperties.controls; let idx = index"

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-form/external-service-form.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-form/external-service-form.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExternalServiceFormComponent } from './external-service-form.component';
 import { FlexModule } from '@angular/flex-layout';
 import { MatTableModule, MatIconModule, MatButtonModule, MatDialogModule,
-  MatInputModule, MatSelectModule, MatProgressBarModule, MatDividerModule } from '@angular/material';
+  MatInputModule, MatSelectModule, MatProgressBarModule, MatDividerModule, MatCheckboxModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { GenericService } from '@app/external-service/services/generic.service';
 import { SharedModule } from '@app/shared/shared.module';
@@ -33,6 +33,7 @@ describe('ExternalServiceFormComponent', () => {
         MatSelectModule,
         MatProgressBarModule,
         MatDividerModule,
+        MatCheckboxModule,
         CoreModule,
         SharedModule.forRoot()
       ],

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-form/external-service-form.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-form/external-service-form.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnInit, OnChanges, Input, Output, EventEmitter, SimpleChanges } from '@angular/core';
 import { Validators, FormGroup, FormBuilder, FormArray, FormControl } from '@angular/forms';
-import { ExternalServiceDto, genericExternalService } from '@app/core';
+import { ExternalServiceDto, genericExternalService, ExternalServiceType } from '@app/core';
 import { ExternalServiceTypeDto } from '@app/core/models/external-service/external-service-type-dto';
 import { ExternalServiceTypeService } from '@app/core/services/external-service-type.service';
 import { Observable } from 'rxjs';
 import { ExternalServicePropertyDto } from '@app/core/models/external-service/external-service-property-dto';
 import { tap } from 'rxjs/operators';
+import { MatSelectChange, MatOption } from '@angular/material';
 
 export interface ExternalServiceFormOutput {
   mainForm: FormGroup;
@@ -39,7 +40,8 @@ export class ExternalServiceFormComponent implements OnInit, OnChanges {
       name: [{value: null, disabled: this.disableForm}, Validators.required],
       description: [{value: null, disabled: this.disableForm}],
       externalServiceTypeId: [{value: null, disabled: this.disableForm}, Validators.required],
-      config: this.externalServiceConfigForm
+      config: this.externalServiceConfigForm,
+      isGlobal: [{value: false, disabled: this.disableForm}]
     });
 
     this.genericServiceProperties = this.fb.array([]);
@@ -119,8 +121,18 @@ export class ExternalServiceFormComponent implements OnInit, OnChanges {
       }));
   }
 
-  onServiceTypeChanged(control) {
+  onServiceTypeChanged(control: MatSelectChange) {
+    let defaultName = '';
+    if ((<MatOption>control.source.selected).viewValue === ExternalServiceType.Azure) {
+      defaultName = 'azure-default';
+    } else if ((<MatOption>control.source.selected).viewValue === ExternalServiceType.GitHub) {
+      defaultName = 'github-default';
+    }
+
     this.getExternalServiceType(control.value).subscribe();
+    this.externalServiceForm.patchValue({
+      name: defaultName
+    });
   }
 
   onAddGenericPropertyClick() {

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-info-dialog/external-service-info-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-info-dialog/external-service-info-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExternalServiceInfoDialogComponent } from './external-service-info-dialog.component';
 import { FlexModule } from '@angular/flex-layout';
 import { MatTableModule, MatIconModule, MatButtonModule, MatDialogModule, MatInputModule,
-  MatSelectModule, MatProgressBarModule, MatDividerModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+  MatSelectModule, MatProgressBarModule, MatDividerModule, MatDialogRef, MAT_DIALOG_DATA, MatCheckboxModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { CoreModule } from '@app/core';
 import { SharedModule } from '@app/shared/shared.module';
@@ -39,6 +39,7 @@ describe('ExternalServiceInfoDialogComponent', () => {
         MatSelectModule,
         MatProgressBarModule,
         MatDividerModule,
+        MatCheckboxModule,
         CoreModule,
         SharedModule.forRoot()
       ],

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-new-dialog/external-service-new-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-new-dialog/external-service-new-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExternalServiceNewDialogComponent } from './external-service-new-dialog.component';
 import { FlexModule } from '@angular/flex-layout';
 import { MatTableModule, MatIconModule, MatButtonModule, MatDialogModule, MatInputModule,
-  MatSelectModule, MatProgressBarModule, MatDividerModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+  MatSelectModule, MatProgressBarModule, MatDividerModule, MatDialogRef, MAT_DIALOG_DATA, MatCheckboxModule } from '@angular/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { CoreModule } from '@app/core';
 import { SharedModule } from '@app/shared/shared.module';
@@ -39,6 +39,7 @@ describe('ExternalServiceNewDialogComponent', () => {
         MatSelectModule,
         MatProgressBarModule,
         MatDividerModule,
+        MatCheckboxModule,
         CoreModule,
         SharedModule.forRoot()
       ],

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service.module.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service.module.ts
@@ -4,7 +4,8 @@ import { CommonModule } from '@angular/common';
 import { ExternalServiceRoutingModule } from './external-service-routing.module';
 import { ExternalServiceComponent } from './external-service/external-service.component';
 import { MatTableModule, MatIconModule, MatButtonModule, MatDialogModule,
-  MatInputModule, MatSelectModule, MatProgressBarModule, MatDividerModule, MatProgressSpinnerModule } from '@angular/material';
+  MatInputModule, MatSelectModule, MatProgressBarModule, MatDividerModule, MatProgressSpinnerModule,
+  MatCheckboxModule } from '@angular/material';
 import { ExternalServiceInfoDialogComponent } from './components/external-service-info-dialog/external-service-info-dialog.component';
 import { ExternalServiceNewDialogComponent } from './components/external-service-new-dialog/external-service-new-dialog.component';
 import { ExternalServiceFormComponent } from './components/external-service-form/external-service-form.component';
@@ -38,7 +39,8 @@ import { SharedModule } from '@app/shared/shared.module';
     MatProgressBarModule,
     MatProgressSpinnerModule,
     MatDividerModule,
-    SharedModule
+    SharedModule,
+    MatCheckboxModule
   ],
   providers: [
     GenericService

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service/external-service.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service/external-service.component.html
@@ -38,6 +38,12 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header> Type </th>
       <td mat-cell *matCellDef="let element"> {{element.externalServiceTypeName}} </td>
     </ng-container>
+
+    <!-- externalServiceTypeName Column -->
+    <ng-container matColumnDef="isGlobal">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Allow global access? </th>
+      <td mat-cell *matCellDef="let element"> {{element.isGlobal ? 'Yes' : 'No'}} </td>
+    </ng-container>
     <!-- Action Column -->
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef> </th>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service/external-service.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service/external-service.component.spec.ts
@@ -11,6 +11,7 @@ import { SharedModule } from '@app/shared/shared.module';
 import { CoreModule } from '@app/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ExternalServiceComponent', () => {
   let component: ExternalServiceComponent;
@@ -22,6 +23,7 @@ describe('ExternalServiceComponent', () => {
       imports: [
         BrowserAnimationsModule,
         HttpClientTestingModule,
+        RouterTestingModule,
         FlexModule,
         MatTableModule,
         MatIconModule,

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service/external-service.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/external-service/external-service.component.ts
@@ -1,31 +1,43 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit } from '@angular/core';
 import { ExternalServiceDto, ExternalServiceService } from '@app/core';
 import { MatDialog } from '@angular/material';
 import { SnackbarService, ConfirmationDialogComponent } from '@app/shared';
 import { ExternalServiceInfoDialogComponent } from '../components/external-service-info-dialog/external-service-info-dialog.component';
 import { ExternalServiceNewDialogComponent } from '../components/external-service-new-dialog/external-service-new-dialog.component';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-external-service',
   templateUrl: './external-service.component.html',
   styleUrls: ['./external-service.component.css']
 })
-export class ExternalServiceComponent implements OnInit {
+export class ExternalServiceComponent implements OnInit, AfterViewInit {
   externalServices: ExternalServiceDto[];
   projectId: number;
   roleId = 0;
   loading: boolean;
 
-  displayedColumns: string[] = ['name', 'description', 'externalServiceTypeName', 'actions'];
+  displayedColumns: string[] = ['name', 'description', 'externalServiceTypeName', 'isGlobal', 'actions'];
 
   constructor(
     private externalServiceService: ExternalServiceService,
+    private route: ActivatedRoute,
     private dialog: MatDialog,
     private snackbar: SnackbarService
     ) { }
 
   ngOnInit() {
     this.getExternalServices();
+  }
+
+  ngAfterViewInit() {
+    this.route.queryParams.subscribe(data => {
+      if (data.newService) {
+        setTimeout(() => {
+          this.onNewExternalServiceClick();
+        }, 0);
+      }
+    });
   }
 
   getExternalServices() {

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
@@ -137,12 +137,27 @@ export class JobDefinitionComponent implements OnInit {
           originUrl: window.location.origin
         }).subscribe(data => this.router.navigateByUrl(`project/${this.projectId}/job-queue`),
           err => {
-            this.dialog.open(MessageDialogComponent, {
-              data: {
-                title: 'Queue Job Failed',
-                message: `${err}\n\nPlease make sure each task configuration is properly set.`
-              }
-            });
+            if (err.includes('have invalid task(s): External service') && err.includes('is not found')) {
+              const addServiceDialogRef = this.dialog.open(ConfirmationDialogComponent, {
+                data: {
+                  title: 'Add External Service?',
+                  confirmationText: `${err}. Do you want to create it now?`
+                }
+              });
+
+              addServiceDialogRef.afterClosed().subscribe(confirmed => {
+                if (confirmed) {
+                  this.router.navigateByUrl('/service?newService=true');
+                }
+              });
+            } else {
+              this.dialog.open(MessageDialogComponent, {
+                data: {
+                  title: 'Queue Job Failed',
+                  message: `${err}\n\nPlease make sure each task configuration is properly set.`
+                }
+              });
+            }
           });
       }
     });

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/ExternalServiceControllerTests.cs.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/ExternalServiceControllerTests.cs.cs
@@ -113,7 +113,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         public async void CreateExternalService_ReturnsCreatedExternalService()
         {
             _externalServiceService
-                .Setup(s => s.AddExternalService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Setup(s => s.AddExternalService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(1);
             _externalServiceService.Setup(s => s.GetExternalService(It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((int id, CancellationToken cancellationToken) =>

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ExternalServiceServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ExternalServiceServiceTests.cs
@@ -81,7 +81,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void AddExternalService_ValidItem()
         {
             var externalServiceService = new ExternalServiceService(_externalServiceRepository.Object, _secretVault.Object);
-            int newId = await externalServiceService.AddExternalService("vstsBuild", null, 1, "config", 1);
+            int newId = await externalServiceService.AddExternalService("vstsBuild", null, 1, "config", 1, false);
 
             Assert.True(newId > 1);
             Assert.True(_data.Count > 1);
@@ -92,7 +92,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddExternalService_InvalidProject()
         {
             var externalServiceService = new ExternalServiceService(_externalServiceRepository.Object, _secretVault.Object);
-            var exception = Record.ExceptionAsync(() => externalServiceService.AddExternalService("Github-Default", null, 1, "config", 1));
+            var exception = Record.ExceptionAsync(() => externalServiceService.AddExternalService("Github-Default", null, 1, "config", 1, false));
 
             Assert.IsType<DuplicateExternalServiceException>(exception?.Result);
         }


### PR DESCRIPTION
## Summary
Add flag `IsGlobal` to external service to have an external service that can be shared to other users within the opencatapult app

## Coverage
- [x] Add `ExternalService.IsGlobal` flag in API
- [x] Implement `ExternalService.IsGlobal` in web UI
- [x] Implement `ExternalService.IsGlobal` in CLI
- [x] Rearrange external service fields so External service type is shown at the top. The name can then be autopopulated based on the selected type
- [x] When queueing a job and an external service is not exist, display modal dialog to ask user to create one.
- [x] Some bugfixes in create user/engine

