### PR TITLE
Change default API Url in Engine and CLI

### DIFF
--- a/src/CLI/Polyrific.Catapult.Cli/Utility/CliConfig.cs
+++ b/src/CLI/Polyrific.Catapult.Cli/Utility/CliConfig.cs
@@ -178,7 +178,7 @@ namespace Polyrific.Catapult.Cli
         {
             var configs = new Dictionary<string, string>
             {
-                {ApiUrlKey, "https://localhost"},
+                {ApiUrlKey, "https://localhost:44305"},
                 {ApiRequestTimeoutKey, "00:01:00"},
                 {AppDataFolderPathKey, "Polyrific/Catapult" }
             };

--- a/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngineConfig.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/CatapultEngineConfig.cs
@@ -188,7 +188,7 @@ namespace Polyrific.Catapult.Engine.Core
         {
             var configs = new Dictionary<string, string>
             {
-                {ApiUrlKey, "https://localhost"},
+                {ApiUrlKey, "https://localhost:44305"},
                 {ApiRequestTimeoutKey, "00:01:00"},
                 {AuthorizationTokenKey, ""},
                 {JobCheckingIntervalKey, "30"},

--- a/tests/Polyrific.Catapult.Cli.UnitTests/CliConfigTests.cs
+++ b/tests/Polyrific.Catapult.Cli.UnitTests/CliConfigTests.cs
@@ -52,7 +52,7 @@ namespace Polyrific.Catapult.Cli.UnitTests
             if (configFileExists)
                 Assert.Equal(_configs["ApiUrl"], config.ApiUrl);
             else
-                Assert.Equal("https://localhost", config.ApiUrl);
+                Assert.Equal("https://localhost:44305", config.ApiUrl);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Polyrific.Catapult.Cli.UnitTests
             if (configName == "ApiUrl")
             {
                 var value = config.GetValue(configName);
-                Assert.Equal("https://localhost", value);
+                Assert.Equal("https://localhost:44305", value);
             }
             else
             {
@@ -107,7 +107,7 @@ namespace Polyrific.Catapult.Cli.UnitTests
             var value = config.GetValueOrDefault(configName, "DefaultValue");
 
             if (configName == "ApiUrl")
-                Assert.Equal("https://localhost", value);
+                Assert.Equal("https://localhost:44305", value);
             else
                 Assert.Equal("DefaultValue", value);
         }
@@ -139,7 +139,7 @@ namespace Polyrific.Catapult.Cli.UnitTests
 
             if (configName == "ApiUrl")
             {
-                Assert.Equal("https://localhost", config.ApiUrl);
+                Assert.Equal("https://localhost:44305", config.ApiUrl);
             }
             else
             {
@@ -156,7 +156,7 @@ namespace Polyrific.Catapult.Cli.UnitTests
 
             await CliConfig.InitConfigFile(reset, _logger.Object);
 
-            var expected = reset ? "https://localhost" : "https://localhost/test";
+            var expected = reset ? "https://localhost:44305" : "https://localhost/test";
             var obj = JObject.Parse(await File.ReadAllTextAsync(CliConfigFile));
             var loadedConfigs = obj["CliConfig"].ToObject<Dictionary<string, string>>();
 
@@ -171,7 +171,7 @@ namespace Polyrific.Catapult.Cli.UnitTests
 
             var config = new CliConfig(_logger.Object);
 
-            Assert.Equal("https://localhost", config.ApiUrl);
+            Assert.Equal("https://localhost:44305", config.ApiUrl);
             Assert.Equal(TimeSpan.Parse("00:01:00"), config.ApiRequestTimeout);
             Assert.Equal("Polyrific/Catapult", config.AppDataFolderPath);
         }

--- a/tests/Polyrific.Catapult.Engine.UnitTests/Core/CatapultEngineConfigTest.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/Core/CatapultEngineConfigTest.cs
@@ -53,7 +53,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
             if (configFileExists)
                 Assert.Equal(_configs["ApiUrl"], config.ApiUrl);
             else
-                Assert.Equal("https://localhost", config.ApiUrl);
+                Assert.Equal("https://localhost:44305", config.ApiUrl);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
             if (configName == "ApiUrl")
             {
                 var value = config.GetValue(configName);
-                Assert.Equal("https://localhost", value);
+                Assert.Equal("https://localhost:44305", value);
             }
             else
             {
@@ -108,7 +108,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
             var value = config.GetValueOrDefault(configName, "DefaultValue");
 
             if (configName == "ApiUrl")
-                Assert.Equal("https://localhost", value);
+                Assert.Equal("https://localhost:44305", value);
             else
                 Assert.Equal("DefaultValue", value);
         }
@@ -140,7 +140,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
 
             if (configName == "ApiUrl")
             {
-                Assert.Equal("https://localhost", config.ApiUrl);
+                Assert.Equal("https://localhost:44305", config.ApiUrl);
             }
             else
             {
@@ -157,7 +157,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
             
             await CatapultEngineConfig.InitConfigFile(reset, _logger.Object);
             
-            var expected = reset ? "https://localhost" : "https://localhost/test";
+            var expected = reset ? "https://localhost:44305" : "https://localhost/test";
             var obj = JObject.Parse(await File.ReadAllTextAsync(EngineConfigFile));
             var loadedConfigs = obj["EngineConfig"].ToObject<Dictionary<string, string>>();
             
@@ -172,7 +172,7 @@ namespace Polyrific.Catapult.Engine.UnitTests.Core
 
             var config = new CatapultEngineConfig(_logger.Object);
 
-            Assert.Equal("https://localhost", config.ApiUrl);
+            Assert.Equal("https://localhost:44305", config.ApiUrl);
             Assert.Equal(TimeSpan.Parse("00:01:00"), config.ApiRequestTimeout);
             Assert.Equal("", config.AuthorizationToken);
             Assert.Equal(30, config.JobCheckingInterval);


### PR DESCRIPTION
## Summary
Change default API Url in Engine and CLI to `https://localhost:44305`. This is to help users to run the components locally for the first time.