### PR TITLE
API: Add email template for resource deletion

### DIFF
--- a/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
+++ b/src/API/Polyrific.Catapult.Api.Core/Services/JobQueueService.cs
@@ -308,12 +308,28 @@ namespace Polyrific.Catapult.Api.Core.Services
 
             var users = await _userRepository.GetUsersByIds(jobQueue.Project.Members.Select(m => m.UserId).ToArray());
 
-            var jobQueueWebUrl = $"{webUrl}/project/{jobQueue.ProjectId}/job-queue/{jobQueueId}";
-            await _notificationProvider.SendNotification(new SendNotificationRequest
+            var jobDefinition = await _jobDefinitionService.GetJobDefinitionById(jobQueue.JobDefinitionId.GetValueOrDefault());
+
+            if (jobDefinition?.IsDeletion ?? false && jobQueue.Status == JobStatus.Completed)
             {
-                MessageType = NotificationConfig.JobQueueCompleted,
-                Emails = users.Select(u => u.Email).Distinct().ToList()
-            }, new Dictionary<string, string>
+                await _notificationProvider.SendNotification(new SendNotificationRequest
+                {
+                    MessageType = NotificationConfig.ProjectResourceDeleted,
+                    Emails = users.Select(u => u.Email).Distinct().ToList()
+                }, new Dictionary<string, string>
+                    {
+                        {MessageParameter.ProjectName, jobQueue.Project.Name},
+                        {MessageParameter.JobTaskStatus, GenerateJobTaskStatusNotificationMessage(jobQueue.JobTasksStatus)}
+                    });
+            }
+            else
+            {
+                var jobQueueWebUrl = $"{webUrl}/project/{jobQueue.ProjectId}/job-queue/{jobQueueId}";
+                await _notificationProvider.SendNotification(new SendNotificationRequest
+                {
+                    MessageType = NotificationConfig.JobQueueCompleted,
+                    Emails = users.Select(u => u.Email).Distinct().ToList()
+                }, new Dictionary<string, string>
                     {
                         {MessageParameter.JobCode, jobQueue.Code},
                         {MessageParameter.JobDefinitionName, jobQueue.JobDefinitionName},
@@ -323,6 +339,7 @@ namespace Polyrific.Catapult.Api.Core.Services
                         {MessageParameter.WebUrl, jobQueueWebUrl},
                         {MessageParameter.JobTaskStatus, GenerateJobTaskStatusNotificationMessage(jobQueue.JobTasksStatus)}
                     });
+            }
         }
 
         private string GenerateJobTaskStatusNotificationMessage(string jobTaskStatus)

--- a/src/API/Polyrific.Catapult.Api/notificationconfig.json
+++ b/src/API/Polyrific.Catapult.Api/notificationconfig.json
@@ -5,14 +5,16 @@
       "ResetPassword": "SmtpEmail",
       "ResetPasswordWeb": "SmtpEmail",
       "JobQueueCompleted": "SmtpEmail",
-      "ProjectDeleted": "SmtpEmail"
+      "ProjectDeleted": "SmtpEmail",
+      "ProjectResourceDeleted": "SmtpEmail"
     },
     "NotificationSubject": {
       "RegistrationCompleted": "Catapult - Please confirm your account",
       "ResetPassword": "Catapult - Reset password token",
       "ResetPasswordWeb": "Catapult - Reset password token",
       "JobQueueCompleted": "Catapult - Your queued job has been completed",
-      "ProjectDeleted": "Catapult - Your project has been deleted"
+      "ProjectDeleted": "Catapult - Your project has been deleted",
+      "ProjectResourceDeleted": "Catapult - Your project resources has been deleted"
     }
   }
 }

--- a/src/Shared/Polyrific.Catapult.Shared.Common/Notification/NotificationConfig.cs
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/Notification/NotificationConfig.cs
@@ -22,6 +22,8 @@ namespace Polyrific.Catapult.Shared.Common.Notification
 
         public const string ProjectDeleted = "ProjectDeleted";
 
+        public const string ProjectResourceDeleted = "ProjectResourceDeleted";
+
         public Dictionary<string, string> NotificationProviders { get; set; }
 
         public Dictionary<string, string> NotificationSubject { get; set; }

--- a/src/Shared/Polyrific.Catapult.Shared.Common/Notification/Template/ProjectResourceDeleted.html
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/Notification/Template/ProjectResourceDeleted.html
@@ -1,0 +1,1 @@
+﻿The resources in project "{{ProjectName}}" has been successfully deleted

--- a/src/Shared/Polyrific.Catapult.Shared.Common/Notification/Template/SmtpEmail/ProjectResourceDeleted.html
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/Notification/Template/SmtpEmail/ProjectResourceDeleted.html
@@ -1,0 +1,13 @@
+﻿﻿<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    The resources in project "{{ProjectName}}" has been successfully deleted. Please find the details below:
+    <br />
+    {{JobTaskStatus}}
+    <br />
+</body>
+</html>

--- a/src/Shared/Polyrific.Catapult.Shared.Common/Polyrific.Catapult.Shared.Common.csproj
+++ b/src/Shared/Polyrific.Catapult.Shared.Common/Polyrific.Catapult.Shared.Common.csproj
@@ -9,11 +9,13 @@
   <ItemGroup>
     <None Remove="Notification\Template\JobQueueCompleted.html" />
     <None Remove="Notification\Template\ProjectDeleted.html" />
+    <None Remove="Notification\Template\ProjectResourceDeleted.html" />
     <None Remove="Notification\Template\RegistrationCompleted.html" />
     <None Remove="Notification\Template\ResetPassword.html" />
     <None Remove="Notification\Template\ResetPasswordWeb.html" />
     <None Remove="Notification\Template\SmtpEmail\JobQueueCompleted.html" />
     <None Remove="Notification\Template\SmtpEmail\ProjectDeleted.html" />
+    <None Remove="Notification\Template\SmtpEmail\ProjectResourceDeleted.html" />
     <None Remove="Notification\Template\SmtpEmail\RegistrationCompleted.html" />
     <None Remove="Notification\Template\SmtpEmail\ResetPassword.html" />
     <None Remove="Notification\Template\SmtpEmail\ResetPasswordWeb.html" />
@@ -24,6 +26,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Notification\Template\ProjectDeleted.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Notification\Template\ProjectResourceDeleted.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Notification\Template\RegistrationCompleted.html">
@@ -39,6 +44,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Notification\Template\SmtpEmail\JobQueueCompleted.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Notification\Template\SmtpEmail\ProjectResourceDeleted.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Notification\Template\SmtpEmail\RegistrationCompleted.html">


### PR DESCRIPTION
## Summary
When a resource deletion job is completed, currently it sends the same email template as the usual job queue, which include the link to the job status web UI. The link will be broken in resource deletion jobs, because the project is deleted once the resource deletion is complete.

To fix this, I created a separate template to notify when a resource deletion job is completed, which does not include link to the job status web UI

## Coverage
- [x] Add email template
- [x] Modify logic in job queue notification
