### PR TITLE
API: Fix export project does not include IsDefault flag

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Entities/ProjectTemplate.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Entities/ProjectTemplate.cs
@@ -39,6 +39,7 @@ namespace Polyrific.Catapult.Api.Core.Entities
         public string Name { get; set; }
         public List<JobTaskDefinitionTemplate> Tasks { get; set; }
         public bool IsDeletion { get; set; }
+        public bool IsDefault { get; set; }
     }
 
     internal class JobTaskDefinitionTemplate


### PR DESCRIPTION
## Summary
Fix export project does not include IsDefault flag

## Coverage
- [x] Add IsDefault to project export model
