### PR TITLE
Run API as windows service

### DIFF
--- a/src/API/Polyrific.Catapult.Api/CustomWebHostService.cs
+++ b/src/API/Polyrific.Catapult.Api/CustomWebHostService.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.WindowsServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Polyrific.Catapult.Api
+{
+    public class CustomWebHostService : WebHostService
+    {
+        private ILogger _logger;
+
+        public CustomWebHostService(IWebHost host) : base(host)
+        {
+            _logger = host.Services.GetRequiredService<ILogger<CustomWebHostService>>();
+        }
+
+        protected override void OnStarting(string[] args)
+        {
+            _logger.LogInformation("Starting OpenCatapult API service.");
+
+            base.OnStarting(args);
+        }
+
+        protected override void OnStarted()
+        {
+            _logger.LogInformation("OpenCatapult API service has started.");
+
+            base.OnStarted();
+        }
+
+        protected override void OnStopping()
+        {
+            _logger.LogInformation("Stopping OpenCatapult API service.");
+
+            base.OnStopping();
+        }
+
+        protected override void OnStopped()
+        {
+            _logger.LogInformation("OpenCatapult API service has stopped.");
+
+            base.OnStopping();
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/CustomWebHostService.cs
+++ b/src/API/Polyrific.Catapult.Api/CustomWebHostService.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Polyrific, Inc 2019. All rights reserved.
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.WindowsServices;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
+++ b/src/API/Polyrific.Catapult.Api/Polyrific.Catapult.Api.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="CorrelationId" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />

--- a/src/API/Polyrific.Catapult.Api/WebHostExtensions.cs
+++ b/src/API/Polyrific.Catapult.Api/WebHostExtensions.cs
@@ -1,0 +1,14 @@
+using System.ServiceProcess;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Polyrific.Catapult.Api
+{
+    public static class WebHostExtensions
+    {
+        public static void RunAsCustomService(this IWebHost host)
+        {
+            var webHostService = new CustomWebHostService(host);
+            ServiceBase.Run(webHostService);
+        }
+    }
+}

--- a/src/API/Polyrific.Catapult.Api/WebHostExtensions.cs
+++ b/src/API/Polyrific.Catapult.Api/WebHostExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Polyrific, Inc 2019. All rights reserved.
+
 using System.ServiceProcess;
 using Microsoft.AspNetCore.Hosting;
 

--- a/tools/api/install-service.bat
+++ b/tools/api/install-service.bat
@@ -1,0 +1,20 @@
+:: Please put this file in the same directory as the ocapi.exe file
+
+@ECHO OFF
+
+IF "%~1"=="/u" (CALL :Uninstall) ELSE (CALL :Install)
+EXIT /B %ERRORLEVEL%
+
+:Install
+SET name="OpenCatapult API"
+SET desc="Service for OpenCatapult API"
+SET binpath="%~dp0ocapi.exe --service --urls \"http://localhost:8005\""
+
+sc create ocapi DisplayName= %name% binPath= %binPath% start= auto
+sc start ocapi
+EXIT /B 0
+
+:Uninstall
+sc stop ocapi
+sc delete ocapi
+EXIT /B 0


### PR DESCRIPTION
## Summary
Allow API to run as Windows service. The `install-service.bat` script will help the users to install the API to the Windows Service. This script will be copied to the root folder of the published package.

## Coverage
- [x] Prepare host service
- [x] Create `install-service.bat`