### PR TITLE
Fix signalr file lock

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
@@ -210,7 +210,7 @@ namespace Polyrific.Catapult.Api.Core.Services
 
             foreach (var dataModel in dataModels)
             {
-                dataModel.Properties = dataModel.Properties.OrderBy(p => p.Sequence).ToList();
+                dataModel.Properties = dataModel.Properties?.OrderBy(p => p.Sequence).ToList();
             }
 
             return dataModels;

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobQueueController.cs
@@ -255,7 +255,7 @@ namespace Polyrific.Catapult.Api.Controllers
                 return Unauthorized();
 
             // log as debug so it won't be put to log when min level is Info
-            _logger.LogDebug("Checking for job queue");
+            _logger.LogRequestDebug("Checking for job queue");
 
             var isEngine = User.IsInRole(UserRole.Engine);
 
@@ -269,7 +269,7 @@ namespace Polyrific.Catapult.Api.Controllers
             // update engine's last seen
             await _engineService.UpdateLastSeen(engineName, GetEngineVersion(Request.Headers["User-Agent"].ToString()));
             
-            _logger.LogResponse("Queued job queue checked. Response body: {@result}", result);
+            _logger.LogResponseDebug("Queued job queue checked. Response body: {@result}", result);
 
             return Ok(result);
         }

--- a/src/API/Polyrific.Catapult.Api/LoggerExtensions.cs
+++ b/src/API/Polyrific.Catapult.Api/LoggerExtensions.cs
@@ -10,9 +10,18 @@ namespace Polyrific.Catapult.Api
         {
             logger.LogInformation($"[Req] {message}", args);
         }
+        public static void LogRequestDebug(this ILogger logger, string message, params object[] args)
+        {
+            logger.LogDebug($"[Req] {message}", args);
+        }
+
         public static void LogResponse(this ILogger logger, string message, params object[] args)
         {
             logger.LogInformation($"[Res] {message}", args);
+        }
+        public static void LogResponseDebug(this ILogger logger, string message, params object[] args)
+        {
+            logger.LogDebug($"[Res] {message}", args);
         }
     }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Common/FileHelper.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/FileHelper.cs
@@ -13,9 +13,12 @@ namespace Polyrific.Catapult.Shared.Common
         public static async Task<string> ReadAllTextAsync(string path)
         {
             string text;
-            using (var reader = File.OpenText(path))
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
-                text = await reader.ReadToEndAsync();
+                using (var reader = new StreamReader(fileStream))
+                {
+                    text = await reader.ReadToEndAsync();
+                }
             }
 
             return text;
@@ -33,11 +36,14 @@ namespace Polyrific.Catapult.Shared.Common
 
         public static async Task AppendAllTextAsync(string path, string content)
         {
-            using (var writer = File.AppendText(path))
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite))
             {
-                await writer.WriteAsync(content);
+                using (var writer = new StreamWriter(fileStream))
+                {
+                    await writer.WriteAsync(content);
 
-                await writer.FlushAsync();
+                    await writer.FlushAsync();
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fix occasional issue where we got the error `The process cannot access the file 'log file' because it is being used by another process.` in SignalR engine log

## PR Coverages
- [x] Fix log file issue in signalR engine log
- [x] small fixes in job queue controller
- [x] small fixes in data model service