### PR TITLE
Hotfix: Fix issue related to job task definition side effect

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -169,10 +169,9 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// </summary>
         /// <param name="jobDefinition">The job definition object</param>
         /// <param name="jobTaskDefinition">The job task definition object</param>
-        /// <param name="encryptConfig">Encrypt additional config?</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns></returns>
-        Task ValidateJobTaskDefinition(JobDefinition jobDefinition, JobTaskDefinition jobTaskDefinition, bool encryptConfig = true, CancellationToken cancellationToken = default(CancellationToken));
+        Task ValidateJobTaskDefinition(JobDefinition jobDefinition, JobTaskDefinition jobTaskDefinition, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Encrypt all secret additional config in a task

--- a/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/IJobDefinitionService.cs
@@ -143,9 +143,10 @@ namespace Polyrific.Catapult.Api.Core.Services
         /// </summary>
         /// <param name="jobDefinitionId">Id of the job definition</param>
         /// <param name="validate">Do validation?</param>
+        /// <param name="decrypt">Do config decryption?</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled</param>
         /// <returns>List of job task definitions</returns>
-        Task<List<JobTaskDefinition>> GetJobTaskDefinitions(int jobDefinitionId, bool validate = false, CancellationToken cancellationToken = default(CancellationToken));
+        Task<List<JobTaskDefinition>> GetJobTaskDefinitions(int jobDefinitionId, bool validate = false, bool decrypt = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get a job task definition by id

--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobDefinitionService.cs
@@ -306,7 +306,7 @@ namespace Polyrific.Catapult.Api.Core.Services
             await _jobTaskDefinitionRepository.Delete(id, cancellationToken);
         }
 
-        public async Task<List<JobTaskDefinition>> GetJobTaskDefinitions(int jobDefinitionId, bool validate = false, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<List<JobTaskDefinition>> GetJobTaskDefinitions(int jobDefinitionId, bool validate = false, bool decrypt = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -328,6 +328,9 @@ namespace Polyrific.Catapult.Api.Core.Services
                         task.ValidationError = ex.Message;
                     }
                 }
+
+                if (decrypt)
+                    await DecryptSecretAdditionalConfigs(task);
             }                
 
             return tasks;

--- a/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/JobDefinitionController.cs
@@ -220,13 +220,12 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             _logger.LogRequest("Updating tasks order for job {jobId} in project {projectId}. Request body: {@dto}", jobId, projectId, dto);
 
-            var tasks = await _jobDefinitionService.GetJobTaskDefinitions(jobId);
+            var tasks = await _jobDefinitionService.GetJobTaskDefinitions(jobId, decrypt: true);
 
             foreach (var taskOrder in dto.TaskOrders)
             {
                 var task = tasks.FirstOrDefault(j => j.Id == taskOrder.Key);
                 task.Sequence = taskOrder.Value;
-                await _jobDefinitionService.DecryptSecretAdditionalConfigs(task);
                 await _jobDefinitionService.UpdateJobTaskDefinition(task, validate: false);
             }
 
@@ -477,9 +476,7 @@ namespace Polyrific.Catapult.Api.Controllers
         {
             _logger.LogRequest("Getting job task definitions in job {jobId}", jobId);
 
-            var jobTaskDefinitions = await _jobDefinitionService.GetJobTaskDefinitions(jobId, validate);
-            foreach (var task in jobTaskDefinitions)
-                await _jobDefinitionService.DecryptSecretAdditionalConfigs(task);
+            var jobTaskDefinitions = await _jobDefinitionService.GetJobTaskDefinitions(jobId, validate, decrypt: true);
 
             var results = _mapper.Map<List<JobTaskDefinitionDto>>(jobTaskDefinitions);
 

--- a/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Controllers/JobDefinitionControllerTests.cs
@@ -229,7 +229,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void GetJobTaskDefinitions_ReturnsJobTaskDefinitionList()
         {
-            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<JobTaskDefinition>
                 {
                     new JobTaskDefinition
@@ -311,7 +311,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Controllers
         [Fact]
         public async void UpdateJobTaskOrder_ReturnsSuccess()
         {
-            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<JobTaskDefinition>
                 {
                     new JobTaskDefinition

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -123,8 +123,8 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                         Id = id,
                         Name = "Default"
                     });
-            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int id, bool validate, CancellationToken token) =>
+            _jobDefinitionService.Setup(s => s.GetJobTaskDefinitions(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int id, bool validate, bool decrypt, CancellationToken token) =>
                     new List<JobTaskDefinition>
                     {
                         new JobTaskDefinition

--- a/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
+++ b/tests/Polyrific.Catapult.Api.UnitTests/Core/Services/JobQueueServiceTests.cs
@@ -133,7 +133,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
                             JobDefinitionId = id
                         }
                     });
-            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
         }
 
@@ -176,7 +176,7 @@ namespace Polyrific.Catapult.Api.UnitTests.Core.Services
         [Fact]
         public void AddJobQueue_TaskValidationException()
         {
-            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            _jobDefinitionService.Setup(s => s.ValidateJobTaskDefinition(It.IsAny<JobDefinition>(), It.IsAny<JobTaskDefinition>(), It.IsAny<CancellationToken>()))
                 .Throws(new ExternalServiceNotFoundException("GitHub"));
 
             var jobQueueService = new JobQueueService(_jobQueueRepository.Object, _projectRepository.Object, _userRepository.Object, _jobCounterService.Object, _jobDefinitionService.Object, _textWriter.Object, _notificationProvider.Object);


### PR DESCRIPTION
## Summary
Fix error that occured after modifying the order of the job task definition, and after queueing a job

## Coverage
- [x] Separate the Decrypt process from validation to avoid side effect on job task definition entity
- [x] Prevent unhandled error when decrypting invalid string. Return null value instead

