### PR TITLE
Trigger validation when clicking submit

### DIFF
--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-info-dialog/external-service-info-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-info-dialog/external-service-info-dialog.component.ts
@@ -5,6 +5,7 @@ import { SnackbarService } from '@app/shared';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { ExternalServiceFormOutput } from '../external-service-form/external-service-form.component';
 import { GenericService } from '@app/external-service/services/generic.service';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 @Component({
   selector: 'app-external-service-info-dialog',
@@ -24,6 +25,7 @@ export class ExternalServiceInfoDialogComponent implements OnInit {
     private fb: FormBuilder,
     private externalServiceService: ExternalServiceService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     private genericService: GenericService,
     public dialogRef: MatDialogRef<ExternalServiceInfoDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public externalService: ExternalServiceDto
@@ -60,6 +62,9 @@ export class ExternalServiceInfoDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.externalServiceForm);
+      this.utilityService.markControlsAsTouched(this.genericConfigForm);
     }
   }
 
@@ -69,6 +74,8 @@ export class ExternalServiceInfoDialogComponent implements OnInit {
   }
 
   onCancelClick() {
+    this.utilityService.markControlsAsTouched(this.externalServiceForm, false);
+    this.utilityService.markControlsAsTouched(this.genericConfigForm, false);
     this.editing = false;
     this.genericService.patchFormValue(this.externalServiceForm, this.genericConfigForm, this.externalServiceWithProp);
     this.genericConfigForm.disable();

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-new-dialog/external-service-new-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/external-service/components/external-service-new-dialog/external-service-new-dialog.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { FormGroup, FormArray } from '@angular/forms';
+import { FormGroup, FormArray, AbstractControl } from '@angular/forms';
 import { ExternalServiceService } from '@app/core';
 import { SnackbarService } from '@app/shared';
 import { MatDialogRef } from '@angular/material';
 import { GenericService } from '@app/external-service/services/generic.service';
 import { ExternalServiceFormOutput } from '../external-service-form/external-service-form.component';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 @Component({
   selector: 'app-external-service-new-dialog',
@@ -19,6 +20,7 @@ export class ExternalServiceNewDialogComponent implements OnInit {
   constructor (
     private externalServiceService: ExternalServiceService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     private genericService: GenericService,
     public dialogRef: MatDialogRef<ExternalServiceNewDialogComponent>
     ) {
@@ -46,6 +48,9 @@ export class ExternalServiceNewDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.externalServiceForm);
+      this.utilityService.markControlsAsTouched(this.genericConfigForm);
     }
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-info-dialog/data-model-info-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-info-dialog/data-model-info-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { DataModelFormComponent } from '../data-model-form/data-model-form.compo
 import { CoreModule } from '@app/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SnackbarService } from '@app/shared';
+import { SharedModule } from '@app/shared/shared.module';
 
 describe('DataModelInfoDialogComponent', () => {
   let component: DataModelInfoDialogComponent;
@@ -26,7 +27,8 @@ describe('DataModelInfoDialogComponent', () => {
         MatProgressBarModule,
         MatDialogModule,
         MatSnackBarModule,
-        CoreModule
+        CoreModule,
+        SharedModule.forRoot()
       ],
       providers: [
         SnackbarService,

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-info-dialog/data-model-info-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-info-dialog/data-model-info-dialog.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { DataModelService, DataModelDto } from '@app/core';
 import { SnackbarService } from '@app/shared';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 @Component({
   selector: 'app-data-model-info-dialog',
@@ -20,6 +21,7 @@ export class DataModelInfoDialogComponent implements OnInit {
     private fb: FormBuilder,
     private dataModelService: DataModelService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     public dialogRef: MatDialogRef<DataModelInfoDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public dataModel: DataModelDto
     ) {
@@ -51,6 +53,8 @@ export class DataModelInfoDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.dataModelForm);
     }
   }
 
@@ -59,6 +63,7 @@ export class DataModelInfoDialogComponent implements OnInit {
   }
 
   onCancelClick() {
+    this.utilityService.markControlsAsTouched(this.dataModelForm, false);
     this.editing = false;
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-new-dialog/data-model-new-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-new-dialog/data-model-new-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { DataModelFormComponent } from '../data-model-form/data-model-form.compo
 import { CoreModule } from '@app/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SnackbarService } from '@app/shared';
+import { SharedModule } from '@app/shared/shared.module';
 
 describe('DataModelNewDialogComponent', () => {
   let component: DataModelNewDialogComponent;
@@ -26,7 +27,8 @@ describe('DataModelNewDialogComponent', () => {
         MatProgressBarModule,
         MatDialogModule,
         MatSnackBarModule,
-        CoreModule
+        CoreModule,
+        SharedModule.forRoot()
       ],
       providers: [
         SnackbarService,

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-new-dialog/data-model-new-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-new-dialog/data-model-new-dialog.component.ts
@@ -3,6 +3,7 @@ import { DataModelDto, DataModelService } from '@app/core';
 import { FormGroup } from '@angular/forms';
 import { SnackbarService } from '@app/shared';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 export interface NewModelDialogData {
   projectId: number;
@@ -20,6 +21,7 @@ export class DataModelNewDialogComponent implements OnInit {
   constructor (
     private dataModelService: DataModelService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     public dialogRef: MatDialogRef<DataModelNewDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: NewModelDialogData
     ) {
@@ -46,6 +48,8 @@ export class DataModelNewDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.dataModelForm);
     }
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { MatInputModule, MatCheckboxModule, MatProgressBarModule, MatDialogModul
 import { CoreModule } from '@app/core';
 import { SnackbarService } from '@app/shared';
 import { DataModelPropertyFormComponent } from '../data-model-property-form/data-model-property-form.component';
+import { SharedModule } from '@app/shared/shared.module';
 
 describe('DataModelPropertyInfoDialogComponent', () => {
   let component: DataModelPropertyInfoDialogComponent;
@@ -29,7 +30,8 @@ describe('DataModelPropertyInfoDialogComponent', () => {
         CoreModule,
         MatCheckboxModule,
         MatSelectModule,
-        MatDividerModule
+        MatDividerModule,
+        SharedModule.forRoot()
       ],
       providers: [
         SnackbarService,

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { DataModelService, DataModelPropertyDto, DataModelDto } from '@app/core';
 import { SnackbarService } from '@app/shared';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 export interface DataModelPropertyViewModel extends DataModelPropertyDto {
   projectId: number;
@@ -26,6 +27,7 @@ export class DataModelPropertyInfoDialogComponent implements OnInit {
     private fb: FormBuilder,
     private dataModelService: DataModelService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     public dialogRef: MatDialogRef<DataModelPropertyInfoDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public dataModelProperty: DataModelPropertyViewModel
     ) {
@@ -59,6 +61,8 @@ export class DataModelPropertyInfoDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.dataModelPropertyForm);
     }
   }
 
@@ -67,6 +71,7 @@ export class DataModelPropertyInfoDialogComponent implements OnInit {
   }
 
   onCancelClick() {
+    this.utilityService.markControlsAsTouched(this.dataModelPropertyForm, false);
     this.editing = false;
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-new-dialog/data-model-property-new-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-new-dialog/data-model-property-new-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { MatInputModule, MatCheckboxModule, MatProgressBarModule,
   MatDialogModule, MatSnackBarModule, MatDialogRef, MAT_DIALOG_DATA, MatSelectModule, MatDividerModule } from '@angular/material';
 import { CoreModule } from '@app/core';
 import { SnackbarService } from '@app/shared';
+import { SharedModule } from '@app/shared/shared.module';
 
 describe('DataModelPropertyNewDialogComponent', () => {
   let component: DataModelPropertyNewDialogComponent;
@@ -28,7 +29,8 @@ describe('DataModelPropertyNewDialogComponent', () => {
         MatSnackBarModule,
         CoreModule,
         MatSelectModule,
-        MatDividerModule
+        MatDividerModule,
+        SharedModule.forRoot()
       ],
       providers: [
         SnackbarService,

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-new-dialog/data-model-property-new-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-new-dialog/data-model-property-new-dialog.component.ts
@@ -3,6 +3,7 @@ import { DataModelPropertyDto, DataModelService, DataModelDto } from '@app/core'
 import { FormGroup } from '@angular/forms';
 import { SnackbarService } from '@app/shared';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 export interface NewModelPropertyDialogData {
   projectId: number;
@@ -23,6 +24,7 @@ export class DataModelPropertyNewDialogComponent implements OnInit {
   constructor (
     private dataModelService: DataModelService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     public dialogRef: MatDialogRef<DataModelPropertyNewDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: NewModelPropertyDialogData
     ) {
@@ -49,6 +51,8 @@ export class DataModelPropertyNewDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.dataModelPropertyForm);
     }
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.spec.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { MatInputModule, MatCheckboxModule, MatProgressBarModule, MatDialogModul
   MatSnackBarModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { CoreModule } from '@app/core';
 import { SnackbarService } from '@app/shared';
+import { SharedModule } from '@app/shared/shared.module';
 
 describe('JobDefinitionNewDialogComponent', () => {
   let component: JobDefinitionNewDialogComponent;
@@ -26,7 +27,8 @@ describe('JobDefinitionNewDialogComponent', () => {
         MatProgressBarModule,
         MatDialogModule,
         MatSnackBarModule,
-        CoreModule
+        CoreModule,
+        SharedModule.forRoot()
       ],
       providers: [
         SnackbarService,

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-definition-new-dialog/job-definition-new-dialog.component.ts
@@ -4,6 +4,7 @@ import { JobDefinitionService, JobDefinitionDto } from '@app/core';
 import { SnackbarService } from '@app/shared';
 import { MatDialogRef, MAT_DIALOG_DATA, MatCheckboxChange } from '@angular/material';
 import { NewModelDialogData } from '@app/project/data-model/components/data-model-new-dialog/data-model-new-dialog.component';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 export interface NewJobDefinitionDialogData {
   projectId: number;
@@ -26,6 +27,7 @@ export class JobDefinitionNewDialogComponent implements OnInit {
     private fb: FormBuilder,
     private jobDefinitionService: JobDefinitionService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     public dialogRef: MatDialogRef<JobDefinitionNewDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: NewModelDialogData
     ) {
@@ -55,6 +57,8 @@ export class JobDefinitionNewDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.jobDefinitionForm);
     }
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-task-definition-info-dialog/job-task-definition-info-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-task-definition-info-dialog/job-task-definition-info-dialog.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { JobDefinitionService, JobTaskDefinitionDto, ExternalServiceService } from '@app/core';
 import { SnackbarService } from '@app/shared';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 export interface JobTaskDefinitionViewModel extends JobTaskDefinitionDto {
   projectId: number;
@@ -28,6 +29,7 @@ export class JobTaskDefinitionInfoDialogComponent implements OnInit {
     private jobDefinitionService: JobDefinitionService,
     private externalServiceService: ExternalServiceService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     public dialogRef: MatDialogRef<JobTaskDefinitionInfoDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public jobTaskDefinition: JobTaskDefinitionViewModel
     ) {
@@ -63,10 +65,14 @@ export class JobTaskDefinitionInfoDialogComponent implements OnInit {
   }
 
   onEditClick() {
+    this.utilityService.markControlsAsTouched(this.jobTaskDefinitionForm);
+    this.utilityService.markControlsAsTouched(this.jobTaskDefinitionInfoForm);
     this.editing = true;
   }
 
   onCancelClick() {
+    this.utilityService.markControlsAsTouched(this.jobTaskDefinitionForm, false);
+    this.utilityService.markControlsAsTouched(this.jobTaskDefinitionInfoForm, false);
     this.editing = false;
   }
 }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-task-definition-new-dialog/job-task-definition-new-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/components/job-task-definition-new-dialog/job-task-definition-new-dialog.component.ts
@@ -3,6 +3,7 @@ import { FormGroup } from '@angular/forms';
 import { JobDefinitionService, JobTaskDefinitionDto, ExternalServiceService } from '@app/core';
 import { SnackbarService } from '@app/shared';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { UtilityService } from '@app/shared/services/utility.service';
 
 export interface NewJobDefinitionDialogData {
   projectId: number;
@@ -25,6 +26,7 @@ export class JobTaskDefinitionNewDialogComponent implements OnInit {
     private jobDefinitionService: JobDefinitionService,
     private externalServiceService: ExternalServiceService,
     private snackbar: SnackbarService,
+    private utilityService: UtilityService,
     public dialogRef: MatDialogRef<JobTaskDefinitionNewDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: NewJobDefinitionDialogData
     ) {
@@ -52,6 +54,8 @@ export class JobTaskDefinitionNewDialogComponent implements OnInit {
               this.snackbar.open(err);
               this.loading = false;
             });
+    } else {
+      this.utilityService.markControlsAsTouched(this.jobTaskDefinitionForm);
     }
   }
 

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/services/utility.service.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/shared/services/utility.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { FormGroup, FormArray, AbstractControl } from '@angular/forms';
 
 @Injectable()
 export class UtilityService {
@@ -24,5 +25,26 @@ export class UtilityService {
     }
 
     return dictionary;
+  }
+
+  markControlsAsTouched(group: FormGroup | FormArray, touched?: boolean): void {
+    if (touched == null) {
+      touched = true;
+    }
+
+    Object.keys(group.controls).forEach(field => {
+        const control = group.get(field);
+
+        if (control instanceof FormGroup || control instanceof FormArray) {
+            this.markControlsAsTouched(control, touched);
+        } else {
+          if (touched) {
+            control.markAsTouched({ onlySelf: true });
+          } else {
+
+            control.markAsUntouched({ onlySelf: true });
+          }
+        }
+    });
   }
 }


### PR DESCRIPTION
## Summary
Some form in the web ui is not showing the validation error after clicking submit. This is because the form is nested in the child form, and the validators does not trigger it recursively. This PR fixes this by manually setting the flag as `touched` so the validation message is triggered.

Note: For editing Job Task Definition, I make the validation error shown after user clicking `Edit`, to highlight the required configs immediately, since in the list page we've already notify user that there's validation error for the task.
