### PR TITLE
Several bugfix api

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Repositories/IProjectDataModelPropertyRepository.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Repositories/IProjectDataModelPropertyRepository.cs
@@ -6,6 +6,11 @@ namespace Polyrific.Catapult.Api.Core.Repositories
 {
     public interface IProjectDataModelPropertyRepository : IRepository<ProjectDataModelProperty>
     {
-        
+        /// <summary>
+        /// Get the highest property sequence in a data model
+        /// </summary>
+        /// <param name="modelId">The Id of the data model</param>
+        /// <returns>The sequence no.</returns>
+        int GetMaxPropertySequence(int modelId);
     }
 }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -116,9 +116,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// Update a job task definition
         /// </summary>
         /// <param name="editedJobTaskDefinition">Edited job task definition</param>
+        /// <param name="validate">Do task validation</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns></returns>
-        Task UpdateJobTaskDefinition(JobTaskDefinition editedJobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
+        Task UpdateJobTaskDefinition(JobTaskDefinition editedJobTaskDefinition, bool validate = true, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Update job task configuration

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IProjectDataModelService.cs
@@ -85,9 +85,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// <param name="relatedDataModelId">Id of the related data model</param>
         /// <param name="relationalType">Type of the relation with the related data model</param>
         /// <param name="isManaged">Is the model managed in the UI?</param>
+        /// <param name="sequence">Sequence of the data model property</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>Id of the new added data model property</returns>
-        Task<int> AddDataModelProperty(int dataModelId, string name, string label, string dataType, string controlType, bool isRequired, int? relatedDataModelId, string relationalType, bool? isManaged, CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> AddDataModelProperty(int dataModelId, string name, string label, string dataType, string controlType, bool isRequired, int? relatedDataModelId, string relationalType, bool? isManaged, int? sequence, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Update a property

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -255,7 +255,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             return await _jobTaskDefinitionRepository.CreateRange(jobTaskDefinitions, cancellationToken);
         }
 
-        public async Task UpdateJobTaskDefinition(JobTaskDefinition editedJobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task UpdateJobTaskDefinition(JobTaskDefinition editedJobTaskDefinition, bool validate = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -272,7 +272,8 @@ namespace Polyrific.Catapult.Api.Core.Services
                 jobTaskDefinition.AdditionalConfigString = editedJobTaskDefinition.AdditionalConfigString;
                 jobTaskDefinition.Sequence = editedJobTaskDefinition.Sequence;
                 
-                await ValidateJobTaskDefinition(jobTaskDefinition.JobDefinition, jobTaskDefinition, encryptConfig: true, cancellationToken);
+                if (validate)
+                    await ValidateJobTaskDefinition(jobTaskDefinition.JobDefinition, jobTaskDefinition, encryptConfig: true, cancellationToken);
 
                 await _jobTaskDefinitionRepository.Update(jobTaskDefinition, cancellationToken);
             }

--- a/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/ProjectDataModelService.cs
@@ -27,7 +27,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             _projectRepository = projectRepository;
         }
 
-        public async Task<int> AddDataModelProperty(int dataModelId, string name, string label, string dataType, string controlType, bool isRequired, int? relatedDataModelId, string relationalType, bool? isManaged, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<int> AddDataModelProperty(int dataModelId, string name, string label, string dataType, string controlType, bool isRequired, int? relatedDataModelId, string relationalType, bool? isManaged, int? sequence, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -55,6 +55,9 @@ namespace Polyrific.Catapult.Api.Core.Services
                 IsRequired = isRequired,
                 IsManaged = isManaged
             };
+
+            if (sequence == null)
+                newDataModelProperty.Sequence = _dataModelPropertyRepository.GetMaxPropertySequence(dataModelId) + 1;
 
             return await _dataModelPropertyRepository.Create(newDataModelProperty, cancellationToken);
         }

--- a/src/API/Polyrific.Catapult.Api.Data/ProjectDataModelPropertyRepository.cs
+++ b/src/API/Polyrific.Catapult.Api.Data/ProjectDataModelPropertyRepository.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
+using System.Linq;
 using Polyrific.Catapult.Api.Core.Entities;
 using Polyrific.Catapult.Api.Core.Repositories;
 
@@ -13,6 +14,11 @@ namespace Polyrific.Catapult.Api.Data
 
         public ProjectDataModelPropertyRepository(CatapultSqliteDbContext dbContext) : base(dbContext)
         {
+        }
+
+        public int GetMaxPropertySequence(int modelId)
+        {
+            return Db.ProjectDataModelProperties.Where(t => t.ProjectDataModelId == modelId).Max(t => t.Sequence) ?? 0;
         }
     }
 }

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -226,7 +226,7 @@ namespace Polyrific.Catapult.Api.Controllers
             {
                 var job = jobs.FirstOrDefault(j => j.Id == jobOrder.Key);
                 job.Sequence = jobOrder.Value;
-                await _jobDefinitionService.UpdateJobTaskDefinition(job, false);
+                await _jobDefinitionService.UpdateJobTaskDefinition(job, validate: false);
             }
 
             _logger.LogResponse("Task order for job definition {jobId} in project {projectId} updated", jobId, projectId);

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -226,7 +226,7 @@ namespace Polyrific.Catapult.Api.Controllers
             {
                 var job = jobs.FirstOrDefault(j => j.Id == jobOrder.Key);
                 job.Sequence = jobOrder.Value;
-                await _jobDefinitionService.UpdateJobTaskDefinition(job);
+                await _jobDefinitionService.UpdateJobTaskDefinition(job, false);
             }
 
             _logger.LogResponse("Task order for job definition {jobId} in project {projectId} updated", jobId, projectId);

--- a/src/API/Polyrific.Catapult.Api/Controllers/ProjectDataModelController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/ProjectDataModelController.cs
@@ -260,7 +260,8 @@ namespace Polyrific.Catapult.Api.Controllers
                     newProperty.IsRequired,
                     newProperty.RelatedProjectDataModelId,
                     newProperty.RelationalType,
-                    newProperty.IsManaged);
+                    newProperty.IsManaged,
+                    newProperty.Sequence);
 
                 var property = await _projectDataModelService.GetProjectDataModelPropertyByName(modelId, newProperty.Name);
                 var result = _mapper.Map<ProjectDataModelPropertyDto>(property);

--- a/src/API/Polyrific.Catapult.Api/Program.cs
+++ b/src/API/Polyrific.Catapult.Api/Program.cs
@@ -13,19 +13,21 @@ namespace Polyrific.Catapult.Api
 {
     public class Program
     {
+        private static bool _isService;
+
         public static void Main(string[] args)
         {
-            var isService = args.Contains("--service");
+            _isService = args.Contains("--service");
 
             Log.Logger = new LoggerConfiguration()
-                .ReadFrom.Configuration(GetConfiguration(isService))
+                .ReadFrom.Configuration(GetConfiguration(_isService))
                 .CreateLogger();
 
             try
             {
-                var webhost = CreateWebHostBuilder(args.Where(a => a != "--service").ToArray(), isService).Build();
+                var webhost = CreateWebHostBuilder(args.Where(a => a != "--service").ToArray()).Build();
 
-                if (isService)
+                if (_isService)
                 {
                     webhost.RunAsCustomService();
                 } 
@@ -47,12 +49,12 @@ namespace Polyrific.Catapult.Api
             }
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args, bool isService) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseConfiguration(GetConfiguration(isService))
+                .UseConfiguration(GetConfiguration(_isService))
                 .UseSerilog();
-        
+
         public static IConfiguration GetConfiguration(bool isService) {
             var basePath = Directory.GetCurrentDirectory();
             if (isService)

--- a/src/Shared/Polyrific.Catapult.Shared.Dto/ProjectDataModel/CreateProjectDataModelPropertyDto.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Dto/ProjectDataModel/CreateProjectDataModelPropertyDto.cs
@@ -48,5 +48,10 @@ namespace Polyrific.Catapult.Shared.Dto.ProjectDataModel
         /// Is the property managed in the UI?
         /// </summary>
         public bool? IsManaged { get; set; }
+
+        /// <summary>
+        /// Sequence of the property
+        /// </summary>
+        public int? Sequence { get; set; }
     }
 }

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
@@ -296,7 +296,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void UpdateJobTaskDefinition_ReturnsSuccess()
         {
-            _jobDefinitionService.Setup(s => s.UpdateJobTaskDefinition(It.IsAny<JobTaskDefinition>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            _jobDefinitionService.Setup(s => s.UpdateJobTaskDefinition(It.IsAny<JobTaskDefinition>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
             var controller = new JobDefinitionController(_jobDefinitionService.Object, _mapper, _logger.Object);
 
@@ -326,7 +326,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
                     }
                 });
 
-            _jobDefinitionService.Setup(s => s.UpdateJobTaskDefinition(It.IsAny<JobTaskDefinition>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            _jobDefinitionService.Setup(s => s.UpdateJobTaskDefinition(It.IsAny<JobTaskDefinition>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
             var controller = new JobDefinitionController(_jobDefinitionService.Object, _mapper, _logger.Object);
 

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/ProjectDataModelControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/ProjectDataModelControllerTests.cs
@@ -205,7 +205,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         {
             _projectDataModelService
                 .Setup(s => s.AddDataModelProperty(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), 
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(1);
 
             _projectDataModelService.Setup(s => s.GetProjectDataModelPropertyByName(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectDataModelServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/ProjectDataModelServiceTests.cs
@@ -387,7 +387,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public async void AddDataModelProperty_ValidItem()
         {
             var projectDataModelService = new ProjectDataModelService(_dataModelRepository.Object, _propertyRepository.Object, _projectRepository.Object);
-            int newId = await projectDataModelService.AddDataModelProperty(1, "Price", "Price", "int", "input-text", false, null, null, null);
+            int newId = await projectDataModelService.AddDataModelProperty(1, "Price", "Price", "int", "input-text", false, null, null, null, null);
 
             Assert.True(newId > 1);
             Assert.True(_dataProperty.Count > 1);
@@ -397,7 +397,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddDataModelProperty_DuplicateItem()
         {
             var projectDataModelService = new ProjectDataModelService(_dataModelRepository.Object, _propertyRepository.Object, _projectRepository.Object);
-            var exception = Record.ExceptionAsync(() => projectDataModelService.AddDataModelProperty(1, "Name", "Name", "string", "input-text", true, null, null, null));
+            var exception = Record.ExceptionAsync(() => projectDataModelService.AddDataModelProperty(1, "Name", "Name", "string", "input-text", true, null, null, null, null));
 
             Assert.IsType<DuplicateProjectDataModelPropertyException>(exception?.Result);
         }
@@ -406,7 +406,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         public void AddDataModelProperty_InvalidDataModel()
         {
             var projectDataModelService = new ProjectDataModelService(_dataModelRepository.Object, _propertyRepository.Object, _projectRepository.Object);
-            var exception = Record.ExceptionAsync(() => projectDataModelService.AddDataModelProperty(2, "Price", "Price", "int", "input-text", false, null, null, null));
+            var exception = Record.ExceptionAsync(() => projectDataModelService.AddDataModelProperty(2, "Price", "Price", "int", "input-text", false, null, null, null, null));
 
             Assert.IsType<ProjectDataModelNotFoundException>(exception?.Result);
         }


### PR DESCRIPTION
## Summary
- Fix error in build-api script: `Unable to create an object of type 'CatapultDbContext'. For the different patterns supported at design time, see https://go.microsoft.com/fwlink/?linkid=851728`. This is fixed by refactoring the `CreateWebHostBuilder` in `Program.cs` to only accept one argument. Though I'm not sure why that fixes thing. I was just trying to compare it with previous code.
- Assign proper property sequence when adding property
- Fix error reordering task when there's invalid task