### PR TITLE
Web UI: Allow set related data model to empty after being selected

### DIFF
--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.html
@@ -35,6 +35,7 @@
 
   <mat-form-field class="full-width-input">
     <mat-select #relatedDataModelControl placeholder="Related Data Model" formControlName="relatedProjectDataModelId" (selectionChange)="onRelatedDataModelChanged($event)">
+      <mat-option [value]="''"></mat-option>
       <mat-option *ngFor="let relatedDataModel of relatedDataModels" [value]="relatedDataModel.id">
         {{relatedDataModel.name}}
       </mat-option>
@@ -43,6 +44,7 @@
 
   <mat-form-field class="full-width-input">
     <mat-select #relationalTypeControl placeholder="Relational Type" formControlName="relationalType" (selectionChange)="onRelationalTypeChanged($event)">
+      <mat-option [value]="''"></mat-option>
       <mat-option *ngFor="let relationalType of propertyRelationalTypes" [value]="relationalType[0]">
         {{relationalType[1]}}
       </mat-option>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-form/data-model-property-form.component.ts
@@ -87,10 +87,6 @@ export class DataModelPropertyFormComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.dataModelProperty && !changes.dataModelProperty.firstChange) {
-      this.dataModelPropertyForm.patchValue(this.dataModelProperty);
-    }
-
     if (changes.disableForm && !changes.disableForm.firstChange) {
       if (this.disableForm) {
         this.dataModelPropertyForm.patchValue(this.dataModelProperty);

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.html
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title>Data Model Property</h1>
-<form [formGroup]="dataModelPropertyForm" (submit)="onSubmit()">
+<form [formGroup]="dataModelPropertyInfoForm" (submit)="onSubmit()">
     <div mat-dialog-content>
         <mat-form-field class="full-width-input">
             <mat-label>Id</mat-label>

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/project/data-model/components/data-model-property-info-dialog/data-model-property-info-dialog.component.ts
@@ -17,9 +17,10 @@ export interface DataModelPropertyViewModel extends DataModelPropertyDto {
   styleUrls: ['./data-model-property-info-dialog.component.css']
 })
 export class DataModelPropertyInfoDialogComponent implements OnInit {
-  dataModelPropertyForm: FormGroup = this.fb.group({
+  dataModelPropertyInfoForm: FormGroup = this.fb.group({
     id: [{value: null, disabled: true}]
   });
+  dataModelPropertyForm: FormGroup;
   editing: boolean;
   loading: boolean;
 
@@ -37,11 +38,9 @@ export class DataModelPropertyInfoDialogComponent implements OnInit {
   }
 
   onFormReady(form: FormGroup) {
-    this.dataModelPropertyForm = this.fb.group({
-      ...this.dataModelPropertyForm.controls,
-      ...form.controls
-    });
+    this.dataModelPropertyForm = form;
     this.dataModelPropertyForm.patchValue(this.dataModelProperty);
+    this.dataModelPropertyInfoForm.patchValue(this.dataModelProperty);
   }
 
   onSubmit() {


### PR DESCRIPTION
## Summary
Allow setting related data model to empty after being selected in the data model property popup

## Coverage
- [x] Add empty option for related data model and relation type
- [x] Fix bug Model Name does not get saved when changed by the Related Data Model dropdown