### PR TITLE
Engine: Disable Quick Edit mode to avoid process freeze

### DIFF
--- a/src/Engine/Polyrific.Catapult.Engine/ConsoleWindow.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/ConsoleWindow.cs
@@ -5,6 +5,8 @@ namespace Polyrific.Catapult.Engine
 {
     public static class ConsoleWindow
     {
+        // Do not create this class in OS other than Windows
+#if Windows
         private static class NativeFunctions
         {
             public enum StdHandle : int
@@ -43,9 +45,12 @@ namespace Polyrific.Catapult.Engine
             [DllImport("kernel32.dll", SetLastError = true)]
             public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
         }
+#endif
 
         public static void QuickEditMode(bool enable)
         {
+            // Make this an empty method when it's not windows OS
+#if Windows
             //QuickEdit lets the user select text in the console window with the mouse, to copy to the windows clipboard.
             //But selecting text stops the console process (e.g. unzipping). This may not be always wanted.
             IntPtr consoleHandle = NativeFunctions.GetStdHandle((int)NativeFunctions.StdHandle.STD_INPUT_HANDLE);
@@ -60,6 +65,7 @@ namespace Polyrific.Catapult.Engine
             consoleMode |= ((uint)NativeFunctions.ConsoleMode.ENABLE_EXTENDED_FLAGS);
 
             NativeFunctions.SetConsoleMode(consoleHandle, consoleMode);
+#endif
         }
     }
 }

--- a/src/Engine/Polyrific.Catapult.Engine/ConsoleWindow.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/ConsoleWindow.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Polyrific.Catapult.Engine
+{
+    public static class ConsoleWindow
+    {
+        private static class NativeFunctions
+        {
+            public enum StdHandle : int
+            {
+                STD_INPUT_HANDLE = -10,
+                STD_OUTPUT_HANDLE = -11,
+                STD_ERROR_HANDLE = -12,
+            }
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern IntPtr GetStdHandle(int nStdHandle); //returns Handle
+
+            public enum ConsoleMode : uint
+            {
+                ENABLE_ECHO_INPUT = 0x0004,
+                ENABLE_EXTENDED_FLAGS = 0x0080,
+                ENABLE_INSERT_MODE = 0x0020,
+                ENABLE_LINE_INPUT = 0x0002,
+                ENABLE_MOUSE_INPUT = 0x0010,
+                ENABLE_PROCESSED_INPUT = 0x0001,
+                ENABLE_QUICK_EDIT_MODE = 0x0040,
+                ENABLE_WINDOW_INPUT = 0x0008,
+                ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200,
+
+                //screen buffer handle
+                ENABLE_PROCESSED_OUTPUT = 0x0001,
+                ENABLE_WRAP_AT_EOL_OUTPUT = 0x0002,
+                ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004,
+                DISABLE_NEWLINE_AUTO_RETURN = 0x0008,
+                ENABLE_LVB_GRID_WORLDWIDE = 0x0010
+            }
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+        }
+
+        public static void QuickEditMode(bool enable)
+        {
+            //QuickEdit lets the user select text in the console window with the mouse, to copy to the windows clipboard.
+            //But selecting text stops the console process (e.g. unzipping). This may not be always wanted.
+            IntPtr consoleHandle = NativeFunctions.GetStdHandle((int)NativeFunctions.StdHandle.STD_INPUT_HANDLE);
+            UInt32 consoleMode;
+
+            NativeFunctions.GetConsoleMode(consoleHandle, out consoleMode);
+            if (enable)
+                consoleMode |= ((uint)NativeFunctions.ConsoleMode.ENABLE_QUICK_EDIT_MODE);
+            else
+                consoleMode &= ~((uint)NativeFunctions.ConsoleMode.ENABLE_QUICK_EDIT_MODE);
+
+            consoleMode |= ((uint)NativeFunctions.ConsoleMode.ENABLE_EXTENDED_FLAGS);
+
+            NativeFunctions.SetConsoleMode(consoleHandle, consoleMode);
+        }
+    }
+}

--- a/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj
+++ b/src/Engine/Polyrific.Catapult.Engine/Polyrific.Catapult.Engine.csproj
@@ -19,6 +19,11 @@
     <RepositoryUrl>https://github.com/Polyrific-Inc/OpenCatapult</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Catapult, OpenCatapult, tools, devops, engine</PackageTags>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+    <DefineConstants>Windows</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Engine/Polyrific.Catapult.Engine/Program.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Program.cs
@@ -17,6 +17,8 @@ namespace Polyrific.Catapult.Engine
     {
         public static async Task<int> Main(string[] args)
         {
+            ConsoleWindow.QuickEditMode(enable: false);
+
             await CatapultEngineConfig.InitConfigFile();
             
             var configuration = new ConfigurationBuilder()

--- a/src/Engine/Polyrific.Catapult.Engine/Program.cs
+++ b/src/Engine/Polyrific.Catapult.Engine/Program.cs
@@ -9,6 +9,7 @@ using Polyrific.Catapult.Engine.Core.JobLogger;
 using Polyrific.Catapult.Engine.Infrastructure;
 using Serilog;
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Polyrific.Catapult.Engine
@@ -17,7 +18,10 @@ namespace Polyrific.Catapult.Engine
     {
         public static async Task<int> Main(string[] args)
         {
-            ConsoleWindow.QuickEditMode(enable: false);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                ConsoleWindow.QuickEditMode(enable: false);
+            }
 
             await CatapultEngineConfig.InitConfigFile();
             


### PR DESCRIPTION
## Summary
Disable the Quick Edit mode in windows console app to prevent the engine from freezing the process

## Coverage
- [x] Modify engine cli

## References
- Related Issues: #598 
