### PR TITLE
Fix engine Task Provider

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/PluginManager.cs
@@ -104,13 +104,21 @@ namespace Polyrific.Catapult.Engine.Core
                                 var instance = (TaskProvider)info.CreateInstance(type, false, BindingFlags.ExactBinding, null, new object[] { new string[0] }, null, null);
                                 if (instance != null)
                                 {
+                                    var startFile = file;
+
+                                    // if .dll, check if .exe file exists
+                                    if (file.EndsWith(".dll") && files.Contains(file.Replace(".dll", ".exe")))
+                                    {
+                                        startFile = file.Replace(".dll", ".exe");
+                                    }
+
                                     if (!_plugins.ContainsKey(instance.Type))
                                         _plugins.Add(instance.Type,
                                             new List<PluginItem>
-                                                {new PluginItem(instance.Name, file, instance.RequiredServices)});
+                                                {new PluginItem(instance.Name, startFile, instance.RequiredServices)});
                                     else
                                         _plugins[instance.Type]
-                                            .Add(new PluginItem(instance.Name, file, instance.RequiredServices));
+                                            .Add(new PluginItem(instance.Name, startFile, instance.RequiredServices));
                                 }
                             }
                         }

--- a/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
+++ b/src/Engine/Polyrific.Catapult.Engine.Core/TaskRunner.cs
@@ -110,7 +110,7 @@ namespace Polyrific.Catapult.Engine.Core
                         }
 
                         // main process
-                        _logger.LogInformation("[Queue {Code}] Running {jobTask.Type} task", job.Code, jobTask.Type);
+                        _logger.LogInformation("[Queue {Code}] Running {Type} task", job.Code, jobTask.Type);
 
                         System.Console.WriteLine($"Invoking \"{jobTask.Type}\" task.");
                         result = await taskObj.RunMainTask(outputValues);

--- a/src/Plugins/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Program.cs
+++ b/src/Plugins/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Polyrific.Catapult.TaskProviders.Core;
+using Polyrific.Catapult.TaskProviders.DotNetCore.Helpers;
 
 namespace Polyrific.Catapult.TaskProviders.DotNetCore
 {
@@ -21,6 +22,12 @@ namespace Polyrific.Catapult.TaskProviders.DotNetCore
         
         public override async Task<(string outputArtifact, Dictionary<string, string> outputValues, string errorMessage)> Build()
         {
+            var (outputVersion, err) = await CommandHelper.Execute("dotnet", "--list-sdks");
+            if (string.IsNullOrWhiteSpace(outputVersion) || !string.IsNullOrEmpty(err))
+            {
+                return (null, null, $"Task Provider {TaskProviderName} require dotnet sdk to be installed");
+            }
+
             var csprojLocation = Path.Combine(Config.SourceLocation ?? Config.WorkingLocation, ProjectName, $"{ProjectName}.csproj");
             if (AdditionalConfigs != null && AdditionalConfigs.ContainsKey("CsprojLocation") && !string.IsNullOrEmpty(AdditionalConfigs["CsprojLocation"]))
                 csprojLocation = AdditionalConfigs["CsprojLocation"];

--- a/src/Plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc/src/Program.cs
+++ b/src/Plugins/GeneratorProvider/Polyrific.Catapult.TaskProviders.AspNetCoreMvc/src/Program.cs
@@ -2,6 +2,8 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Polyrific.Catapult.TaskProviders.AspNetCoreMvc.Helpers;
 using Polyrific.Catapult.TaskProviders.Core;
 
 namespace Polyrific.Catapult.TaskProviders.AspNetCoreMvc
@@ -18,6 +20,12 @@ namespace Polyrific.Catapult.TaskProviders.AspNetCoreMvc
         
         public override async Task<(string outputLocation, Dictionary<string, string> outputValues, string errorMessage)> Generate()
         {
+            var installedSdk = await CommandHelper.RunDotnet("--list-sdks");
+            if (string.IsNullOrWhiteSpace(installedSdk) || !installedSdk.Contains("2.2."))
+            {
+                return (null, null, $"Task Provider {TaskProviderName} require minimum dotnet sdk 2.2 to be installed");
+            }
+
             AdditionalConfigs.TryGetValue("AdminEmail", out var adminEmail);
 
             Config.OutputLocation = Config.OutputLocation ?? Config.WorkingLocation;

--- a/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Program.cs
+++ b/src/Plugins/HostingProvider/Polyrific.Catapult.TaskProviders.AzureAppService/src/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Polyrific.Catapult.TaskProviders.AzureAppService.Helpers;
 using Polyrific.Catapult.TaskProviders.Core;
 
 namespace Polyrific.Catapult.TaskProviders.AzureAppService
@@ -30,6 +31,12 @@ namespace Polyrific.Catapult.TaskProviders.AzureAppService
 
         public override async Task<(string hostLocation, Dictionary<string, string> outputValues, string errorMessage)> Deploy()
         {
+            var (outputVersion, err) = await CommandHelper.Execute("dotnet", "--list-sdks");
+            if (string.IsNullOrWhiteSpace(outputVersion) || !string.IsNullOrEmpty(err))
+            {
+                return (null, null, $"Task Provider {TaskProviderName} require dotnet sdk to be installed");
+            }
+
             if (_azure == null)
                 _azure = new AzureAutomation(GetAzureAppServiceConfig(AdditionalConfigs), _azureUtils, _deployUtils, Logger);
 

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/HostingProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/HostingProvider.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Polyrific.Catapult.TaskProviders.Core.Configs;
 using Polyrific.Catapult.Shared.Dto.Constants;
+using Microsoft.Extensions.Logging;
+using System;
 
 namespace Polyrific.Catapult.TaskProviders.Core
 {
@@ -43,38 +45,46 @@ namespace Polyrific.Catapult.TaskProviders.Core
         {
             var result = new Dictionary<string, object>();
 
-            switch (ProcessToExecute)
+            try
             {
-                case "pre":
-                    var error = await BeforeDeploy();
-                    if (!string.IsNullOrEmpty(error))
-                        result.Add("errorMessage", error);
-                    break;
-                case "main":
-                    (string hostLocation, Dictionary<string, string> outputValues, string errorMessage) = await Deploy();
-                    result.Add("hostLocation", hostLocation);
-                    result.Add("outputValues", outputValues);
-                    result.Add("errorMessage", errorMessage);
-                    break;
-                case "post":
-                    error = await AfterDeploy();
-                    if (!string.IsNullOrEmpty(error))
-                        result.Add("errorMessage", error);
-                    break;
-                case "delete":
-                    (string deletedHostLocation, string deleteErrorMessage) = await DeleteHostingResources();
-                    result.Add("deletedHostLocation", deletedHostLocation);
-                    result.Add("errorMessage", deleteErrorMessage);
-                    break;
-                default:
-                    await BeforeDeploy();
-                    (hostLocation, outputValues, errorMessage) = await Deploy();
-                    await AfterDeploy();
+                switch (ProcessToExecute)
+                {
+                    case "pre":
+                        var error = await BeforeDeploy();
+                        if (!string.IsNullOrEmpty(error))
+                            result.Add("errorMessage", error);
+                        break;
+                    case "main":
+                        (string hostLocation, Dictionary<string, string> outputValues, string errorMessage) = await Deploy();
+                        result.Add("hostLocation", hostLocation);
+                        result.Add("outputValues", outputValues);
+                        result.Add("errorMessage", errorMessage);
+                        break;
+                    case "post":
+                        error = await AfterDeploy();
+                        if (!string.IsNullOrEmpty(error))
+                            result.Add("errorMessage", error);
+                        break;
+                    case "delete":
+                        (string deletedHostLocation, string deleteErrorMessage) = await DeleteHostingResources();
+                        result.Add("deletedHostLocation", deletedHostLocation);
+                        result.Add("errorMessage", deleteErrorMessage);
+                        break;
+                    default:
+                        await BeforeDeploy();
+                        (hostLocation, outputValues, errorMessage) = await Deploy();
+                        await AfterDeploy();
 
-                    result.Add("hostLocation", hostLocation);
-                    result.Add("outputValues", outputValues);
-                    result.Add("errorMessage", errorMessage);
-                    break;
+                        result.Add("hostLocation", hostLocation);
+                        result.Add("outputValues", outputValues);
+                        result.Add("errorMessage", errorMessage);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, ex.Message);
+                result.Add("errorMessage", ex.Message);
             }
 
             return JsonConvert.SerializeObject(result);

--- a/src/Plugins/Polyrific.Catapult.TaskProviders.Core/StorageProvider.cs
+++ b/src/Plugins/Polyrific.Catapult.TaskProviders.Core/StorageProvider.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Polyrific.Catapult.TaskProviders.Core.Configs;
 using Polyrific.Catapult.Shared.Dto.Constants;
+using System;
+using Microsoft.Extensions.Logging;
 
 namespace Polyrific.Catapult.TaskProviders.Core
 {
@@ -43,35 +45,43 @@ namespace Polyrific.Catapult.TaskProviders.Core
         {
             var result = new Dictionary<string, object>();
 
-            switch (ProcessToExecute)
+            try
             {
-                case "pre":
-                    var error = await BeforePublishArtifact();
-                    if (!string.IsNullOrEmpty(error))
-                        result.Add("errorMessage", error);
-                    break;
-                case "main":
-                    (string storageLocation, Dictionary<string, string> outputValues, string errorMessage) = await PublishArtifact();
-                    result.Add("storageLocation", storageLocation);
-                    result.Add("outputValues", outputValues);
-                    result.Add("errorMessage", errorMessage);
-                    break;
-                case "post":
-                    error = await AfterPublishArtifact();
-                    if (!string.IsNullOrEmpty(error))
-                        result.Add("errorMessage", error);
-                    break;
-                default:
-                    await BeforePublishArtifact();
-                    (storageLocation, outputValues, errorMessage) = await PublishArtifact();
-                    await AfterPublishArtifact();
+                switch (ProcessToExecute)
+                {
+                    case "pre":
+                        var error = await BeforePublishArtifact();
+                        if (!string.IsNullOrEmpty(error))
+                            result.Add("errorMessage", error);
+                        break;
+                    case "main":
+                        (string storageLocation, Dictionary<string, string> outputValues, string errorMessage) = await PublishArtifact();
+                        result.Add("storageLocation", storageLocation);
+                        result.Add("outputValues", outputValues);
+                        result.Add("errorMessage", errorMessage);
+                        break;
+                    case "post":
+                        error = await AfterPublishArtifact();
+                        if (!string.IsNullOrEmpty(error))
+                            result.Add("errorMessage", error);
+                        break;
+                    default:
+                        await BeforePublishArtifact();
+                        (storageLocation, outputValues, errorMessage) = await PublishArtifact();
+                        await AfterPublishArtifact();
 
-                    result.Add("storageLocation", storageLocation);
-                    result.Add("outputValues", outputValues);
-                    result.Add("errorMessage", errorMessage);
-                    break;
+                        result.Add("storageLocation", storageLocation);
+                        result.Add("outputValues", outputValues);
+                        result.Add("errorMessage", errorMessage);
+                        break;
+                }
             }
-
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, ex.Message);
+                result.Add("errorMessage", ex.Message);
+            }
+            
             return JsonConvert.SerializeObject(result);
         }
 

--- a/src/Plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest/src/Program.cs
+++ b/src/Plugins/TestProvider/Polyrific.Catapult.TaskProviders.DotNetCoreTest/src/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Polyrific.Catapult.TaskProviders.Core;
+using Polyrific.Catapult.TaskProviders.DotNetCoreTest.Helpers;
 
 namespace Polyrific.Catapult.TaskProviders.DotNetCoreTest
 {
@@ -21,6 +22,12 @@ namespace Polyrific.Catapult.TaskProviders.DotNetCoreTest
         
         public override async Task<(string testResultLocation, Dictionary<string, string> outputValues, string errorMessage)> Test()
         {
+            var (outputVersion, err, exitCode) = await CommandHelper.Execute("dotnet", "--list-sdks");
+            if (string.IsNullOrWhiteSpace(outputVersion) || !string.IsNullOrEmpty(err))
+            {
+                return (null, null, $"Task Provider {TaskProviderName} require dotnet sdk to be installed");
+            }
+
             var testLocation = Config.TestLocation ?? string.Empty;
             if (!Path.IsPathRooted(testLocation))
                 testLocation = Path.Combine(Config.WorkingLocation, testLocation);

--- a/tests/Polyrific.Catapult.Engine.UnitTests/SkipOnNonWindowsFact.cs
+++ b/tests/Polyrific.Catapult.Engine.UnitTests/SkipOnNonWindowsFact.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Polyrific.Catapult.Engine.UnitTests
+{
+    public sealed class SkipOnNonWindowsFact : FactAttribute
+    {
+        public SkipOnNonWindowsFact()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Skip = "Skip on non-Windows platform.";
+            }
+        }
+    }
+}

--- a/tools/scripts/run.bat
+++ b/tools/scripts/run.bat
@@ -7,6 +7,8 @@
 
 @ECHO OFF
 
+cd %~dp0
+
 SET runapi=0
 SET runcli=0
 SET runengine=0


### PR DESCRIPTION
## Summary
Fix some issue in engine task provider release

## Coverage
- [x] Fix issue in plugin manager to run .EXE file of a task provider if available
- [x] Fix unit test for windows platform specific test
- [x] Fix issue in task provider hang when there's unhandled exception
- [x] Add validation for task provider if it requires dotnet sdk to be installed