### PR TITLE
Small adjustment to the intro message in run scripts

### DIFF
--- a/tools/scripts/run-cli.bat
+++ b/tools/scripts/run-cli.bat
@@ -1,9 +1,9 @@
 @ECHO OFF
 
-cd cli
-
 echo  =======================================
 echo    OpenCatapult Command Line Interface
 echo  =======================================
 echo.
-echo  Please run "occli.exe --help" to check for available commands, or check https://docs.opencatapult.net for more details.
+echo  Please run "occli --help" to check for available commands, or check https://docs.opencatapult.net for more details.
+
+cd cli

--- a/tools/scripts/run-engine.bat
+++ b/tools/scripts/run-engine.bat
@@ -4,6 +4,6 @@ echo  =======================
 echo    OpenCatapult Engine
 echo  =======================
 echo.
-echo  Please run "ocengine.exe --help" for available commands, or check https://docs.opencatapult.net for more details.
+echo  Please run "ocengine --help" for available commands, or check https://docs.opencatapult.net for more details.
 
 cd engine


### PR DESCRIPTION
## Summary
Some small adjustments to the intro message in run scripts: remove `.exe` so it matches with the usage guide.