### PR TITLE
Issue #604 - Fix role dropdown not showing on set user role

### DIFF
--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/account/components/user-set-role-dialog/user-set-role-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/account/components/user-set-role-dialog/user-set-role-dialog.component.ts
@@ -29,7 +29,11 @@ export class UserSetRoleDialogComponent implements OnInit {
     }
 
   ngOnInit() {
-    this.userRoleForm.patchValue(this.user);
+    this.userRoleForm = this.fb.group({
+      id : this.user.id,
+      userName : this.user.userName,
+      roleName : this.user.role
+    });
   }
 
   onSubmit() {

--- a/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/account/components/user-set-role-dialog/user-set-role-dialog.component.ts
+++ b/src/Web/Polyrific.Catapult.Web/ClientApp/src/app/account/components/user-set-role-dialog/user-set-role-dialog.component.ts
@@ -29,7 +29,7 @@ export class UserSetRoleDialogComponent implements OnInit {
     }
 
   ngOnInit() {
-    this.userRoleForm = this.fb.group({
+    this.userRoleForm.patchValue({
       id : this.user.id,
       userName : this.user.userName,
       roleName : this.user.role


### PR DESCRIPTION
## Summary
Fix role dropdown not showing on set user role. The issue was caused by different property name of `role`, so mapping process is not working between `userRoleForm` and `user`

## Coverage
- [x] Fix role dropdown not showing on set user role

## References
- Related Issues: https://github.com/Polyrific-Inc/OpenCatapult/issues/604
