### PR TITLE
Hotfix - Fix build error when project name contains hyphen

### DIFF
--- a/src/TaskProviders/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Helpers/TextHelper.cs
+++ b/src/TaskProviders/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Helpers/TextHelper.cs
@@ -1,0 +1,12 @@
+﻿using Humanizer;
+
+namespace Polyrific.Catapult.TaskProviders.DotNetCore.Helpers
+{
+    public static class TextHelper
+    {
+        public static string GetNormalizedName(string text)
+        {
+            return text.Replace("-", "_").Pascalize();
+        }
+    }
+}

--- a/src/TaskProviders/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Polyrific.Catapult.TaskProviders.DotNetCore.csproj
+++ b/src/TaskProviders/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Polyrific.Catapult.TaskProviders.DotNetCore.csproj
@@ -11,6 +11,10 @@
         <OutputPath>..\..\..\..\Engine\Polyrific.Catapult.Engine\bin\$(Configuration)\taskproviders\BuildProvider\Polyrific.Catapult.TaskProviders.DotNetCore\</OutputPath>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Humanizer.Core" Version="2.6.2" />
+    </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\Polyrific.Catapult.TaskProviders.Core\Polyrific.Catapult.TaskProviders.Core.csproj" />
   </ItemGroup>

--- a/src/TaskProviders/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Program.cs
+++ b/src/TaskProviders/BuildProvider/Polyrific.Catapult.TaskProviders.DotNetCore/src/Program.cs
@@ -28,7 +28,9 @@ namespace Polyrific.Catapult.TaskProviders.DotNetCore
                 return (null, null, $"Task Provider {TaskProviderName} require dotnet sdk to be installed");
             }
 
-            var csprojLocation = Path.Combine(Config.SourceLocation ?? Config.WorkingLocation, ProjectName, $"{ProjectName}.csproj");
+            var normalizedProjectName = TextHelper.GetNormalizedName(ProjectName);
+
+            var csprojLocation = Path.Combine(Config.SourceLocation ?? Config.WorkingLocation, normalizedProjectName, $"{normalizedProjectName}.csproj");
             if (AdditionalConfigs != null && AdditionalConfigs.ContainsKey("CsprojLocation") && !string.IsNullOrEmpty(AdditionalConfigs["CsprojLocation"]))
                 csprojLocation = AdditionalConfigs["CsprojLocation"];
             if (!Path.IsPathRooted(csprojLocation))

--- a/src/TaskProviders/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Helpers/TextHelper.cs
+++ b/src/TaskProviders/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Helpers/TextHelper.cs
@@ -1,0 +1,12 @@
+﻿using Humanizer;
+
+namespace Polyrific.Catapult.TaskProviders.EntityFrameworkCore.Helpers
+{
+    public static class TextHelper
+    {
+        public static string GetNormalizedName(string text)
+        {
+            return text.Replace("-", "_").Pascalize();
+        }
+    }
+}

--- a/src/TaskProviders/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Polyrific.Catapult.TaskProviders.EntityFrameworkCore.csproj
+++ b/src/TaskProviders/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Polyrific.Catapult.TaskProviders.EntityFrameworkCore.csproj
@@ -12,6 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Humanizer.Core" Version="2.6.2" />
       <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     </ItemGroup>
 

--- a/src/TaskProviders/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Program.cs
+++ b/src/TaskProviders/DatabaseProvider/Polyrific.Catapult.TaskProviders.EntityFrameworkCore/src/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Polyrific.Catapult.TaskProviders.Core;
+using Polyrific.Catapult.TaskProviders.EntityFrameworkCore.Helpers;
 
 namespace Polyrific.Catapult.TaskProviders.EntityFrameworkCore
 {
@@ -26,7 +27,8 @@ namespace Polyrific.Catapult.TaskProviders.EntityFrameworkCore
         
         public override async Task<(string databaseLocation, Dictionary<string, string> outputValues, string errorMessage)> DeployDatabase()
         {
-            var startupProjectName = ProjectName;
+            var normalizedProjectName = TextHelper.GetNormalizedName(ProjectName);
+            var startupProjectName = normalizedProjectName;
             if (AdditionalConfigs != null && AdditionalConfigs.ContainsKey("StartupProjectName") && !string.IsNullOrEmpty(AdditionalConfigs["StartupProjectName"]))
                 startupProjectName = AdditionalConfigs["StartupProjectName"];
             startupProjectName = $"{startupProjectName}.dll";
@@ -37,7 +39,7 @@ namespace Polyrific.Catapult.TaskProviders.EntityFrameworkCore
             if (!Path.IsPathRooted(startupProjectPath))
                 startupProjectPath = Path.Combine(Config.WorkingLocation, startupProjectPath);
 
-            var dataProjectName = $"{ProjectName}.Data";
+            var dataProjectName = $"{normalizedProjectName}.Data";
             if (AdditionalConfigs != null && AdditionalConfigs.ContainsKey("DatabaseProjectName") && !string.IsNullOrEmpty(AdditionalConfigs["DatabaseProjectName"]))
                 dataProjectName = AdditionalConfigs["DatabaseProjectName"];
             dataProjectName = $"{dataProjectName}.dll";


### PR DESCRIPTION
## Summary
Fix issue in `Polyrific.Catapult.TaskProviders.DotNetCore` & `Polyrific.Catapult.TaskProviders.EntityFrameworkCore` when there's hyphen character in the project name


## Coverage
- [x] Fix build provider
- [x] Fix database provider
