### PR TITLE
Prevent basic user from getting logged out when adding task

### DIFF
--- a/src/API/Polyrific.Catapult.Api/Controllers/TaskProviderController.cs
+++ b/src/API/Polyrific.Catapult.Api/Controllers/TaskProviderController.cs
@@ -37,7 +37,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpGet]
-        [Authorize(Policy = AuthorizePolicy.UserRoleAdminAccess)]
+        [Authorize(Policy = AuthorizePolicy.UserRoleBasicAccess)]
         public async Task<IActionResult> GetTaskProviders()
         {
             _logger.LogRequest("Getting task providers");
@@ -57,7 +57,7 @@ namespace Polyrific.Catapult.Api.Controllers
         /// <param name="taskProviderType">Type of the taskProvider</param>
         /// <returns></returns>
         [HttpGet("type/{taskProviderType}")]
-        [Authorize(Policy = AuthorizePolicy.UserRoleAdminAccess)]
+        [Authorize(Policy = AuthorizePolicy.UserRoleBasicAccess)]
         public async Task<IActionResult> GetTaskProvidersByType(string taskProviderType)
         {
             _logger.LogRequest("Getting task providers for type {taskProviderType}", taskProviderType);

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/interceptors/error.interceptor.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/interceptors/error.interceptor.ts
@@ -4,19 +4,24 @@ import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { AuthService } from '../auth/auth.service';
+import { Router } from '@angular/router';
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
-    constructor(private authService: AuthService) { }
+    constructor(private authService: AuthService, private router: Router) { }
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(catchError(err => {
-            if ([401, 403].indexOf(err.status) !== -1) {
-                // auto logout if 401 Unauthorized or 403 Forbidden response returned from api
-                this.authService.logout();
-                location.reload();
+            switch (err.status) {
+              case 401:
+                  // auto logout if 401 Unauthorized
+                  this.authService.logout();
+                  location.reload();
+                break;
+              case 403:
+                this.router.navigateByUrl('/unauthorized').finally(() => location.reload());
+                break;
             }
-
             return throwError(err);
         }));
     }

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/interceptors/error.interceptor.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/core/interceptors/error.interceptor.ts
@@ -4,11 +4,10 @@ import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { AuthService } from '../auth/auth.service';
-import { Router } from '@angular/router';
 
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
-    constructor(private authService: AuthService, private router: Router) { }
+    constructor(private authService: AuthService) { }
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(catchError(err => {
@@ -19,7 +18,7 @@ export class ErrorInterceptor implements HttpInterceptor {
                   location.reload();
                 break;
               case 403:
-                this.router.navigateByUrl('/unauthorized').finally(() => location.reload());
+                location.href = '/unauthorized';
                 break;
             }
             return throwError(err);


### PR DESCRIPTION
## Summary
Prevent basic user from getting logged out when adding task

## Coverage
- [x] Fix the permission for getting task providers
- [x] Modify error interceptor to redirect to unauthorized page when we get 403 from API

## References
Issue #593 
