### PR TITLE
Fix run.bat if being run from drive other than "c"

### DIFF
--- a/tools/scripts/run.bat
+++ b/tools/scripts/run.bat
@@ -7,7 +7,7 @@
 
 @ECHO OFF
 
-cd %~dp0
+cd /D %~dp0
 
 SET runapi=0
 SET runcli=0


### PR DESCRIPTION
## Summary
There was an issue when running "run.bat" script from a drive other than `C:\`. This PR should fix it.