### PR TITLE
Fix issue in delete project when using sqlite

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190507060100_SqliteInitMigration.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190507060100_SqliteInitMigration.cs
@@ -669,7 +669,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
                         column: x => x.RelatedProjectDataModelId,
                         principalTable: "ProjectDataModels",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.InsertData(

--- a/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190507060100_SqliteInitMigration.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/Migrations/CatapultSqliteDb/20190507060100_SqliteInitMigration.cs
@@ -669,7 +669,7 @@ namespace Polyrific.Catapult.Api.Data.Migrations.CatapultSqliteDb
                         column: x => x.RelatedProjectDataModelId,
                         principalTable: "ProjectDataModels",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.InsertData(

--- a/src/API/Polyrific.Catapult.Api.Data/ProjectRepository.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/ProjectRepository.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Api.Core.Repositories;
 
@@ -13,6 +16,20 @@ namespace Polyrific.Catapult.Api.Data
 
         public ProjectRepository(CatapultSqliteDbContext dbContext) : base(dbContext)
         {
+        }
+
+        public override async Task Delete(int id, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Remove all data model properties to avoid FK conflict of "RelatedProjectDataModel"
+            var properties = Db.Set<ProjectDataModelProperty>().Where(p => p.ProjectDataModel.ProjectId == id);
+            Db.ProjectDataModelProperties.RemoveRange(properties);
+
+            var dbSet = Db.Set<Project>();
+            var entity = await dbSet.FindAsync(id);
+            dbSet.Remove(entity);
+            await Db.SaveChangesAsync(cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary
When using sqlite, I get an error when trying to delete a project: `SQLite Error 19: 'FOREIGN KEY constraint failed'`

After investigating, the issue occured because there's often foreign key conflict in `ProjectDataModels.RelatedDataModelId`. It seems the `mssql` handles this more intelligently, so that the execution order of a deletion process does not have the same error.  

My solution here is to modify the `20190507060100_SqliteInitMigration` migration file so that the `RelatedDataModelId` foreign key is `Cascade` on delete. I did not create a new migration file bacause it would result in error since sqlite does not really support modifying the foreign key property:
`https://github.com/aspnet/EntityFramework.Docs/issues/32`

Note: If you currently have existing database file, you would not to delete it first for this fix to work.