### PR TITLE
Highlight task that have incorrect configuration

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/JobTaskDefinition.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/JobTaskDefinition.cs
@@ -43,5 +43,15 @@ namespace Polyrific.Catapult.Api.Core.Entities
         /// Sequence of the job task definition
         /// </summary>
         public int? Sequence { get; set; }
+
+        /// <summary>
+        /// Is the job task definition valid?
+        /// </summary>
+        public bool? Valid { get; set; }
+
+        /// <summary>
+        /// Validation error message
+        /// </summary>
+        public string ValidationError { get; set; }
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -141,9 +141,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// Get list of job task definitions for a job definition
         /// </summary>
         /// <param name="jobDefinitionId">Id of the job definition</param>
+        /// <param name="validate">Do validation?</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>List of job task definitions</returns>
-        Task<List<JobTaskDefinition>> GetJobTaskDefinitions(int jobDefinitionId, CancellationToken cancellationToken = default(CancellationToken));
+        Task<List<JobTaskDefinition>> GetJobTaskDefinitions(int jobDefinitionId, bool validate = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get a job task definition by id
@@ -167,9 +168,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// </summary>
         /// <param name="jobDefinition">The job definition object</param>
         /// <param name="jobTaskDefinition">The job task definition object</param>
+        /// <param name="encryptConfig">Encrypt additional config?</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns></returns>
-        Task ValidateJobTaskDefinition(JobDefinition jobDefinition, JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
+        Task ValidateJobTaskDefinition(JobDefinition jobDefinition, JobTaskDefinition jobTaskDefinition, bool encryptConfig = true, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Encrypt all secret additional config in a task

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -350,10 +350,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         {
             try
             {
-                var tasks = await _jobDefinitionService.GetJobTaskDefinitions(jobDefinition.Id, cancellationToken);
+                var tasks = await _jobDefinitionService.GetJobTaskDefinitions(jobDefinition.Id, cancellationToken: cancellationToken);
                 foreach (var task in tasks)
                 {
-                    await _jobDefinitionService.ValidateJobTaskDefinition(jobDefinition, task, cancellationToken);
+                    await _jobDefinitionService.ValidateJobTaskDefinition(jobDefinition, task, encryptConfig: false, cancellationToken: cancellationToken);
                 }
             }
             catch (Exception ex)

--- a/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/JobTaskDefinitionConfig.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/EntityConfigs/JobTaskDefinitionConfig.cs
@@ -1,11 +1,18 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Polyrific.Catapult.Api.Core.Entities;
 
 namespace Polyrific.Catapult.Api.Data.EntityConfigs
 {
     public class JobTaskDefinitionConfig : BaseEntityConfig<JobTaskDefinition>
     {
-        
+        public override void Configure(EntityTypeBuilder<JobTaskDefinition> builder)
+        {
+            base.Configure(builder);
+
+            builder.Ignore(p => p.Valid);
+            builder.Ignore(p => p.ValidationError);
+        }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -469,13 +469,14 @@ namespace Polyrific.Catapult.Api.Controllers
         /// Get job task definitions for a job definition
         /// </summary>
         /// <param name="jobId">Id of the job definition</param>
+        /// <param name="validate">Do validation?</param>
         /// <returns>List of job task definitions</returns>
         [HttpGet("Project/{projectId}/job/{jobId}/task", Name = "GetJobTaskDefinitions")]
-        public async Task<IActionResult> GetJobTaskDefinitions(int jobId)
+        public async Task<IActionResult> GetJobTaskDefinitions(int jobId, bool validate = false)
         {
             _logger.LogRequest("Getting job task definitions in job {jobId}", jobId);
 
-            var jobTaskDefinitions = await _jobDefinitionService.GetJobTaskDefinitions(jobId);
+            var jobTaskDefinitions = await _jobDefinitionService.GetJobTaskDefinitions(jobId, validate);
             var results = _mapper.Map<List<JobTaskDefinitionDto>>(jobTaskDefinitions);
 
             _logger.LogResponse("Job task definitions in job {jobId} retrieved. Response body: {@results}", jobId, results);

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobTaskDefinitionDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/JobDefinition/JobTaskDefinitionDto.cs
@@ -45,5 +45,15 @@ namespace Polyrific.Catapult.Shared.Dto.JobDefinition
         /// Sequence of the job task definition
         /// </summary>
         public int? Sequence { get; set; }
+
+        /// <summary>
+        /// Is the job task definition valid?
+        /// </summary>
+        public bool? Valid { get; set; }
+
+        /// <summary>
+        /// Validation error message
+        /// </summary>
+        public string ValidationError { get; set; }
     }
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/job-definition/job-task-definition-dto.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/models/job-definition/job-task-definition-dto.ts
@@ -7,4 +7,6 @@ export interface JobTaskDefinitionDto {
   configs: { [key: string]: string };
   additionalConfigs: { [key: string]: string };
   sequence: number;
+  valid: boolean;
+  validationError: string;
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/services/job-definition.service.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/services/job-definition.service.ts
@@ -15,8 +15,8 @@ export class JobDefinitionService {
     return this.api.get<JobDefinitionDto[]>(`project/${projectId}/job`);
   }
 
-  getJobTaskDefinitions(projectId: number, jobDefinitionId: number) {
-    return this.api.get<JobTaskDefinitionDto[]>(`project/${projectId}/job/${jobDefinitionId}/task`);
+  getJobTaskDefinitions(projectId: number, jobDefinitionId: number, validate: boolean) {
+    return this.api.get<JobTaskDefinitionDto[]>(`project/${projectId}/job/${jobDefinitionId}/task?validate=${validate}`);
   }
 
   getDeletionJobDefinition(projectId: number) {

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.html
@@ -12,7 +12,7 @@
 </div>
 <app-loading-spinner *ngIf="loading"></app-loading-spinner>
 <mat-accordion class="headers-align" *ngIf="!loading">
-<mat-expansion-panel *ngFor="let jobDefinition of jobDefinitions"
+<mat-expansion-panel *ngFor="let jobDefinition of jobDefinitions" [expanded]="jobDefinition.expanded"
   (afterExpand)="onTaskExpanded(jobDefinition)">
   <mat-expansion-panel-header>
     <mat-panel-title>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.spec.ts
@@ -4,7 +4,7 @@ import { JobDefinitionComponent } from './job-definition.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatButtonModule, MatExpansionModule, MatListModule, MatIconModule,
-  MatCheckboxModule, MatDialogModule, MatSnackBarModule, MatProgressSpinnerModule } from '@angular/material';
+  MatCheckboxModule, MatDialogModule, MatSnackBarModule, MatProgressSpinnerModule, MatTooltipModule } from '@angular/material';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { CoreModule } from '@app/core';
 import { FormsModule } from '@angular/forms';
@@ -38,6 +38,7 @@ describe('JobDefinitionComponent', () => {
         DragDropModule,
         MatProgressSpinnerModule,
         MatCheckboxModule,
+        MatTooltipModule,
         SharedModule.forRoot()
       ],
       providers: [

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-task-definition/job-task-definition.component.css
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-task-definition/job-task-definition.component.css
@@ -36,3 +36,7 @@ mat-list-item {
   opacity: 0;
 }
 
+.error {
+  color: #9c1212;
+  margin-left: 8px;
+}

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-task-definition/job-task-definition.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-task-definition/job-task-definition.component.html
@@ -2,7 +2,9 @@
   <mat-list-item *ngFor="let task of jobTaskDefinitions" cdkDrag>
     <div fxLayout="row" fxLayoutAlign="space-between center" class="task-item">
       <div fxLayout="row" fxLayoutAlign="flex-start center">
-          <mat-icon>drag_handle</mat-icon> {{task.name}} <span class="task-provider">({{task.provider}})</span>
+          <mat-icon>drag_handle</mat-icon> {{task.name}}
+          <span class="task-provider">({{task.provider}})</span>
+          <mat-icon *ngIf="task.valid === false" matTooltip="{{task.validationError}}" class="error">error</mat-icon>
       </div>
       <div class="action-buttons">
         <button mat-icon-button (click)="onTaskInfoClick(task)">

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-task-definition/job-task-definition.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-task-definition/job-task-definition.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { JobTaskDefinitionComponent } from './job-task-definition.component';
-import { MatButtonModule, MatListModule, MatIconModule, MatDialogModule, MatSnackBarModule } from '@angular/material';
+import { MatButtonModule, MatListModule, MatIconModule, MatDialogModule, MatSnackBarModule, MatTooltipModule } from '@angular/material';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { CoreModule } from '@app/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -24,7 +24,8 @@ describe('JobTaskDefinitionComponent', () => {
         MatDialogModule,
         HttpClientTestingModule,
         DragDropModule,
-        MatSnackBarModule
+        MatSnackBarModule,
+        MatTooltipModule
       ],
       providers: [
         SnackbarService

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.html
@@ -18,15 +18,13 @@
   </mat-card-header>
   <mat-card-content>
       <nav mat-tab-nav-bar flex>
-          <a mat-tab-link (click)="activeLink = 'info'" [active]="activeLink == 'info'" routerLink='info'>Info</a>
-          <a mat-tab-link (click)="activeLink = 'data-model'" [active]="activeLink == 'data-model'" routerLink='data-model'>Data Models</a>
-          <a mat-tab-link (click)="activeLink = 'job-definition'"
-            [active]="activeLink == 'job-definition'" routerLink='job-definition'
+          <a mat-tab-link routerLink="info" routerLinkActive #rlaInfo="routerLinkActive" [active]="rlaInfo.isActive">Info</a>
+          <a mat-tab-link routerLink="data-model"  routerLinkActive #rlaModel="routerLinkActive" [active]="rlaModel.isActive">Data Models</a>
+          <a mat-tab-link routerLink="job-definition" routerLinkActive #rlaJob="routerLinkActive" [active]="rlaJob.isActive"
             *appHasAccess="authorizePolicy.ProjectContributorAccess">Job Definitions</a>
-          <a mat-tab-link (click)="activeLink = 'job-queue'"
-            [active]="activeLink == 'job-queue'" routerLink='job-queue'
+          <a mat-tab-link routerLink="job-queue" routerLinkActive #rlaQueue="routerLinkActive" [active]="rlaQueue.isActive"
             *appHasAccess="authorizePolicy.ProjectMaintainerAccess">Job Queues</a>
-          <a mat-tab-link (click)="activeLink = 'member'" [active]="activeLink == 'member'" routerLink='member'>Members</a>
+          <a mat-tab-link routerLink="member" routerLinkActive #rlaMember="routerLinkActive" [active]="rlaMember.isActive">Members</a>
       </nav>
       <router-outlet></router-outlet>
   </mat-card-content>

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
@@ -229,7 +229,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void GetJobTaskDefinitions_ReturnsJobTaskDefinitionList()
         {
-            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<JobTaskDefinition>
                 {
                     new JobTaskDefinition
@@ -311,7 +311,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void UpdateJobTaskOrder_ReturnsSuccess()
         {
-            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<JobTaskDefinition>
                 {
                     new JobTaskDefinition

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -123,8 +123,8 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                         Id = id,
                         Name = "Default"
                     });
-            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int id, CancellationToken token) =>
+            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int id, bool validate, CancellationToken token) =>
                     new List<JobTaskDefinition>
                     {
                         new JobTaskDefinition
@@ -133,7 +133,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                             JobDefinitionId = id
                         }
                     });
-            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
         }
 
@@ -176,7 +176,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public void AddJobQueue_TaskValidationException()
         {
-            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Throws(new ExternalServiceNotFoundException("GitHub"));
 
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _userRepository.Object, _jobCounterService.Object, _jobDefinitionService.Object, _textWriter.Object, _notificationProvider.Object);


### PR DESCRIPTION
## Summary
Highlight the task have incorrect configurations in job definition list

## Coverage
- [x] Add valid flag to get task API endpoint
- [x] Highlight the task that have valid flag = false
- [x] Expand the job that is queued to show the invalid tasks
- [x] Redirect to job definition tab after queueing default job

## References
- Related Issues: #527 