### PR TITLE
Fix incorrect error message when there's already queued job

### DIFF
--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/job-definition/job-definition/job-definition.component.ts
@@ -157,6 +157,15 @@ export class JobDefinitionComponent implements OnInit {
                   this.router.navigateByUrl('/service?newService=true');
                 }
               });
+            } else if (err.includes('There is already a running job')) {
+              // Stay on the page
+              this.dialog.open(MessageDialogComponent, {
+                data: {
+                  title: 'Queue Job Failed',
+                  // tslint:disable-next-line: max-line-length
+                  message: `There is already a running job in the project. Please wait for it to complete before queueing a new job.`
+                }
+              });
             } else {
               this.onTaskExpanded(jobDefinition);
               this.dialog.open(MessageDialogComponent, {

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/project-detail/project-detail.component.ts
@@ -173,8 +173,16 @@ export class ProjectDetailComponent implements OnInit {
               this.dialog.open(MessageDialogComponent, {
                 data: {
                   title: 'Queue Job Failed',
-                  // tslint:disable-next-line: max-line-length
                   message: `Project ${this.project.name} does not have a default job definition`
+                }
+              });
+            } else if (err.includes('There is already a running job')) {
+              // Stay on the page
+              this.dialog.open(MessageDialogComponent, {
+                data: {
+                  title: 'Queue Job Failed',
+                  // tslint:disable-next-line: max-line-length
+                  message: `There is already a running job in the project. Please wait for it to complete before queueing a new job.`
                 }
               });
             } else {


### PR DESCRIPTION
## Summary
Fix incorrect error message when trying to queue a job and there's already running job in the project. Now it's showing as if there's some issue in the task definition instead.
